### PR TITLE
fix: Improve installation instructions with proper tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,31 @@ alias azlin-git='uvx --from git+https://github.com/rysweet/azlin azlin'
 azlin-git list
 ```
 
-### Option 2: Install with pip
+### Option 2: Install with uv (Recommended)
 
 ```bash
+# Install azlin using uv (fastest)
+uv tool install azlin
+
+# Or install from GitHub
+uv tool install git+https://github.com/rysweet/azlin
+
+# Now use azlin commands
+azlin list
+azlin --help
+```
+
+### Option 3: Install with pip
+
+```bash
+# Create and activate virtual environment
+uv venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+
 # Install azlin
+uv pip install azlin
+
+# Or use regular pip
 pip install azlin
 
 # Create a development VM


### PR DESCRIPTION
## Summary
Updated installation instructions to follow modern Python packaging best practices with proper virtual environment setup.

## Changes
✅ Reordered installation options by ease of use
✅ Made `uv tool install` the recommended Option 2
✅ Updated pip install instructions with proper venv setup
✅ Added both `uv venv` and traditional pip workflow

## New Installation Options (in order)

### 1. uvx (Zero-Install) ✨
For trying out - no installation needed

### 2. uv tool install (Recommended) ⚡
```bash
uv tool install azlin
# Fast, isolated, globally available
```

### 3. pip install (Traditional) 🐍
```bash
uv venv
source .venv/bin/activate
uv pip install azlin  # or: pip install azlin
```

## Rationale
- **Follows best practices**: Always use venv for pip installs
- **Aligns with project tooling**: azlin uses uv (pyproject.toml, uv.lock)
- **User-friendly**: `uv tool install` is faster and simpler than venv setup
- **Complete instructions**: Shows activation commands for all platforms

## Impact
- Documentation improvement only
- No code changes
- Clearer guidance for new users