### PR TITLE
fix: Add pyyaml to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.1.0",
+    "pyyaml>=6.0.0",
     "tomli>=2.0.0; python_version < '3.11'",
     "tomli-w>=1.0.0",
 ]


### PR DESCRIPTION
## Problem
When running azlin via uvx, it fails with ImportError because pyyaml is not installed:
```
ModuleNotFoundError: No module named 'yaml'
ImportError: PyYAML not available. Install with: pip install pyyaml
```

## Solution
Added `pyyaml>=6.0.0` to the dependencies list in pyproject.toml.

## Testing
This will fix the error when running:
```bash
uvx --from git+https://github.com/rysweet/azlin azlin
```

The template_manager module requires pyyaml for template storage, so it needs to be a core dependency.