### PR TITLE
fix: Use correct parameter name for VMManager.list_vms

### DIFF
--- a/src/azlin/cli.py
+++ b/src/azlin/cli.py
@@ -1929,7 +1929,7 @@ def connect(
             
             # Get list of running VMs
             try:
-                vms = VMManager.list_vms(resource_group=rg, show_all=False)
+                vms = VMManager.list_vms(resource_group=rg, include_stopped=False)
             except VMManagerError as e:
                 click.echo(f"Error listing VMs: {e}", err=True)
                 sys.exit(1)


### PR DESCRIPTION
## Problem
Running `azlin connect` without a VM identifier caused a TypeError:
```
VMManager.list_vms() got an unexpected keyword argument 'show_all'
```

## Root Cause
The interactive selection feature was calling:
```python
VMManager.list_vms(resource_group=rg, show_all=False)
```

But the actual signature is:
```python
def list_vms(cls, resource_group: str, include_stopped: bool = True)
```

## Solution
Changed parameter name from `show_all` to `include_stopped`:
```python
VMManager.list_vms(resource_group=rg, include_stopped=False)
```

## Testing
- ✅ All 11 unit tests still pass
- ✅ `azlin connect --help` works
- ✅ Import succeeds without errors

## Apology
I should have tested the actual runtime behavior before merging #41. This was a careless mistake - I only ran unit tests with mocks, not the actual CLI command.