### PR TITLE
feat: Add azlin alias to provisioned VMs

### DIFF
--- a/src/azlin/vm_provisioning.py
+++ b/src/azlin/vm_provisioning.py
@@ -536,6 +536,9 @@ runcmd:
     NPM_PACKAGES="${HOME}/.npm-packages"
     PATH="$NPM_PACKAGES/bin:$PATH"
     MANPATH="$NPM_PACKAGES/share/man:$(manpath 2>/dev/null || echo $MANPATH)"
+
+    # azlin alias for convenient VM management
+    alias azlin="uvx --from git+https://github.com/rysweet/azlin azlin"
     EOF
   - chown azureuser:azureuser /home/azureuser/.npmrc /home/azureuser/.npm-packages
 


### PR DESCRIPTION
## Summary

Adds an `azlin` alias to the default user's bashrc during VM provisioning, enabling azlin commands to be run from within provisioned VMs.

## Motivation

Users may want to manage other VMs from within a provisioned VM. With this change, they can simply type `azlin` commands without needing to install anything - the alias uses `uvx` to run azlin directly from the GitHub repository.

## Changes

### Cloud-Init Script Update
- Added alias to `/home/azureuser/.bashrc` during provisioning
- Alias: `alias azlin="uvx --from git+https://github.com/rysweet/azlin azlin"`
- Placed in the same section as npm configuration for consistency

## Usage

After SSH'ing into a provisioned VM:

```bash
# The alias is already configured
azlin list
azlin new
azlin connect another-vm
# etc.
```

The alias leverages `uvx` (already installed via snap as `astral-uv`) to run azlin directly from the GitHub repo without local installation.

## Benefits

- ✨ **Zero Installation**: No need to install azlin on VMs
- 🔄 **Always Up-to-Date**: Uses latest version from GitHub
- 🚀 **Recursive Management**: Manage VMs from within VMs
- 💡 **Convenience**: Just type `azlin` like any other command

## Implementation Details

- The alias is added via cloud-init during VM provisioning
- Placed in user's bashrc for persistent availability
- Uses `uvx` which is already installed on all azlin VMs
- No breaking changes or dependencies

## Testing

- ✅ Syntax validated
- ✅ Cloud-init YAML structure maintained
- ✅ No conflicts with existing bashrc configuration

## Use Cases

1. **Multi-tier deployments**: Create and manage worker VMs from a control VM
2. **Development workflows**: Spin up test VMs from your dev VM
3. **Automation**: Script VM management from within VMs
4. **Convenience**: One less thing to install when using VMs