### PR TITLE
feat: Display azlin session name in tmux status bar

### DIFF
--- a/src/azlin/cli.py
+++ b/src/azlin/cli.py
@@ -2093,6 +2093,13 @@ def connect(
         else:
             rg = resource_group
 
+        # If no explicit tmux session name, try to use azlin session name
+        if not tmux_session and not no_tmux:
+            session_name = ConfigManager.get_session_name(vm_identifier, config)
+            if session_name:
+                tmux_session = session_name
+                click.echo(f"Using session name '{session_name}' for tmux")
+
         # Connect to VM
         click.echo(f"Connecting to {vm_identifier}...")
 

--- a/src/azlin/vm_provisioning.py
+++ b/src/azlin/vm_provisioning.py
@@ -539,6 +539,21 @@ runcmd:
     EOF
   - chown azureuser:azureuser /home/azureuser/.npmrc /home/azureuser/.npm-packages
 
+  # Tmux configuration for session name display
+  - |
+    cat > /home/azureuser/.tmux.conf << 'EOF'
+    # Display session name in status bar
+    set -g status-left-length 40
+    set -g status-left "#[fg=green]Session: #S #[fg=yellow]| "
+    set -g status-right "#[fg=cyan]%Y-%m-%d %H:%M"
+    
+    # Additional useful settings
+    set -g status-interval 60
+    set -g status-bg black
+    set -g status-fg white
+    EOF
+  - chown azureuser:azureuser /home/azureuser/.tmux.conf
+
   # AI CLI tools (installed as azureuser to use user-local npm config)
   - su - azureuser -c "npm install -g @github/copilot"
   - su - azureuser -c "npm install -g @openai/codex"


### PR DESCRIPTION
## Summary

Makes the azlin session name visible in the tmux status bar, making it easy to see which project/VM you're working in at a glance.

## Motivation

When using tmux inside VMs, users couldn't easily see which project they were working on. The tmux status bar would show the tmux session name, but this was just "azlin" or the VM name. With azlin session names (like "my-project"), it's much more helpful to display those in the status bar.

## Changes

### 1. Tmux Configuration During Provisioning
- Added `.tmux.conf` creation during VM provisioning
- Configured status bar to display session name prominently
- Status left format: `Session: <name> |`
- Added time/date on the right

### 2. Auto-Use Session Name for Tmux
- When connecting without explicit `--tmux-session`, use azlin session name
- Falls back to default behavior if no session name set
- User feedback when session name is used

## Visual Result

**Before:**
```
[azlin] 0:bash*                                    2025-10-17 01:30
```

**After:**
```
Session: my-project | 0:bash*                      2025-10-17 01:30
```

## Usage Example

```bash
# Set a session name
azlin new --name my-project
# or
azlin session azlin-vm-12345 my-project

# Connect - session name automatically used
azlin connect my-project
# Output: Using session name 'my-project' for tmux
#         Connecting to my-project...

# Inside the VM, tmux status bar shows:
# Session: my-project | 0:bash*
```

## Benefits

- ✨ **Visual Clarity**: Immediately see which project you're in
- 🎯 **Context Awareness**: No confusion when switching between VMs
- 🔄 **Automatic**: Works without any additional configuration
- 💡 **Consistent**: Matches the session name used everywhere else

## Implementation Details

### Tmux Configuration
```tmux
set -g status-left-length 40
set -g status-left "#[fg=green]Session: #S #[fg=yellow]| "
set -g status-right "#[fg=cyan]%Y-%m-%d %H:%M"
```

### Connect Logic
- Checks for azlin session name when `--tmux-session` not provided
- Uses session name as tmux session name
- Falls back to default if no session name configured

## Testing

- ✅ Syntax validated
- ✅ Cloud-init YAML structure maintained
- ✅ Backward compatible (works without session names)
- ✅ No breaking changes

## Depends On

- PR #44 (session naming feature) - already merged