### PR TITLE
fix: Correct attribute references in storage list and status commands

### DIFF
--- a/src/azlin/commands/storage.py
+++ b/src/azlin/commands/storage.py
@@ -189,7 +189,7 @@ def list_storage(resource_group: str | None):
             click.echo(f"  Endpoint: {account.nfs_endpoint}")
             click.echo(f"  Size: {account.size_gb}GB")
             click.echo(f"  Tier: {account.tier}")
-            click.echo(f"  Location: {account.location}")
+            click.echo(f"  Region: {account.region}")
 
         click.echo(f"\nTotal: {len(accounts)} storage account(s)")
 
@@ -230,15 +230,15 @@ def show_status(name: str, resource_group: str | None):
         # Get status
         status = StorageManager.get_storage_status(name, rg)
 
-        click.echo(f"\nStorage Account: {status.name}")
+        click.echo(f"\nStorage Account: {status.info.name}")
         click.echo("=" * 80)
-        click.echo(f"  Endpoint: {status.nfs_endpoint}")
-        click.echo(f"  Location: {status.location}")
-        click.echo(f"  Tier: {status.tier}")
+        click.echo(f"  Endpoint: {status.info.nfs_endpoint}")
+        click.echo(f"  Region: {status.info.region}")
+        click.echo(f"  Tier: {status.info.tier}")
         click.echo("\nCapacity:")
-        click.echo(f"  Total: {status.size_gb}GB")
-        click.echo(f"  Used: {status.used_gb}GB ({status.used_gb / status.size_gb * 100:.1f}%)")
-        click.echo(f"  Available: {status.size_gb - status.used_gb}GB")
+        click.echo(f"  Total: {status.info.size_gb}GB")
+        click.echo(f"  Used: {status.used_gb:.2f}GB ({status.utilization_percent:.1f}%)")
+        click.echo(f"  Available: {status.info.size_gb - status.used_gb:.2f}GB")
         click.echo("\nCost:")
         click.echo(f"  Monthly: ${status.cost_per_month:.2f}")
         click.echo("\nConnected VMs:")


### PR DESCRIPTION
## Problem
The `azlin storage list` and `azlin storage status` commands were failing with AttributeError because they were accessing attributes that don't exist on the dataclasses:

1. `storage list` tried to access `account.location` but the `StorageInfo` dataclass uses `region` 
2. `storage status` tried to access attributes directly on `StorageStatus` (e.g., `status.name`, `status.location`) but these attributes are nested within `status.info`

## Solution
- Changed `location` references to `region` in the list command
- Fixed status command to access attributes through the `info` field (e.g., `status.info.name`, `status.info.region`)
- Used the `utilization_percent` field directly instead of manually calculating it

## Testing
Tested both commands successfully:
```bash
$ azlin storage list
# Shows all storage accounts with correct attributes

$ azlin storage status rysweethomedir  
# Shows detailed status with all correct attributes
```

Both commands now work without errors.