### PR TITLE
fix: remove duplicate command execution in post_edit_format.py

### DIFF
--- a/.claude/tools/amplihack/hooks/post_edit_format.py
+++ b/.claude/tools/amplihack/hooks/post_edit_format.py
@@ -109,21 +109,13 @@ def is_language_enabled(extension: str) -> bool:
 def command_exists(command: str) -> bool:
     """Check if a command exists in PATH"""
     try:
-        subprocess.run(
+        result = subprocess.run(
             ["which", command],
             capture_output=True,
             check=False,
             timeout=1,
         )
-        return (
-            subprocess.run(
-                ["which", command],
-                capture_output=True,
-                check=False,
-                timeout=1,
-            ).returncode
-            == 0
-        )
+        return result.returncode == 0
     except (subprocess.SubprocessError, OSError):
         return False
 

--- a/docs/TESTING_EVIDENCE.md
+++ b/docs/TESTING_EVIDENCE.md
@@ -93,7 +93,7 @@ Total: 2 storage account(s)
 ## Summary
 All storage commands are now working correctly:
 - ✅ `azlin storage create` - Creates NFS storage accounts
-- ✅ `azlin storage list` - Lists all storage accounts  
+- ✅ `azlin storage list` - Lists all storage accounts
 - ✅ `azlin storage status` - Shows detailed storage status
 - ✅ `azlin storage delete` - Deletes storage accounts **WITHOUT ERRORS**
 

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -30,7 +30,7 @@ Complete TDD test plan for Azure Files NFS storage feature following DEFAULT_WOR
 **Fix**: Change `status.name` to `status.info.name`, etc.
 
 #### Bug 3: NFS implementation uses wrong Azure service
-**File**: `src/azlin/modules/storage_manager.py` lines 148-194  
+**File**: `src/azlin/modules/storage_manager.py` lines 148-194
 **Issue**: Uses HNS + blob storage for NFS, should use Azure Files NFS
 **Fix**: Use FileStorage kind + file shares, not StorageV2 + blob containers
 
@@ -112,7 +112,7 @@ Complete TDD test plan for Azure Files NFS storage feature following DEFAULT_WOR
 
 All of these must pass before merge:
 - [ ] All unit tests pass
-- [ ] All integration tests pass  
+- [ ] All integration tests pass
 - [ ] Pre-commit hooks pass
 - [ ] Manual test: Create storage account
 - [ ] Manual test: List storage accounts

--- a/src/azlin/commands/storage.py
+++ b/src/azlin/commands/storage.py
@@ -302,24 +302,24 @@ def delete_storage(name: str, resource_group: str | None, force: bool):
         try:
             config = ConfigManager.load_config()
             config_dict = config.to_dict()
-            
+
             # Remove from storage accounts if present
             storage_accounts = config_dict.get("storage_accounts", {})
             if name in storage_accounts:
                 del storage_accounts[name]
-            
+
             # Remove any VM storage mappings
             vm_storage = config_dict.get("vm_storage", {})
             vms_to_update = [vm for vm, storage in vm_storage.items() if storage == name]
             for vm_name in vms_to_update:
                 del vm_storage[vm_name]
-                
+
             # Save updated config if changes were made
             if vms_to_update or name in config_dict.get("storage_accounts", {}):
                 # Update the config object attributes
-                if hasattr(config, 'storage_accounts'):
+                if hasattr(config, "storage_accounts"):
                     config.storage_accounts = storage_accounts
-                if hasattr(config, 'vm_storage'):
+                if hasattr(config, "vm_storage"):
                     config.vm_storage = vm_storage
                 ConfigManager.save_config(config)
         except Exception as e:

--- a/tests/test_post_edit_format_hook.py
+++ b/tests/test_post_edit_format_hook.py
@@ -1,0 +1,90 @@
+"""Tests for post_edit_format hook."""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import from the hook module
+import sys
+from pathlib import Path
+
+# Add amplihack tools to path
+hook_path = Path(__file__).parent.parent / ".claude" / "tools"
+sys.path.insert(0, str(hook_path))
+
+from amplihack.hooks.post_edit_format import command_exists
+
+
+class TestCommandExists:
+    """Tests for command_exists function."""
+
+    def test_command_exists_returns_true_for_existing_command(self):
+        """Test that command_exists returns True for commands that exist."""
+        # Python should exist on all systems
+        assert command_exists("python3") is True
+
+    def test_command_exists_returns_false_for_nonexistent_command(self):
+        """Test that command_exists returns False for commands that don't exist."""
+        assert command_exists("this_command_definitely_does_not_exist_12345") is False
+
+    @patch("subprocess.run")
+    def test_command_exists_calls_subprocess_only_once(self, mock_run):
+        """
+        Test that command_exists calls subprocess.run exactly once.
+
+        Regression test for bug where which command was executed twice.
+        """
+        # Setup mock to return success
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        # Call function
+        result = command_exists("test_command")
+
+        # Verify subprocess.run called exactly once
+        assert mock_run.call_count == 1, (
+            f"Expected subprocess.run to be called once, "
+            f"but it was called {mock_run.call_count} times"
+        )
+        assert result is True
+
+    @patch("subprocess.run")
+    def test_command_exists_handles_subprocess_error(self, mock_run):
+        """Test that command_exists handles subprocess errors gracefully."""
+        # Setup mock to raise error
+        mock_run.side_effect = subprocess.SubprocessError("Test error")
+
+        # Should return False, not raise exception
+        result = command_exists("test_command")
+        assert result is False
+
+    @patch("subprocess.run")
+    def test_command_exists_handles_os_error(self, mock_run):
+        """Test that command_exists handles OS errors gracefully."""
+        # Setup mock to raise OSError
+        mock_run.side_effect = OSError("Test OS error")
+
+        # Should return False, not raise exception
+        result = command_exists("test_command")
+        assert result is False
+
+    @patch("subprocess.run")
+    def test_command_exists_uses_correct_subprocess_params(self, mock_run):
+        """Test that command_exists uses correct subprocess.run parameters."""
+        # Setup mock
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        # Call function
+        command_exists("test_command")
+
+        # Verify correct parameters
+        mock_run.assert_called_once_with(
+            ["which", "test_command"],
+            capture_output=True,
+            check=False,
+            timeout=1,
+        )


### PR DESCRIPTION
## Summary

Fixes bug where `command_exists()` function executed `subprocess.run` twice unnecessarily, with the second call overwriting the first result.

- Remove duplicate `subprocess.run` call
- Store result from single execution and check returncode  
- Add comprehensive test suite (6 tests) with regression test

## Changes

### Bug Fix (.claude/tools/amplihack/hooks/post_edit_format.py)
- **Before**: Two subprocess.run calls (lines 112-124), first one discarded
- **After**: Single subprocess.run call with stored result

### Tests Added (tests/test_post_edit_format_hook.py)
1. ✅ Test existing commands return True
2. ✅ Test nonexistent commands return False  
3. ✅ Test subprocess called exactly once (regression test)
4. ✅ Test subprocess error handling
5. ✅ Test OS error handling
6. ✅ Test correct subprocess parameters

## Test Plan

- [x] All 6 new tests pass
- [x] Pre-commit hooks pass
- [x] No regressions in existing functionality
- [x] Function still correctly detects command availability

## Philosophy Alignment

- ✅ **Zero-BS Principle**: Removed dead/duplicate code
- ✅ **Quality over Speed**: Added comprehensive tests to prevent regression
- ✅ **TDD Approach**: Tests verify behavior and prevent future issues

## Related Issue

Closes #97

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>