### PR TITLE
feat: Restore azdoit standalone CLI command to main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
 
 [project.scripts]
 azlin = "azlin.cli:main"
+azdoit = "azlin.cli:azdoit_main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/azlin"]

--- a/src/azlin/cli.py
+++ b/src/azlin/cli.py
@@ -3971,14 +3971,7 @@ def status(resource_group: str | None, config: str | None, vm: str | None):
         sys.exit(1)
 
 
-@main.command()
-@click.argument("request", type=str)
-@click.option("--dry-run", is_flag=True, help="Show execution plan without running commands")
-@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompts")
-@click.option("--resource-group", "--rg", help="Resource group", type=str)
-@click.option("--config", help="Config file path", type=click.Path())
-@click.option("--verbose", "-v", is_flag=True, help="Show detailed execution information")
-def do(  # noqa: C901
+def _do_impl(  # noqa: C901
     request: str,
     dry_run: bool,
     yes: bool,
@@ -3986,80 +3979,21 @@ def do(  # noqa: C901
     config: str | None,
     verbose: bool,
 ):
-    """Execute natural language azlin commands using AI.
+    """Shared implementation for natural language command execution.
 
-    The 'do' command understands natural language and automatically translates
-    your requests into the appropriate azlin commands. Just describe what you
-    want in plain English.
+    This function contains the core logic used by both 'azlin do' and 'azdoit'
+    commands to parse and execute natural language requests.
 
-    \b
-    Quick Start:
-        1. Set API key: export ANTHROPIC_API_KEY=your-key-here
-        2. Get key from: https://console.anthropic.com/
-        3. Try: azlin do "list all my vms"
+    Args:
+        request: Natural language request describing desired action
+        dry_run: If True, show execution plan without running commands
+        yes: If True, skip confirmation prompts
+        resource_group: Azure resource group name (optional)
+        config: Path to config file (optional)
+        verbose: If True, show detailed execution information
 
-    \b
-    VM Management Examples:
-        azlin do "create a new vm called Sam"
-        azlin do "show me all my vms"
-        azlin do "what is the status of my vms"
-        azlin do "start my development vm"
-        azlin do "stop all test vms"
-
-    \b
-    Cost & Monitoring:
-        azlin do "what are my azure costs"
-        azlin do "show me costs by vm"
-        azlin do "what's my spending this month"
-
-    \b
-    File Operations:
-        azlin do "sync all my vms"
-        azlin do "sync my home directory to vm Sam"
-        azlin do "copy myproject to the vm"
-
-    \b
-    Resource Cleanup:
-        azlin do "delete vm called test-123" --dry-run  # Preview first
-        azlin do "delete all test vms"                   # Then execute
-        azlin do "stop idle vms to save costs"
-
-    \b
-    Complex Operations:
-        azlin do "create 5 test vms and sync them all"
-        azlin do "set up a new development environment"
-        azlin do "show costs and stop any idle vms"
-
-    \b
-    Options:
-        --dry-run      Preview actions without executing anything
-        --yes, -y      Skip confirmation prompts (for automation)
-        --verbose, -v  Show detailed parsing and confidence scores
-        --rg NAME      Specify Azure resource group
-
-    \b
-    Safety Features:
-        - Shows plan and asks for confirmation (unless --yes)
-        - High accuracy: 95-100% confidence on VM operations
-        - Graceful error handling for invalid requests
-        - Dry-run mode to preview without executing
-
-    \b
-    Error Handling:
-        - Invalid requests (0% confidence): No commands executed
-        - Ambiguous requests (low confidence): Asks for confirmation
-        - Always shows what will be executed before running
-
-    \b
-    Requirements:
-        - ANTHROPIC_API_KEY environment variable (get from console.anthropic.com)
-        - Azure CLI authenticated (az login)
-        - Active Azure subscription
-
-    \b
-    For More Examples:
-        See docs/AZDOIT.md for 50+ examples and comprehensive guide
-        Integration tested: 7/7 tests passing with real Azure resources
+    Raises:
+        SystemExit: On various error conditions with appropriate exit codes
     """
     try:
         # Check for API key
@@ -4174,6 +4108,99 @@ def do(  # noqa: C901
     except KeyboardInterrupt:
         click.echo("\n\nCancelled by user.")
         sys.exit(130)
+
+
+@main.command()
+@click.argument("request", type=str)
+@click.option("--dry-run", is_flag=True, help="Show execution plan without running commands")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompts")
+@click.option("--resource-group", "--rg", help="Resource group", type=str)
+@click.option("--config", help="Config file path", type=click.Path())
+@click.option("--verbose", "-v", is_flag=True, help="Show detailed execution information")
+def do(
+    request: str,
+    dry_run: bool,
+    yes: bool,
+    resource_group: str | None,
+    config: str | None,
+    verbose: bool,
+):
+    """Execute natural language azlin commands using AI.
+
+    The 'do' command understands natural language and automatically translates
+    your requests into the appropriate azlin commands. Just describe what you
+    want in plain English.
+
+    \b
+    Quick Start:
+        1. Set API key: export ANTHROPIC_API_KEY=your-key-here
+        2. Get key from: https://console.anthropic.com/
+        3. Try: azlin do "list all my vms"
+
+    \b
+    VM Management Examples:
+        azlin do "create a new vm called Sam"
+        azlin do "show me all my vms"
+        azlin do "what is the status of my vms"
+        azlin do "start my development vm"
+        azlin do "stop all test vms"
+
+    \b
+    Cost & Monitoring:
+        azlin do "what are my azure costs"
+        azlin do "show me costs by vm"
+        azlin do "what's my spending this month"
+
+    \b
+    File Operations:
+        azlin do "sync all my vms"
+        azlin do "sync my home directory to vm Sam"
+        azlin do "copy myproject to the vm"
+
+    \b
+    Resource Cleanup:
+        azlin do "delete vm called test-123" --dry-run  # Preview first
+        azlin do "delete all test vms"                   # Then execute
+        azlin do "stop idle vms to save costs"
+
+    \b
+    Complex Operations:
+        azlin do "create 5 test vms and sync them all"
+        azlin do "set up a new development environment"
+        azlin do "show costs and stop any idle vms"
+
+    \b
+    Options:
+        --dry-run      Preview actions without executing anything
+        --yes, -y      Skip confirmation prompts (for automation)
+        --verbose, -v  Show detailed parsing and confidence scores
+        --rg NAME      Specify Azure resource group
+
+    \b
+    Safety Features:
+        - Shows plan and asks for confirmation (unless --yes)
+        - High accuracy: 95-100% confidence on VM operations
+        - Graceful error handling for invalid requests
+        - Dry-run mode to preview without executing
+
+    \b
+    Error Handling:
+        - Invalid requests (0% confidence): No commands executed
+        - Ambiguous requests (low confidence): Asks for confirmation
+        - Always shows what will be executed before running
+
+    \b
+    Requirements:
+        - ANTHROPIC_API_KEY environment variable (get from console.anthropic.com)
+        - Azure CLI authenticated (az login)
+        - Active Azure subscription
+
+    \b
+    For More Examples:
+        See docs/AZDOIT.md for 50+ examples and comprehensive guide
+        Integration tested: 7/7 tests passing with real Azure resources
+    """
+    _do_impl(request, dry_run, yes, resource_group, config, verbose)
 
 
 @main.command()
@@ -6333,8 +6360,101 @@ def _get_ssh_config_for_vm(
     return SSHConfig(host=vm.public_ip, user="azureuser", key_path=ssh_key_pair.private_path)
 
 
+@click.command()
+@click.argument("request", type=str)
+@click.option("--dry-run", is_flag=True, help="Show execution plan without running commands")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompts")
+@click.option("--resource-group", "--rg", help="Resource group", type=str)
+@click.option("--config", help="Config file path", type=click.Path())
+@click.option("--verbose", "-v", is_flag=True, help="Show detailed execution information")
+def azdoit_main(
+    request: str,
+    dry_run: bool,
+    yes: bool,
+    resource_group: str | None,
+    config: str | None,
+    verbose: bool,
+):
+    """Execute natural language Azure commands using AI (standalone CLI).
+
+    azdoit is a standalone command that provides the same natural language
+    interface as 'azlin do', allowing you to describe what you want in plain
+    English and have it automatically translated into Azure CLI commands.
+
+    \b
+    Quick Start:
+        1. Set API key: export ANTHROPIC_API_KEY=your-key-here
+        2. Get key from: https://console.anthropic.com/
+        3. Try: azdoit "list all my vms"
+
+    \b
+    VM Management Examples:
+        azdoit "create a new vm called Sam"
+        azdoit "show me all my vms"
+        azdoit "what is the status of my vms"
+        azdoit "start my development vm"
+        azdoit "stop all test vms"
+
+    \b
+    Cost & Monitoring:
+        azdoit "what are my azure costs"
+        azdoit "show me costs by vm"
+        azdoit "what's my spending this month"
+
+    \b
+    File Operations:
+        azdoit "sync all my vms"
+        azdoit "sync my home directory to vm Sam"
+        azdoit "copy myproject to the vm"
+
+    \b
+    Resource Cleanup:
+        azdoit "delete vm called test-123" --dry-run  # Preview first
+        azdoit "delete all test vms"                   # Then execute
+        azdoit "stop idle vms to save costs"
+
+    \b
+    Complex Operations:
+        azdoit "create 5 test vms and sync them all"
+        azdoit "set up a new development environment"
+        azdoit "show costs and stop any idle vms"
+
+    \b
+    Options:
+        --dry-run      Preview actions without executing anything
+        --yes, -y      Skip confirmation prompts (for automation)
+        --verbose, -v  Show detailed parsing and confidence scores
+        --rg NAME      Specify Azure resource group
+
+    \b
+    Safety Features:
+        - Shows plan and asks for confirmation (unless --yes)
+        - High accuracy: 95-100% confidence on VM operations
+        - Graceful error handling for invalid requests
+        - Dry-run mode to preview without executing
+
+    \b
+    Error Handling:
+        - Invalid requests (0% confidence): No commands executed
+        - Ambiguous requests (low confidence): Asks for confirmation
+        - Always shows what will be executed before running
+
+    \b
+    Requirements:
+        - ANTHROPIC_API_KEY environment variable (get from console.anthropic.com)
+        - Azure CLI authenticated (az login)
+        - Active Azure subscription
+
+    \b
+    For More Examples:
+        See docs/AZDOIT.md for 50+ examples and comprehensive guide
+        Integration tested: 7/7 tests passing with real Azure resources
+    """
+    _do_impl(request, dry_run, yes, resource_group, config, verbose)
+
+
 if __name__ == "__main__":
     main()
 
 
-__all__ = ["AzlinError", "CLIOrchestrator", "main"]
+__all__ = ["AzlinError", "CLIOrchestrator", "azdoit_main", "main"]

--- a/tests/unit/test_azdoit_cli.py
+++ b/tests/unit/test_azdoit_cli.py
@@ -1,0 +1,712 @@
+"""TDD Tests for Issue #166: azdoit standalone CLI.
+
+These tests follow TDD principles and WILL FAIL until implementation is complete.
+
+Design Requirements:
+- Create azdoit_main() entry point in cli.py
+- Extract _do_impl() shared implementation
+- Add azdoit script to pyproject.toml
+- Maintain backward compatibility with azlin do
+
+Test Coverage:
+1. azdoit_main() entry point exists and is callable
+2. azdoit CLI accepts natural language prompts
+3. azdoit delegates to same implementation as azlin do
+4. Backward compatibility: azlin do still works
+5. Both CLIs share identical behavior
+6. Error handling works in both CLIs
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
+
+# Import modules - individual tests will mock as needed
+from click.testing import CliRunner
+
+from azlin.cli import main
+
+
+class TestAzdoitEntryPoint:
+    """Test that azdoit_main() entry point exists (TDD: RED phase)."""
+
+    def test_azdoit_main_exists(self):
+        """Test that azdoit_main() function exists in cli module.
+
+        RED PHASE: This will fail - function doesn't exist yet.
+        """
+        from azlin import cli
+
+        assert hasattr(cli, "azdoit_main"), "azdoit_main() entry point not found in cli.py"
+        assert callable(cli.azdoit_main), "azdoit_main must be callable"
+
+    def test_azdoit_main_is_click_command(self):
+        """Test that azdoit_main() is a Click command.
+
+        RED PHASE: This will fail - function doesn't exist yet.
+        """
+        from azlin import cli
+
+        assert hasattr(cli, "azdoit_main")
+        # Click commands have a params attribute after @click.command() decoration
+        assert hasattr(cli.azdoit_main, "params"), "azdoit_main should be a Click command"
+
+    def test_azdoit_main_accepts_request_argument(self):
+        """Test that azdoit_main() accepts REQUEST argument.
+
+        RED PHASE: This will fail - function doesn't exist yet.
+        """
+        from azlin import cli
+
+        runner = CliRunner()
+        # Should accept a request argument without error
+        result = runner.invoke(cli.azdoit_main, ["--help"])
+
+        assert result.exit_code == 0
+        assert "REQUEST" in result.output or "request" in result.output.lower()
+
+
+class TestAzdoitCLIBasicUsage:
+    """Test that azdoit CLI accepts and processes natural language (TDD: RED phase)."""
+
+    @patch("azlin.cli.IntentParser")
+    @patch("azlin.cli.CommandExecutor")
+    @patch("azlin.cli.ResultValidator")
+    @patch("os.getenv")
+    def test_azdoit_accepts_natural_language_request(
+        self, mock_getenv, mock_validator, mock_executor, mock_parser
+    ):
+        """Test that azdoit processes natural language requests.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        # Setup mocks
+        mock_getenv.return_value = "test-api-key"
+        mock_parser_instance = MagicMock()
+        mock_parser.return_value = mock_parser_instance
+        mock_parser_instance.parse.return_value = {
+            "intent": "list_vms",
+            "confidence": 0.95,
+            "azlin_commands": [{"command": "list", "args": []}],
+        }
+
+        mock_executor_instance = MagicMock()
+        mock_executor.return_value = mock_executor_instance
+        mock_executor_instance.execute_plan.return_value = [
+            {"success": True, "command": "list", "stdout": "VM list", "stderr": ""}
+        ]
+
+        mock_validator_instance = MagicMock()
+        mock_validator.return_value = mock_validator_instance
+        mock_validator_instance.validate.return_value = {
+            "success": True,
+            "message": "Successfully listed VMs",
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(cli.azdoit_main, ["list all my vms", "--yes"])
+
+        # Should execute successfully
+        assert result.exit_code == 0
+        assert mock_parser_instance.parse.called
+        assert mock_executor_instance.execute_plan.called
+
+    @patch("azlin.cli.IntentParser")
+    @patch("os.getenv")
+    def test_azdoit_shows_help(self, mock_getenv, mock_parser):
+        """Test that azdoit --help shows help text.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli.azdoit_main, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Usage:" in result.output or "usage:" in result.output.lower()
+        # Should describe natural language capability
+        assert (
+            "natural language" in result.output.lower() or "plain english" in result.output.lower()
+        )
+
+    @patch("os.getenv")
+    def test_azdoit_requires_api_key(self, mock_getenv):
+        """Test that azdoit requires ANTHROPIC_API_KEY.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        mock_getenv.return_value = None  # No API key set
+
+        runner = CliRunner()
+        result = runner.invoke(cli.azdoit_main, ["list my vms", "--yes"])
+
+        # Should fail with clear error message
+        assert result.exit_code != 0
+        assert "ANTHROPIC_API_KEY" in result.output
+
+
+class TestSharedImplementation:
+    """Test that azdoit and azlin do share the same implementation (TDD: RED phase)."""
+
+    def test_do_impl_function_exists(self):
+        """Test that _do_impl() shared function exists.
+
+        RED PHASE: This will fail - _do_impl doesn't exist yet.
+        """
+        from azlin import cli
+
+        assert hasattr(cli, "_do_impl"), "_do_impl() shared function not found in cli.py"
+        assert callable(cli._do_impl), "_do_impl must be callable"
+
+    @patch("azlin.cli._do_impl")
+    @patch("os.getenv")
+    def test_azdoit_delegates_to_do_impl(self, mock_getenv, mock_do_impl):
+        """Test that azdoit_main() calls _do_impl().
+
+        RED PHASE: This will fail - neither function exists yet.
+        """
+        from azlin import cli
+
+        mock_getenv.return_value = "test-api-key"
+        mock_do_impl.return_value = None
+
+        runner = CliRunner()
+        _ = runner.invoke(cli.azdoit_main, ["test request", "--yes", "--dry-run"])
+
+        # Should delegate to shared implementation
+        assert mock_do_impl.called
+        call_args = mock_do_impl.call_args
+        assert call_args is not None
+
+    @patch("azlin.cli._do_impl")
+    @patch("os.getenv")
+    def test_azlin_do_delegates_to_do_impl(self, mock_getenv, mock_do_impl):
+        """Test that 'azlin do' command calls _do_impl().
+
+        RED PHASE: This will fail - _do_impl doesn't exist yet.
+        """
+        mock_getenv.return_value = "test-api-key"
+        mock_do_impl.return_value = None
+
+        runner = CliRunner()
+        _ = runner.invoke(main, ["do", "test request", "--yes", "--dry-run"])
+
+        # Should delegate to shared implementation
+        assert mock_do_impl.called
+
+    @patch("azlin.cli.IntentParser")
+    @patch("azlin.cli.CommandExecutor")
+    @patch("azlin.cli.ResultValidator")
+    @patch("os.getenv")
+    def test_both_clis_produce_identical_behavior(
+        self, mock_getenv, mock_validator, mock_executor, mock_parser
+    ):
+        """Test that azdoit and azlin do produce identical results.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        # Setup mocks
+        mock_getenv.return_value = "test-api-key"
+        mock_parser_instance = MagicMock()
+        mock_parser.return_value = mock_parser_instance
+        mock_parser_instance.parse.return_value = {
+            "intent": "list_vms",
+            "confidence": 0.95,
+            "azlin_commands": [{"command": "list", "args": []}],
+        }
+
+        mock_executor_instance = MagicMock()
+        mock_executor.return_value = mock_executor_instance
+        mock_executor_instance.execute_plan.return_value = [
+            {"success": True, "command": "list", "stdout": "VM list", "stderr": ""}
+        ]
+
+        mock_validator_instance = MagicMock()
+        mock_validator.return_value = mock_validator_instance
+        mock_validator_instance.validate.return_value = {
+            "success": True,
+            "message": "Successfully listed VMs",
+        }
+
+        runner = CliRunner()
+
+        # Test azdoit
+        result1 = runner.invoke(cli.azdoit_main, ["list all my vms", "--yes"])
+
+        # Both should succeed
+        assert result1.exit_code == 0
+        # First command should have called parse
+        assert mock_parser_instance.parse.call_count == 1
+
+        # Reset mocks
+        mock_parser_instance.reset_mock()
+        mock_executor_instance.reset_mock()
+        mock_validator_instance.reset_mock()
+
+        # Test azlin do
+        result2 = runner.invoke(main, ["do", "list all my vms", "--yes"])
+
+        # Should also succeed
+        assert result2.exit_code == 0
+
+        # Second command should also have called parse
+        assert mock_parser_instance.parse.call_count == 1
+
+
+class TestBackwardCompatibility:
+    """Test that azlin do command still works (TDD: RED phase but should PASS)."""
+
+    def test_azlin_do_command_exists(self):
+        """Test that 'azlin do' command still exists.
+
+        GREEN PHASE: This should pass - azlin do already exists.
+        """
+        runner = CliRunner()
+        result = runner.invoke(main, ["do", "--help"])
+
+        assert result.exit_code == 0
+        assert "Usage:" in result.output or "usage:" in result.output.lower()
+        assert "natural language" in result.output.lower()
+
+    @patch("azlin.cli.IntentParser")
+    @patch("azlin.cli.CommandExecutor")
+    @patch("azlin.cli.ResultValidator")
+    @patch("os.getenv")
+    def test_azlin_do_still_processes_requests(
+        self, mock_getenv, mock_validator, mock_executor, mock_parser
+    ):
+        """Test that 'azlin do' still processes natural language.
+
+        GREEN PHASE: This should pass - azlin do functionality is unchanged.
+        """
+        # Setup mocks
+        mock_getenv.return_value = "test-api-key"
+        mock_parser_instance = MagicMock()
+        mock_parser.return_value = mock_parser_instance
+        mock_parser_instance.parse.return_value = {
+            "intent": "list_vms",
+            "confidence": 0.95,
+            "azlin_commands": [{"command": "list", "args": []}],
+        }
+
+        mock_executor_instance = MagicMock()
+        mock_executor.return_value = mock_executor_instance
+        mock_executor_instance.execute_plan.return_value = [
+            {"success": True, "command": "list", "stdout": "VM list", "stderr": ""}
+        ]
+
+        mock_validator_instance = MagicMock()
+        mock_validator.return_value = mock_validator_instance
+        mock_validator_instance.validate.return_value = {
+            "success": True,
+            "message": "Successfully listed VMs",
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["do", "list all my vms", "--yes"])
+
+        # Should work exactly as before
+        assert result.exit_code == 0
+        assert mock_parser_instance.parse.called
+        assert mock_executor_instance.execute_plan.called
+
+
+class TestCLIOptions:
+    """Test that both CLIs support the same options (TDD: RED phase)."""
+
+    @patch("os.getenv")
+    def test_azdoit_supports_dry_run(self, mock_getenv):
+        """Test that azdoit supports --dry-run option.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        mock_getenv.return_value = "test-api-key"
+
+        runner = CliRunner()
+        result = runner.invoke(cli.azdoit_main, ["--help"])
+
+        assert result.exit_code == 0
+        assert "--dry-run" in result.output
+
+    @patch("os.getenv")
+    def test_azdoit_supports_yes_flag(self, mock_getenv):
+        """Test that azdoit supports --yes/-y flag.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        mock_getenv.return_value = "test-api-key"
+
+        runner = CliRunner()
+        result = runner.invoke(cli.azdoit_main, ["--help"])
+
+        assert result.exit_code == 0
+        assert "--yes" in result.output or "-y" in result.output
+
+    @patch("os.getenv")
+    def test_azdoit_supports_verbose_flag(self, mock_getenv):
+        """Test that azdoit supports --verbose/-v flag.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        mock_getenv.return_value = "test-api-key"
+
+        runner = CliRunner()
+        result = runner.invoke(cli.azdoit_main, ["--help"])
+
+        assert result.exit_code == 0
+        assert "--verbose" in result.output or "-v" in result.output
+
+    @patch("os.getenv")
+    def test_azdoit_supports_resource_group_option(self, mock_getenv):
+        """Test that azdoit supports --resource-group/--rg option.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        mock_getenv.return_value = "test-api-key"
+
+        runner = CliRunner()
+        result = runner.invoke(cli.azdoit_main, ["--help"])
+
+        assert result.exit_code == 0
+        assert "--resource-group" in result.output or "--rg" in result.output
+
+    @patch("os.getenv")
+    def test_azdoit_supports_config_option(self, mock_getenv):
+        """Test that azdoit supports --config option.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        mock_getenv.return_value = "test-api-key"
+
+        runner = CliRunner()
+        result = runner.invoke(cli.azdoit_main, ["--help"])
+
+        assert result.exit_code == 0
+        assert "--config" in result.output
+
+
+class TestErrorHandling:
+    """Test error handling in both CLIs (TDD: RED phase)."""
+
+    @patch("azlin.cli.IntentParser")
+    @patch("os.getenv")
+    def test_azdoit_handles_parse_errors(self, mock_getenv, mock_parser):
+        """Test that azdoit handles IntentParseError gracefully.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        mock_getenv.return_value = "test-api-key"
+        mock_parser_instance = MagicMock()
+        mock_parser.return_value = mock_parser_instance
+        mock_parser_instance.parse.side_effect = cli.IntentParseError("Failed to parse")
+
+        runner = CliRunner()
+        result = runner.invoke(cli.azdoit_main, ["invalid gibberish request", "--yes"])
+
+        # Should fail gracefully with helpful message
+        assert result.exit_code != 0
+        assert "Failed to parse" in result.output
+
+    @patch("azlin.cli.IntentParser")
+    @patch("azlin.cli.CommandExecutor")
+    @patch("os.getenv")
+    def test_azdoit_handles_execution_errors(self, mock_getenv, mock_executor, mock_parser):
+        """Test that azdoit handles CommandExecutionError gracefully.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        mock_getenv.return_value = "test-api-key"
+        mock_parser_instance = MagicMock()
+        mock_parser.return_value = mock_parser_instance
+        mock_parser_instance.parse.return_value = {
+            "intent": "list_vms",
+            "confidence": 0.95,
+            "azlin_commands": [{"command": "list", "args": []}],
+        }
+
+        mock_executor_instance = MagicMock()
+        mock_executor.return_value = mock_executor_instance
+        mock_executor_instance.execute_plan.side_effect = cli.CommandExecutionError(
+            "Execution failed"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli.azdoit_main, ["list my vms", "--yes"])
+
+        # Should fail gracefully with helpful message
+        assert result.exit_code != 0
+        assert "Execution failed" in result.output or "execution failed" in result.output.lower()
+
+    @patch("azlin.cli.IntentParser")
+    @patch("os.getenv")
+    def test_azdoit_handles_low_confidence(self, mock_getenv, mock_parser):
+        """Test that azdoit warns on low confidence and requires confirmation.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        mock_getenv.return_value = "test-api-key"
+        mock_parser_instance = MagicMock()
+        mock_parser.return_value = mock_parser_instance
+        mock_parser_instance.parse.return_value = {
+            "intent": "unknown",
+            "confidence": 0.3,  # Low confidence
+            "azlin_commands": [],
+        }
+
+        runner = CliRunner()
+        # User declines to continue (no --yes flag, and input='n')
+        result = runner.invoke(cli.azdoit_main, ["ambiguous request"], input="n\n")
+
+        # Should exit without executing
+        assert result.exit_code != 0 or "Cancelled" in result.output
+
+
+class TestPyprojectConfiguration:
+    """Test that pyproject.toml is correctly configured (TDD: RED phase)."""
+
+    def test_azdoit_script_defined_in_pyproject(self):
+        """Test that azdoit script is defined in pyproject.toml.
+
+        RED PHASE: This will fail - azdoit not in pyproject.toml yet.
+        """
+        # Use tomllib (Python 3.11+) or tomli
+        try:
+            import tomllib
+        except ImportError:
+            # Import real tomli by temporarily removing mock
+            import importlib
+
+            mock_tomli = sys.modules.get("tomli")
+            if mock_tomli and isinstance(mock_tomli, MagicMock):
+                del sys.modules["tomli"]
+            tomli = importlib.import_module("tomli")
+            if mock_tomli:
+                sys.modules["tomli"] = mock_tomli
+            tomllib = tomli
+
+        # Find pyproject.toml relative to this test file
+        pyproject_path = Path(__file__).parents[2] / "pyproject.toml"
+        with open(pyproject_path, "rb") as f:
+            config = tomllib.load(f)
+
+        scripts = config.get("project", {}).get("scripts", {})
+
+        # Check azdoit is defined
+        assert "azdoit" in scripts, "azdoit script not found in pyproject.toml"
+
+        # Check it points to the right entry point
+        assert scripts["azdoit"] == "azlin.cli:azdoit_main", (
+            "azdoit should point to azlin.cli:azdoit_main"
+        )
+
+    def test_azlin_script_still_exists(self):
+        """Test that azlin script still exists in pyproject.toml.
+
+        GREEN PHASE: This should pass - azlin already exists.
+        """
+        # Use tomllib (Python 3.11+) or tomli
+        try:
+            import tomllib
+        except ImportError:
+            # Import real tomli by temporarily removing mock
+            import importlib
+
+            mock_tomli = sys.modules.get("tomli")
+            if mock_tomli and isinstance(mock_tomli, MagicMock):
+                del sys.modules["tomli"]
+            tomli = importlib.import_module("tomli")
+            if mock_tomli:
+                sys.modules["tomli"] = mock_tomli
+            tomllib = tomli
+
+        # Find pyproject.toml relative to this test file
+        pyproject_path = Path(__file__).parents[2] / "pyproject.toml"
+        with open(pyproject_path, "rb") as f:
+            config = tomllib.load(f)
+
+        scripts = config.get("project", {}).get("scripts", {})
+
+        # Check azlin still exists
+        assert "azlin" in scripts, "azlin script must remain in pyproject.toml"
+        assert scripts["azlin"] == "azlin.cli:main"
+
+
+class TestDocumentation:
+    """Test that help text is appropriate for standalone CLI (TDD: RED phase)."""
+
+    @patch("os.getenv")
+    def test_azdoit_help_emphasizes_natural_language(self, mock_getenv):
+        """Test that azdoit help text emphasizes natural language usage.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli.azdoit_main, ["--help"])
+
+        assert result.exit_code == 0
+        # Should have examples
+        assert "example" in result.output.lower()
+        # Should mention natural language
+        assert (
+            "natural language" in result.output.lower() or "plain english" in result.output.lower()
+        )
+
+    @patch("os.getenv")
+    def test_azdoit_help_shows_quick_start(self, mock_getenv):
+        """Test that azdoit help shows quick start guide.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli.azdoit_main, ["--help"])
+
+        assert result.exit_code == 0
+        # Should mention API key requirement
+        assert "ANTHROPIC_API_KEY" in result.output
+        # Should have usage examples
+        assert "list" in result.output.lower() or "create" in result.output.lower()
+
+
+@pytest.mark.integration
+class TestEndToEndIntegration:
+    """Integration tests to verify both CLIs work identically (TDD: RED phase)."""
+
+    @patch("azlin.cli.IntentParser")
+    @patch("azlin.cli.CommandExecutor")
+    @patch("azlin.cli.ResultValidator")
+    @patch("azlin.cli.ConfigManager")
+    @patch("os.getenv")
+    def test_complete_workflow_azdoit(
+        self, mock_getenv, mock_config, mock_validator, mock_executor, mock_parser
+    ):
+        """Test complete workflow with azdoit CLI.
+
+        RED PHASE: This will fail - azdoit_main doesn't exist yet.
+        """
+        from azlin import cli
+
+        # Setup complete mock chain
+        mock_getenv.return_value = "test-api-key"
+        mock_config.get_resource_group.return_value = "test-rg"
+
+        mock_parser_instance = MagicMock()
+        mock_parser.return_value = mock_parser_instance
+        mock_parser_instance.parse.return_value = {
+            "intent": "list_vms",
+            "confidence": 0.98,
+            "explanation": "List all VMs",
+            "azlin_commands": [{"command": "list", "args": ["--resource-group", "test-rg"]}],
+        }
+
+        mock_executor_instance = MagicMock()
+        mock_executor.return_value = mock_executor_instance
+        mock_executor_instance.execute_plan.return_value = [
+            {
+                "success": True,
+                "command": "list",
+                "stdout": "vm1\nvm2",
+                "stderr": "",
+            }
+        ]
+
+        mock_validator_instance = MagicMock()
+        mock_validator.return_value = mock_validator_instance
+        mock_validator_instance.validate.return_value = {
+            "success": True,
+            "message": "Successfully listed VMs",
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(cli.azdoit_main, ["list all my vms", "--yes", "--verbose"])
+
+        # Complete workflow should succeed
+        assert result.exit_code == 0
+        assert "Successfully listed VMs" in result.output
+        assert mock_parser_instance.parse.called
+        assert mock_executor_instance.execute_plan.called
+        assert mock_validator_instance.validate.called
+
+    @patch("azlin.cli.IntentParser")
+    @patch("azlin.cli.CommandExecutor")
+    @patch("azlin.cli.ResultValidator")
+    @patch("azlin.cli.ConfigManager")
+    @patch("os.getenv")
+    def test_complete_workflow_azlin_do(
+        self, mock_getenv, mock_config, mock_validator, mock_executor, mock_parser
+    ):
+        """Test complete workflow with azlin do command.
+
+        GREEN PHASE: This should pass - azlin do already works.
+        """
+        # Setup complete mock chain
+        mock_getenv.return_value = "test-api-key"
+        mock_config.get_resource_group.return_value = "test-rg"
+
+        mock_parser_instance = MagicMock()
+        mock_parser.return_value = mock_parser_instance
+        mock_parser_instance.parse.return_value = {
+            "intent": "list_vms",
+            "confidence": 0.98,
+            "explanation": "List all VMs",
+            "azlin_commands": [{"command": "list", "args": ["--resource-group", "test-rg"]}],
+        }
+
+        mock_executor_instance = MagicMock()
+        mock_executor.return_value = mock_executor_instance
+        mock_executor_instance.execute_plan.return_value = [
+            {
+                "success": True,
+                "command": "list",
+                "stdout": "vm1\nvm2",
+                "stderr": "",
+            }
+        ]
+
+        mock_validator_instance = MagicMock()
+        mock_validator.return_value = mock_validator_instance
+        mock_validator_instance.validate.return_value = {
+            "success": True,
+            "message": "Successfully listed VMs",
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["do", "list all my vms", "--yes", "--verbose"])
+
+        # Complete workflow should succeed
+        assert result.exit_code == 0
+        assert "Successfully listed VMs" in result.output
+        assert mock_parser_instance.parse.called
+        assert mock_executor_instance.execute_plan.called
+        assert mock_validator_instance.validate.called

--- a/tests/unit/test_azdoit_cli_simple.py
+++ b/tests/unit/test_azdoit_cli_simple.py
@@ -1,0 +1,437 @@
+"""TDD Tests for Issue #166: azdoit standalone CLI (Simplified).
+
+These tests follow TDD principles and WILL FAIL until implementation is complete.
+This version focuses on testable aspects without full module imports.
+
+Design Requirements:
+- Create azdoit_main() entry point in cli.py
+- Extract _do_impl() shared implementation
+- Add azdoit script to pyproject.toml
+- Maintain backward compatibility with azlin do
+
+Test Coverage:
+1. azdoit_main() entry point exists
+2. _do_impl() shared implementation exists
+3. azdoit script defined in pyproject.toml
+4. Both entry points have same signature
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+class TestAzdoitEntryPointExists:
+    """Test that azdoit_main() entry point exists in cli.py (TDD: RED phase)."""
+
+    @pytest.fixture
+    def cli_module_path(self):
+        """Get path to cli.py module."""
+        return Path(__file__).parents[2] / "src" / "azlin" / "cli.py"
+
+    @pytest.fixture
+    def cli_ast(self, cli_module_path):
+        """Parse cli.py AST for inspection without importing."""
+        with open(cli_module_path) as f:
+            return ast.parse(f.read())
+
+    @pytest.fixture
+    def function_names(self, cli_ast):
+        """Extract all function names from cli.py."""
+        return {node.name for node in ast.walk(cli_ast) if isinstance(node, ast.FunctionDef)}
+
+    def test_azdoit_main_function_exists(self, function_names):
+        """Test that azdoit_main() function exists in cli.py.
+
+        RED PHASE: This will fail - function doesn't exist yet.
+        """
+        assert "azdoit_main" in function_names, (
+            "azdoit_main() entry point function not found in cli.py"
+        )
+
+    def test_do_impl_shared_function_exists(self, function_names):
+        """Test that _do_impl() shared function exists in cli.py.
+
+        RED PHASE: This will fail - function doesn't exist yet.
+        """
+        assert "_do_impl" in function_names, (
+            "_do_impl() shared implementation function not found in cli.py"
+        )
+
+    def test_do_command_still_exists(self, function_names):
+        """Test that do() command function still exists (backward compatibility).
+
+        GREEN PHASE: This should pass - do() already exists.
+        """
+        assert "do" in function_names, "do() command function must remain in cli.py"
+
+    def test_main_function_exists(self, function_names):
+        """Test that main() entry point still exists (backward compatibility).
+
+        GREEN PHASE: This should pass - main() already exists.
+        """
+        assert "main" in function_names, "main() entry point must remain in cli.py"
+
+
+class TestAzdoitFunctionSignatures:
+    """Test that function signatures are correct (TDD: RED phase)."""
+
+    @pytest.fixture
+    def cli_module_path(self):
+        """Get path to cli.py module."""
+        return Path(__file__).parents[2] / "src" / "azlin" / "cli.py"
+
+    @pytest.fixture
+    def cli_ast(self, cli_module_path):
+        """Parse cli.py AST for inspection."""
+        with open(cli_module_path) as f:
+            return ast.parse(f.read())
+
+    @pytest.fixture
+    def function_definitions(self, cli_ast):
+        """Extract function definitions from cli.py."""
+        return {node.name: node for node in ast.walk(cli_ast) if isinstance(node, ast.FunctionDef)}
+
+    def test_azdoit_main_accepts_request_param(self, function_definitions):
+        """Test that azdoit_main() accepts 'request' parameter.
+
+        RED PHASE: This will fail - function doesn't exist yet.
+        """
+        if "azdoit_main" not in function_definitions:
+            pytest.skip("azdoit_main() not implemented yet")
+
+        azdoit_func = function_definitions["azdoit_main"]
+        param_names = [arg.arg for arg in azdoit_func.args.args]
+
+        assert "request" in param_names, "azdoit_main() should accept 'request' parameter"
+
+    def test_azdoit_main_accepts_common_flags(self, function_definitions):
+        """Test that azdoit_main() accepts common CLI flags.
+
+        RED PHASE: This will fail - function doesn't exist yet.
+        """
+        if "azdoit_main" not in function_definitions:
+            pytest.skip("azdoit_main() not implemented yet")
+
+        azdoit_func = function_definitions["azdoit_main"]
+        param_names = [arg.arg for arg in azdoit_func.args.args]
+
+        # Should have at least some standard parameters
+        expected_params = ["request", "dry_run", "yes"]
+        for param in expected_params:
+            assert param in param_names, (
+                f"azdoit_main() should accept '{param}' parameter like azlin do"
+            )
+
+    def test_do_impl_has_required_params(self, function_definitions):
+        """Test that _do_impl() has required parameters for shared logic.
+
+        RED PHASE: This will fail - function doesn't exist yet.
+        """
+        if "_do_impl" not in function_definitions:
+            pytest.skip("_do_impl() not implemented yet")
+
+        do_impl_func = function_definitions["_do_impl"]
+        param_names = [arg.arg for arg in do_impl_func.args.args]
+
+        # Should have core parameters needed for implementation
+        required_params = ["request"]
+        for param in required_params:
+            assert param in param_names, f"_do_impl() must have '{param}' parameter"
+
+
+class TestPyprojectConfiguration:
+    """Test that pyproject.toml is correctly configured (TDD: RED phase)."""
+
+    @pytest.fixture
+    def pyproject_path(self):
+        """Get path to pyproject.toml."""
+        return Path(__file__).parents[2] / "pyproject.toml"
+
+    def test_pyproject_exists(self, pyproject_path):
+        """Test that pyproject.toml exists."""
+        assert pyproject_path.exists(), "pyproject.toml not found"
+
+    def test_azdoit_script_entry_defined(self, pyproject_path):
+        """Test that azdoit script entry is defined in pyproject.toml.
+
+        RED PHASE: This will fail - azdoit not in pyproject.toml yet.
+        """
+        # Read as text and search for azdoit entry
+        content = pyproject_path.read_text()
+
+        # Should have azdoit in [project.scripts] section
+        assert "azdoit = " in content or 'azdoit = "' in content, (
+            "azdoit script entry not found in pyproject.toml"
+        )
+
+    def test_azdoit_points_to_correct_entry_point(self, pyproject_path):
+        """Test that azdoit points to azlin.cli:azdoit_main.
+
+        RED PHASE: This will fail - entry point doesn't exist yet.
+        """
+        content = pyproject_path.read_text()
+
+        # Should point to azlin.cli:azdoit_main
+        assert (
+            'azdoit = "azlin.cli:azdoit_main"' in content
+            or "azdoit = 'azlin.cli:azdoit_main'" in content
+        ), "azdoit should point to azlin.cli:azdoit_main"
+
+    def test_azlin_script_still_exists(self, pyproject_path):
+        """Test that azlin script still exists (backward compatibility).
+
+        GREEN PHASE: This should pass - azlin already exists.
+        """
+        content = pyproject_path.read_text()
+
+        # azlin entry should still exist
+        assert "azlin = " in content, "azlin script entry must remain in pyproject.toml"
+        assert 'azlin = "azlin.cli:main"' in content or "azlin = 'azlin.cli:main'" in content, (
+            "azlin should still point to azlin.cli:main"
+        )
+
+
+class TestFunctionDecorators:
+    """Test that functions have appropriate Click decorators (TDD: RED phase)."""
+
+    @pytest.fixture
+    def cli_source(self):
+        """Read cli.py source code."""
+        cli_path = Path(__file__).parents[2] / "src" / "azlin" / "cli.py"
+        with open(cli_path) as f:
+            return f.read()
+
+    def test_azdoit_main_has_click_decorators(self, cli_source):
+        """Test that azdoit_main() is decorated as a Click command.
+
+        RED PHASE: This will fail - function doesn't exist yet.
+        """
+        # Look for function definition and decorators
+        if "def azdoit_main(" not in cli_source:
+            pytest.fail("azdoit_main() function not found in cli.py")
+
+        # Extract the function and its decorators
+        lines = cli_source.split("\n")
+        azdoit_idx = None
+        for i, line in enumerate(lines):
+            if "def azdoit_main(" in line:
+                azdoit_idx = i
+                break
+
+        assert azdoit_idx is not None, "Could not find azdoit_main() definition"
+
+        # Check for Click decorators above the function
+        decorators_section = "\n".join(lines[max(0, azdoit_idx - 20) : azdoit_idx])
+
+        # Should have click.command or @click.command()
+        assert "@click.command" in decorators_section or "@main.command" in decorators_section, (
+            "azdoit_main() should be a Click command"
+        )
+
+        # Should have click.argument for REQUEST
+        assert "@click.argument" in decorators_section, (
+            "azdoit_main() should have @click.argument decorator for REQUEST"
+        )
+
+    def test_azdoit_main_has_same_options_as_do(self, cli_source):
+        """Test that azdoit_main() has similar options to do() command.
+
+        RED PHASE: This will fail - function doesn't exist yet.
+        """
+        if "def azdoit_main(" not in cli_source:
+            pytest.skip("azdoit_main() not implemented yet")
+
+        # Extract decorators for both functions
+        lines = cli_source.split("\n")
+
+        # Find do() function decorators
+        do_idx = None
+        for i, line in enumerate(lines):
+            if "def do(" in line:
+                do_idx = i
+                break
+
+        assert do_idx is not None, "Could not find do() function"
+
+        # Find azdoit_main() decorators
+        azdoit_idx = None
+        for i, line in enumerate(lines):
+            if "def azdoit_main(" in line:
+                azdoit_idx = i
+                break
+
+        do_decorators = "\n".join(lines[max(0, do_idx - 20) : do_idx])
+        azdoit_decorators = "\n".join(lines[max(0, azdoit_idx - 20) : azdoit_idx])
+
+        # Both should have --dry-run option
+        if "--dry-run" in do_decorators:
+            assert "--dry-run" in azdoit_decorators, (
+                "azdoit_main() should have --dry-run option like do()"
+            )
+
+        # Both should have --yes/-y option
+        if "--yes" in do_decorators:
+            assert "--yes" in azdoit_decorators, "azdoit_main() should have --yes option like do()"
+
+
+class TestCodeStructure:
+    """Test code structure and refactoring (TDD: RED phase)."""
+
+    @pytest.fixture
+    def cli_source(self):
+        """Read cli.py source code."""
+        cli_path = Path(__file__).parents[2] / "src" / "azlin" / "cli.py"
+        with open(cli_path) as f:
+            return f.read()
+
+    def test_do_impl_called_from_do_command(self, cli_source):
+        """Test that do() command calls _do_impl().
+
+        RED PHASE: This will fail - _do_impl doesn't exist yet.
+        """
+        if "def _do_impl(" not in cli_source:
+            pytest.skip("_do_impl() not implemented yet")
+
+        # Find do() function body
+        lines = cli_source.split("\n")
+        do_idx = None
+        for i, line in enumerate(lines):
+            if "def do(" in line:
+                do_idx = i
+                break
+
+        assert do_idx is not None, "Could not find do() function"
+
+        # Look for _do_impl call in next 200 lines (approximate function body)
+        do_body = "\n".join(lines[do_idx : do_idx + 200])
+
+        assert "_do_impl(" in do_body, (
+            "do() command should call _do_impl() for shared implementation"
+        )
+
+    def test_azdoit_main_called_from_azdoit_main(self, cli_source):
+        """Test that azdoit_main() calls _do_impl().
+
+        RED PHASE: This will fail - functions don't exist yet.
+        """
+        if "def azdoit_main(" not in cli_source:
+            pytest.skip("azdoit_main() not implemented yet")
+
+        if "def _do_impl(" not in cli_source:
+            pytest.skip("_do_impl() not implemented yet")
+
+        # Find azdoit_main() function body
+        lines = cli_source.split("\n")
+        azdoit_idx = None
+        for i, line in enumerate(lines):
+            if "def azdoit_main(" in line:
+                azdoit_idx = i
+                break
+
+        # Look for _do_impl call in next 200 lines
+        azdoit_body = "\n".join(lines[azdoit_idx : azdoit_idx + 200])
+
+        assert "_do_impl(" in azdoit_body, (
+            "azdoit_main() should call _do_impl() for shared implementation"
+        )
+
+    def test_code_deduplication(self, cli_source):
+        """Test that implementation is not duplicated between do() and azdoit_main().
+
+        RED PHASE: This will pass once refactored.
+        """
+        if "def azdoit_main(" not in cli_source:
+            pytest.skip("azdoit_main() not implemented yet")
+
+        if "def _do_impl(" not in cli_source:
+            pytest.skip("_do_impl() not implemented yet")
+
+        # Both functions should be small if they delegate to _do_impl
+        lines = cli_source.split("\n")
+
+        # Find function lengths
+        def get_function_length(func_name):
+            start_idx = None
+            for i, line in enumerate(lines):
+                if f"def {func_name}(" in line:
+                    start_idx = i
+                    break
+
+            if start_idx is None:
+                return 0
+
+            # Count lines until next function or end
+            length = 0
+            indent_level = len(lines[start_idx]) - len(lines[start_idx].lstrip())
+            for line in lines[start_idx + 1 :]:
+                if line.strip() and not line.startswith(" " * (indent_level + 1)):
+                    break
+                length += 1
+
+            return length
+
+        do_length = get_function_length("do")
+        azdoit_length = get_function_length("azdoit_main")
+
+        # If properly refactored, both should be relatively small (mostly just parameter handling)
+        # This is a soft check - functions delegating to _do_impl should be < 30 lines
+        if do_length > 0:
+            assert do_length < 50, (
+                f"do() should be small if it delegates to _do_impl() (found {do_length} lines)"
+            )
+
+        if azdoit_length > 0:
+            assert azdoit_length < 50, (
+                f"azdoit_main() should be small if it delegates to _do_impl() (found {azdoit_length} lines)"
+            )
+
+
+class TestDocumentation:
+    """Test that functions have appropriate documentation (TDD: RED phase)."""
+
+    @pytest.fixture
+    def cli_source(self):
+        """Read cli.py source code."""
+        cli_path = Path(__file__).parents[2] / "src" / "azlin" / "cli.py"
+        with open(cli_path) as f:
+            return f.read()
+
+    def test_azdoit_main_has_docstring(self, cli_source):
+        """Test that azdoit_main() has a docstring.
+
+        RED PHASE: This will fail - function doesn't exist yet.
+        """
+        if "def azdoit_main(" not in cli_source:
+            pytest.fail("azdoit_main() function not found")
+
+        # Look for docstring after function definition
+        lines = cli_source.split("\n")
+        for i, line in enumerate(lines):
+            if "def azdoit_main(" in line:
+                # Check next few lines for docstring
+                next_lines = "\n".join(lines[i : i + 10])
+                assert '"""' in next_lines or "'''" in next_lines, (
+                    "azdoit_main() should have a docstring"
+                )
+                return
+
+    def test_do_impl_has_docstring(self, cli_source):
+        """Test that _do_impl() has a docstring.
+
+        RED PHASE: This will fail - function doesn't exist yet.
+        """
+        if "def _do_impl(" not in cli_source:
+            pytest.fail("_do_impl() function not found")
+
+        # Look for docstring after function definition
+        lines = cli_source.split("\n")
+        for i, line in enumerate(lines):
+            if "def _do_impl(" in line:
+                # Check next few lines for docstring
+                next_lines = "\n".join(lines[i : i + 10])
+                assert '"""' in next_lines or "'''" in next_lines, (
+                    "_do_impl() should have a docstring"
+                )
+                return


### PR DESCRIPTION
## Summary

Restores `azdoit` standalone CLI command to main branch from develop (PR #168).

**Key Changes:**
- ✅ Extract `_do_impl()` shared implementation in cli.py
- ✅ Add `azdoit_main()` entry point for standalone command (line 6370)
- ✅ Update pyproject.toml with azdoit script entry
- ✅ Include comprehensive test coverage (1,158 lines, 44 tests)
- ✅ Maintain backward compatibility (`azlin do` unchanged)

**Implementation Details:**
- cli.py: +120 lines (6340 → 6460 lines)
- Refactored `do` command to delegate to `_do_impl()`
- `azdoit_main()` uses same `_do_impl()` for consistency
- No changes to vm_manager.py needed (main already has include_stopped filtering)

**Testing:**
- ✅ All 44 azdoit tests passing (26 comprehensive + 18 simple)
- ✅ No regressions in existing test suite (1123 tests passed)
- ✅ Manual integration testing completed
- ✅ Pre-commit hooks passing (ruff, pyright, security checks)

**Usage:**
```bash
# New standalone command
azdoit "spin up 3 VMs"
azdoit "stop all VMs matching dev-*" --dry-run
azdoit "list all my VMs" --verbose

# Existing command still works
azlin do "list all VMs"
```

**Verification:**
```bash
# Both commands available
which azlin  # ✅
which azdoit # ✅

# Help text displays correctly
azdoit --help # ✅

# Tests pass
pytest tests/unit/test_azdoit_cli*.py -v # ✅ 44 passed
```

**Fixes:** #166
**Related:** #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)