### PR TITLE
Update AMPLIFIER_CHEATSHEET with azlin tool install

### DIFF
--- a/docs/AMPLIFIER_CHEATSHEET.md
+++ b/docs/AMPLIFIER_CHEATSHEET.md
@@ -31,6 +31,16 @@ uvx --from git+https://github.com/rysweet/azlin azlin new --name amplifier-dev -
 uvx --from git+https://github.com/rysweet/azlin azlin new --vm-size Standard_D4s_v3 --repo https://github.com/microsoft/amplifier
 ```
 
+**Or install as a tool without alias:**
+
+```bash
+# Set up as a local tool
+uv tool install git+https://github.com/rysweet/azlin
+
+# Now use azlin as normal!
+azlin new --repo https://github.com/microsoft/amplifier
+```
+
 ### If you have azlin installed
 
 ```bash


### PR DESCRIPTION
Added instructions for installing azlin as a local tool via `uv tool install`.  If there was a reason you want to use the alias + uvx approach, it's not super clear (though I wonder if you did so because that approach ensures it is up-to-date more regularly - though not sure since it gets cached)?  Feel free to close if you had a reason for not using this approach, though an updated comment as to why the alias approach might prevent someone else from submitting the same.