### PR TITLE
Fix: Update deprecated Claude model to fix azlin do 404 error

### DIFF
--- a/src/azlin/agentic/command_executor.py
+++ b/src/azlin/agentic/command_executor.py
@@ -202,7 +202,7 @@ Output JSON only:
             import json
 
             message = self.client.messages.create(
-                model="claude-3-5-sonnet-20241022",
+                model="claude-sonnet-4-5-20250929",
                 max_tokens=1024,
                 system=system_prompt,
                 messages=[{"role": "user", "content": json.dumps(user_message)}],

--- a/src/azlin/agentic/intent_parser.py
+++ b/src/azlin/agentic/intent_parser.py
@@ -57,7 +57,7 @@ class IntentParser:
 
         try:
             message = self.client.messages.create(
-                model="claude-3-5-sonnet-20241022",
+                model="claude-sonnet-4-5-20250929",
                 max_tokens=2048,
                 system=system_prompt,
                 messages=[{"role": "user", "content": user_message}],
@@ -230,7 +230,7 @@ Output JSON only:
 
         try:
             message = self.client.messages.create(
-                model="claude-3-5-sonnet-20241022",
+                model="claude-sonnet-4-5-20250929",
                 max_tokens=1024,
                 system=system_prompt,
                 messages=[{"role": "user", "content": json.dumps(user_message)}],


### PR DESCRIPTION
## Problem

`azlin do` fails with 404 error due to deprecated Claude model.

## Solution

Updated model from `claude-3-5-sonnet-20241022` (deprecated) to `claude-sonnet-4-5-20250929` (current).

## Changes

- command_executor.py: Updated model
- intent_parser.py: Updated model (2 locations)

## Testing

- [ ] Test `azlin do "show me costs"` works without 404

## Fixes

Fixes #199