### PR TITLE
fix: Split GitHub CLI installation from Python packages for better error handling

### DIFF
--- a/src/azlin/vm_provisioning.py
+++ b/src/azlin/vm_provisioning.py
@@ -660,7 +660,18 @@ runcmd:
 
   # OPTIMIZATION: Single apt update for both deadsnakes and GitHub CLI
   - apt update
-  - apt install -y python3.12 python3.12-venv python3.12-dev python3.12-distutils gh
+
+  # Install Python 3.12 packages
+  - apt install -y python3.12 python3.12-venv python3.12-dev python3.12-distutils
+
+  # Install GitHub CLI (separate command for explicit error handling)
+  - |
+    if apt install -y gh; then
+      echo "GitHub CLI (gh) installed successfully"
+    else
+      echo "WARNING: GitHub CLI (gh) installation failed - check repository setup"
+    fi
+
   - update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
   - update-alternatives --set python3 /usr/bin/python3.12
   - curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12


### PR DESCRIPTION
## Summary
Fixes #240 by separating GitHub CLI installation from Python packages and adding explicit error handling.

## Changes
- Split `gh` installation into its own apt command with conditional logic
- Add success/failure logging to cloud-init output
- Prevent `gh` installation failures from blocking VM provisioning
- Maintain backward compatibility with existing workflow

## Root Cause
Previously, `gh` was installed in the same apt command as Python 3.12 packages. If any package failed, the entire command would fail, potentially blocking VM provisioning.

## Solution
- Use a multiline shell script block with if/then/else logic
- Log success message: "GitHub CLI (gh) installed successfully"
- Log warning on failure: "WARNING: GitHub CLI (gh) installation failed - check repository setup"
- VM provisioning continues even if gh fails (non-blocking)

## Testing
- ✅ Python syntax validation passed
- ✅ YAML syntax valid
- 📋 Full test requires VM creation (see issue for test plan)

## Test Plan
```bash
# Create new VM
azlin create test-gh-fix

# SSH and verify gh is installed
ssh azureuser@<vm-ip> "gh --version"

# Check cloud-init logs
ssh azureuser@<vm-ip> "sudo cat /var/log/cloud-init-output.log | grep 'GitHub CLI'"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)