### PR TITLE
fix: Add port parameter to RemoteExecutor SSH command for Bastion tunnels

### DIFF
--- a/src/azlin/remote_exec.py
+++ b/src/azlin/remote_exec.py
@@ -89,6 +89,8 @@ class RemoteExecutor:
                 f"ConnectTimeout={min(timeout, 10)}",
                 "-i",
                 str(ssh_config.key_path),
+                "-p",
+                str(ssh_config.port),
                 f"{ssh_config.user}@{ssh_config.host}",
                 command,  # Pass command directly, not through shell
             ]


### PR DESCRIPTION
## Summary

Fixes password prompts and 5s timeouts in `azlin list` when collecting tmux sessions from Bastion-only VMs.

**Follow-up to PR #255** - This fix was committed after PR #255 was merged.

## Problem

When running `azlin list` with Bastion-only VMs:

```
Bastion tunnel created on 127.0.0.1:50035
(azureuser@127.0.0.1) Password:
Failed on 127.0.0.1: Command timed out after 5s on 127.0.0.1
```

**Root Cause**: `RemoteExecutor.execute_command()` was ignoring the `SSHConfig.port` parameter when building SSH commands.

**What happened:**
1. `azlin list` creates Bastion tunnel on `127.0.0.1:50035` (dynamic port)
2. Creates `SSHConfig(host="127.0.0.1", port=50035)`
3. RemoteExecutor builds SSH command **without** `-p 50035` flag
4. SSH connects to `127.0.0.1:22` (default port, nothing listening)
5. SSH falls back to password auth and times out after 5s

## Solution

Added `-p` port flag to SSH command in `RemoteExecutor.execute_command()`:

```python
ssh_cmd = [
    "ssh",
    ...
    "-i", str(ssh_config.key_path),
    "-p", str(ssh_config.port),  # ← ADDED
    f"{ssh_config.user}@{ssh_config.host}",
    command,
]
```

## Files Modified

- `src/azlin/remote_exec.py` (+2 lines)

## Test Results

### Unit Tests
- ✅ All 45 remote_exec tests passing
- ✅ Backward compatible (port defaults to 22 for direct SSH)

### E2E Tests
Verified with real Azure resources:
```bash
uvx --from git+https://github.com/rysweet/azlin@fix/remote-exec-port-parameter azlin list --rg rysweet-linux-vm-pool
```

**Results**:
- ✅ 4 Bastion tunnels created successfully
- ✅ Tmux sessions collected from all Bastion VMs
- ✅ **NO password prompts**
- ✅ **NO 5s timeouts**
- ✅ Clean tunnel cleanup

## Impact

- Fixes `azlin list` for Bastion-only VMs
- No changes to direct SSH behavior (port=22 by default)
- Fully backward compatible

## Related

- Issue #254 - Original Bastion SSH timeout issue
- PR #255 - VM boot wait fix (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)