### PR TITLE
fix: VM subnet selection to avoid AzureBastionSubnet error

### DIFF
--- a/src/azlin/vm_provisioning.py
+++ b/src/azlin/vm_provisioning.py
@@ -505,6 +505,14 @@ class VMProvisioner:
         else:
             cmd.extend(["--public-ip-address", ""])  # Empty string disables public IP creation
 
+        # CRITICAL: Specify subnet when using Bastion (avoid AzureBastionSubnet)
+        # When a VNet exists with multiple subnets (e.g., from Bastion provisioning),
+        # Azure may pick the wrong subnet (AzureBastionSubnet). We must explicitly
+        # specify the 'default' subnet for VMs.
+        if not config.public_ip_enabled:
+            # Bastion-only VM - ensure it uses correct subnet
+            cmd.extend(["--subnet", "default"])
+
         cmd.append("--output")
         cmd.append("json")
 


### PR DESCRIPTION
Fixes critical bug where VMs try to use AzureBastionSubnet instead of default subnet when Bastion exists.