### PR TITLE
feat: Add progress indicators and command visibility to Bastion operations

### DIFF
--- a/src/azlin/modules/bastion_provisioner.py
+++ b/src/azlin/modules/bastion_provisioner.py
@@ -905,7 +905,9 @@ class BastionProvisioner:
             ]
             # Bastion creation takes 5-15 minutes - use proper timeout
             # The command will return when provisioning starts
-            executor = AzureCLIExecutor(show_progress=True, timeout=cls.DEFAULT_PROVISIONING_TIMEOUT)
+            executor = AzureCLIExecutor(
+                show_progress=True, timeout=cls.DEFAULT_PROVISIONING_TIMEOUT
+            )
             exec_result = executor.execute(cmd)
             if not exec_result["success"]:
                 raise subprocess.CalledProcessError(


### PR DESCRIPTION
## UX Improvement

Fixes user feedback: "when there is an azure operation like creating a bastion host we are not showing the command and we are not showing a progress bar or spinner"

## Changes

Replaced all 8 `subprocess.run()` calls in `bastion_provisioner.py` with `AzureCLIExecutor`.

### Before
```
... Creating Bastion host...
[10-15 minutes of SILENCE]
✓ Bastion created
```

### After
```
... Creating Bastion host...
Executing: az network bastion create --name azlin-bastion-westus ...
⠋ Running command... (shows spinner)
✓ Bastion created
```

## Benefits

- **Command Visibility**: Shows what Azure CLI command is running
- **Progress Feedback**: Spinner shows activity during long operations
- **Better Error Messages**: AzureCLIExecutor provides clearer errors
- **Consistent UX**: Matches existing VM provisioning behavior

## Operations Enhanced

1. VNet existence check
2. VNet listing
3. Subnet existence check
4. Public IP existence check
5. VNet creation
6. Bastion subnet creation
7. Public IP creation
8. **Bastion creation (10-15 min!)**

All operations now show progress instead of silently running.

Co-Authored-By: Claude <noreply@anthropic.com>