### PR TITLE
fix: Change Bastion SKU default from Basic to Standard for CLI tunneling

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ azlin bastion configure my-vm --bastion-name my-bastion --resource-group my-rg
 
 **Security Benefits**: Bastion eliminates internet-facing access to VMs, providing enhanced security through centralized access control, audit logging, and compliance with security policies requiring private-only VMs.
 
-**Cost**: ~$140/month per Bastion host (shared across all VMs in the VNet).
+**Cost**: ~$289/month per Bastion host (Standard SKU, shared across all VMs in the VNet).
+
+**Note**: azlin requires Standard SKU to enable CLI tunneling via `az network bastion tunnel`. Basic SKU only supports browser-based access.
 
 For complete documentation, see the [Azure Bastion](#azure-bastion-secure-vm-access) section.
 
@@ -852,9 +854,16 @@ Azure Bastion provides secure SSH access to VMs without public IPs, enhancing se
 - Compliance with security policies requiring private-only VMs
 
 **Cost Consideration:**
-- Bastion: ~$140/month per host
+- Bastion: ~$289/month per host (Standard SKU required for CLI access)
 - Saves: ~$3/month per VM (no public IP needed)
-- Break-even: ~47 VMs per Bastion host
+- Break-even: ~96 VMs per Bastion host
+
+**Standard SKU Requirement:**
+
+azlin uses Azure Bastion Standard SKU (not Basic) because:
+- **CLI tunneling support**: Standard SKU enables `az network bastion tunnel` for programmatic SSH access
+- **Basic SKU limitation**: Basic SKU only supports browser-based SSH through Azure Portal
+- **azlin workflow**: Requires CLI-based tunneling for automated connection management and tmux integration
 
 ### Bastion Commands
 

--- a/src/azlin/cli.py
+++ b/src/azlin/cli.py
@@ -526,7 +526,7 @@ class CLIOrchestrator:
                             vnet_name=None,  # Will auto-create VNet if needed
                             vnet_id=None,
                             bastion_subnet_id=None,
-                            sku="Basic",
+                            sku="Standard",
                             allow_public_ip_fallback=False,  # NEVER allow public IP on VMs
                         )
                     )

--- a/src/azlin/modules/cleanup_orchestrator.py
+++ b/src/azlin/modules/cleanup_orchestrator.py
@@ -105,10 +105,10 @@ class OrphanedBastionInfo:
         """Calculate estimated monthly cost for this Bastion."""
         # Bastion pricing (approximate US East):
         # - Basic SKU: ~$0.19/hour = ~$140/month
-        # - Standard SKU: ~$0.32/hour = ~$230/month
+        # - Standard SKU: ~$0.40/hour = ~$289/month
         # - Public IP: ~$3.65/month
         if self.sku:
-            bastion_cost = Decimal("230.0") if "Standard" in self.sku else Decimal("140.0")
+            bastion_cost = Decimal("289.0") if "Standard" in self.sku else Decimal("140.0")
         else:
             bastion_cost = Decimal("140.0")
 

--- a/src/azlin/modules/cost_estimator.py
+++ b/src/azlin/modules/cost_estimator.py
@@ -51,7 +51,7 @@ class CostEstimator:
     NFS_STANDARD_GB = 0.06  # per GB/month
 
     @staticmethod
-    def estimate_bastion_cost(sku: str = "Basic") -> float:
+    def estimate_bastion_cost(sku: str = "Standard") -> float:
         """Estimate monthly Azure Bastion cost including required public IP.
 
         Azure Bastion requires a static public IP address in addition to the

--- a/src/azlin/modules/resource_orchestrator.py
+++ b/src/azlin/modules/resource_orchestrator.py
@@ -170,7 +170,7 @@ class BastionOptions:
     vnet_name: str | None
     vnet_id: str | None = None
     bastion_subnet_id: str | None = None
-    sku: str = "Basic"
+    sku: str = "Standard"
     allow_public_ip_fallback: bool = True
 
 
@@ -738,8 +738,8 @@ class ResourceOrchestrator:
         if not self.cost_estimator:
             # Default estimates if no cost estimator provided
             # Basic SKU: ~$0.19/hour = ~$140/month
-            # Standard SKU: ~$0.32/hour = ~$230/month
-            hourly = Decimal("0.19" if sku == "Basic" else "0.32")
+            # Standard SKU: ~$0.40/hour = ~$289/month
+            hourly = Decimal("0.19" if sku == "Basic" else "0.40")
             monthly = hourly * Decimal("730")  # Average hours per month
 
             logger.warning(

--- a/tests/integration/test_cleanup_workflow.py
+++ b/tests/integration/test_cleanup_workflow.py
@@ -246,25 +246,25 @@ class TestOrphanedBastionInfoCost:
         bastion.calculate_cost()
 
         # Assert
-        # $140 Bastion + $3.65 public IP
-        assert bastion.estimated_monthly_cost == Decimal("143.65")
+        # $289 Bastion + $3.65 public IP
+        assert bastion.estimated_monthly_cost == Decimal("292.65")
 
-    def test_calculate_cost_premium_sku(self):
-        """Test cost calculation for Premium SKU."""
+    def test_calculate_cost_basic_sku(self):
+        """Test cost calculation for Basic SKU."""
         # Arrange
         bastion = OrphanedBastionInfo(
             name="my-bastion",
             resource_group="test-rg",
             location="eastus",
-            sku="Premium",
+            sku="Basic",
         )
 
         # Act
         bastion.calculate_cost()
 
         # Assert
-        # $230 Bastion + $3.65 public IP
-        assert bastion.estimated_monthly_cost == Decimal("233.65")
+        # $140 Bastion + $3.65 public IP
+        assert bastion.estimated_monthly_cost == Decimal("143.65")
 
     def test_calculate_cost_unknown_sku_uses_basic(self):
         """Test cost calculation defaults to Basic for unknown SKU."""
@@ -322,21 +322,21 @@ class TestCleanupDecisionPrompt:
                 resource_group="test-rg",
                 location="eastus",
                 sku="Standard",
-                estimated_monthly_cost=Decimal("143.65"),
+                estimated_monthly_cost=Decimal("292.65"),
             )
         ]
 
         # Act
         decision = orchestrator._prompt_cleanup_decision(
             orphaned=orphaned,
-            total_savings=Decimal("143.65"),
+            total_savings=Decimal("292.65"),
             force=False,
         )
 
         # Assert
         assert decision.approved is True
         assert "orphaned-bastion" in decision.resources_to_delete
-        assert decision.estimated_savings == Decimal("143.65")
+        assert decision.estimated_savings == Decimal("292.65")
         assert decision.cancelled is False
 
     @patch("builtins.input")

--- a/tests/modules/test_resource_orchestrator.py
+++ b/tests/modules/test_resource_orchestrator.py
@@ -36,13 +36,13 @@ class TestResourceDecision:
             action=DecisionAction.CREATE,
             resource_type=ResourceType.BASTION,
             resource_name="my-bastion",
-            cost_estimate=Decimal("140.00"),
+            cost_estimate=Decimal("292.65"),
         )
 
         assert decision.action == DecisionAction.CREATE
         assert decision.resource_type == ResourceType.BASTION
         assert decision.resource_name == "my-bastion"
-        assert decision.cost_estimate == Decimal("140.00")
+        assert decision.cost_estimate == Decimal("292.65")
 
     def test_use_existing_decision(self):
         """Test decision for using existing resource."""
@@ -498,9 +498,9 @@ class TestCostEstimation:
         # Mock cost estimator
         mock_estimator = MagicMock()
         mock_estimator.estimate.return_value = CostEstimate(
-            total_monthly=Decimal("140.00"),
-            total_hourly=Decimal("0.19"),
-            breakdown={"bastion": Decimal("140.00")},
+            total_monthly=Decimal("292.65"),
+            total_hourly=Decimal("0.40"),
+            breakdown={"bastion": Decimal("289.00")},
             confidence="high",
         )
 
@@ -519,7 +519,7 @@ class TestCostEstimation:
 
             decision = orchestrator.ensure_bastion(options)
 
-            assert decision.cost_estimate == Decimal("140.00")
+            assert decision.cost_estimate == Decimal("292.65")
             assert mock_estimator.estimate.called
 
     def test_bastion_cost_without_estimator(self):

--- a/tests/unit/modules/__init__.py
+++ b/tests/unit/modules/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for modules package."""

--- a/tests/unit/modules/test_bastion_provisioner.py
+++ b/tests/unit/modules/test_bastion_provisioner.py
@@ -1,0 +1,536 @@
+"""Unit tests for bastion_provisioner module.
+
+Tests provisioning logic with mocked Azure CLI calls.
+"""
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from azlin.modules.bastion_provisioner import (
+    BastionProvisioner,
+    BastionProvisionerError,
+    PrerequisiteStatus,
+    ProvisioningResult,
+)
+
+
+class TestInputValidation:
+    """Test input validation for bastion provisioning."""
+
+    def test_empty_bastion_name_raises_error(self):
+        """Empty bastion name should raise error."""
+        with pytest.raises(BastionProvisionerError, match="cannot be empty"):
+            BastionProvisioner._validate_inputs("", "rg", "eastus")
+
+    def test_empty_resource_group_raises_error(self):
+        """Empty resource group should raise error."""
+        with pytest.raises(BastionProvisionerError, match="cannot be empty"):
+            BastionProvisioner._validate_inputs("bastion", "", "eastus")
+
+    def test_empty_location_raises_error(self):
+        """Empty location should raise error."""
+        with pytest.raises(BastionProvisionerError, match="cannot be empty"):
+            BastionProvisioner._validate_inputs("bastion", "rg", "")
+
+    def test_invalid_bastion_name_format(self):
+        """Invalid bastion name should raise error."""
+        with pytest.raises(BastionProvisionerError, match="Invalid Bastion name"):
+            BastionProvisioner._validate_inputs("bastion@name", "rg", "eastus")
+
+    def test_valid_bastion_name(self):
+        """Valid bastion name should not raise error."""
+        # Should not raise
+        BastionProvisioner._validate_inputs("my-bastion", "my-rg", "eastus")
+        BastionProvisioner._validate_inputs("bastion_123", "rg", "westus")
+        BastionProvisioner._validate_inputs("bastion.1", "rg", "centralus")
+
+
+class TestPrerequisiteStatus:
+    """Test PrerequisiteStatus dataclass."""
+
+    def test_is_ready_all_satisfied(self):
+        """Status with all prerequisites should be ready."""
+        status = PrerequisiteStatus(
+            vnet_exists=True,
+            subnet_exists=True,
+            public_ip_exists=True,
+            quota_available=True,
+        )
+        assert status.is_ready() is True
+
+    def test_is_ready_missing_vnet(self):
+        """Status missing VNet should not be ready."""
+        status = PrerequisiteStatus(
+            vnet_exists=False,
+            subnet_exists=True,
+            public_ip_exists=True,
+            quota_available=True,
+        )
+        assert status.is_ready() is False
+
+    def test_is_ready_missing_multiple(self):
+        """Status missing multiple prerequisites should not be ready."""
+        status = PrerequisiteStatus(
+            vnet_exists=False,
+            subnet_exists=False,
+            public_ip_exists=True,
+            quota_available=True,
+        )
+        assert status.is_ready() is False
+
+    def test_missing_resources_none(self):
+        """Status with no missing resources."""
+        status = PrerequisiteStatus(
+            vnet_exists=True,
+            subnet_exists=True,
+            public_ip_exists=True,
+            quota_available=True,
+        )
+        assert status.missing_resources() == []
+
+    def test_missing_resources_vnet(self):
+        """Status should list missing VNet."""
+        status = PrerequisiteStatus(
+            vnet_exists=False,
+            subnet_exists=True,
+            public_ip_exists=True,
+            quota_available=True,
+        )
+        assert "vnet" in status.missing_resources()
+
+    def test_missing_resources_multiple(self):
+        """Status should list all missing resources."""
+        status = PrerequisiteStatus(
+            vnet_exists=False,
+            subnet_exists=False,
+            public_ip_exists=False,
+            quota_available=True,
+        )
+        missing = status.missing_resources()
+        assert "vnet" in missing
+        assert "subnet" in missing
+        assert "public_ip" in missing
+
+
+class TestProvisioningResult:
+    """Test ProvisioningResult dataclass."""
+
+    def test_to_dict_success(self):
+        """Successful result should convert to dict."""
+        result = ProvisioningResult(
+            success=True,
+            bastion_name="my-bastion",
+            resource_group="my-rg",
+            location="eastus",
+            resources_created=["vnet:my-vnet", "bastion:my-bastion"],
+            provisioning_state="Succeeded",
+            duration_seconds=300.5,
+        )
+
+        result_dict = result.to_dict()
+
+        assert result_dict["success"] is True
+        assert result_dict["bastion_name"] == "my-bastion"
+        assert result_dict["resource_group"] == "my-rg"
+        assert result_dict["location"] == "eastus"
+        assert len(result_dict["resources_created"]) == 2
+        assert result_dict["provisioning_state"] == "Succeeded"
+        assert result_dict["duration_seconds"] == 300.5
+
+    def test_to_dict_failure(self):
+        """Failed result should include error message."""
+        result = ProvisioningResult(
+            success=False,
+            bastion_name="my-bastion",
+            resource_group="my-rg",
+            location="eastus",
+            resources_created=[],
+            error_message="Provisioning failed",
+        )
+
+        result_dict = result.to_dict()
+
+        assert result_dict["success"] is False
+        assert result_dict["error_message"] == "Provisioning failed"
+
+
+class TestErrorSanitization:
+    """Test Azure CLI error message sanitization."""
+
+    def test_sanitize_resource_not_found(self):
+        """ResourceNotFound error should be sanitized."""
+        stderr = "ERROR: ResourceNotFound: The resource was not found"
+        sanitized = BastionProvisioner._sanitize_azure_error(stderr)
+        assert sanitized == "Resource not found"
+
+    def test_sanitize_auth_failed(self):
+        """Authentication errors should be sanitized."""
+        stderr = "ERROR: InvalidAuthenticationToken: Token expired"
+        sanitized = BastionProvisioner._sanitize_azure_error(stderr)
+        assert sanitized == "Authentication failed"
+
+    def test_sanitize_quota_exceeded(self):
+        """Quota errors should be sanitized."""
+        stderr = "ERROR: QuotaExceeded: You have reached your quota limit"
+        sanitized = BastionProvisioner._sanitize_azure_error(stderr)
+        assert sanitized == "Quota exceeded"
+
+    def test_sanitize_already_exists(self):
+        """AlreadyExists errors should be sanitized."""
+        stderr = "ERROR: Resource already exists in this region"
+        sanitized = BastionProvisioner._sanitize_azure_error(stderr)
+        assert sanitized == "Resource already exists"
+
+    def test_sanitize_generic_error(self):
+        """Unknown errors should return generic message."""
+        stderr = "ERROR: SomeUnknownError: Something went wrong"
+        sanitized = BastionProvisioner._sanitize_azure_error(stderr)
+        assert sanitized == "Azure operation failed"
+
+
+class TestCheckPrerequisites:
+    """Test prerequisite checking."""
+
+    @patch("azlin.modules.bastion_provisioner.subprocess.run")
+    def test_check_prerequisites_vnet_exists(self, mock_run):
+        """Check prerequisites should detect existing VNet."""
+        # Mock VNet check - exists
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"name": "my-vnet"}')
+
+        status = BastionProvisioner.check_prerequisites(
+            "my-rg", "eastus", vnet_name="my-vnet"
+        )
+
+        assert status.vnet_exists is True
+        assert status.vnet_name == "my-vnet"
+
+    @patch("azlin.modules.bastion_provisioner.subprocess.run")
+    def test_check_prerequisites_vnet_not_exists(self, mock_run):
+        """Check prerequisites should detect missing VNet."""
+        # Mock VNet check - doesn't exist
+        mock_run.return_value = MagicMock(returncode=1, stderr="ResourceNotFound")
+
+        status = BastionProvisioner.check_prerequisites(
+            "my-rg", "eastus", vnet_name="missing-vnet"
+        )
+
+        assert status.vnet_exists is False
+
+    @patch("azlin.modules.bastion_provisioner.subprocess.run")
+    def test_check_prerequisites_no_vnet_specified(self, mock_run):
+        """Check prerequisites with no VNet should list existing VNets."""
+        # Mock VNet list
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout='[{"name": "vnet1"}, {"name": "vnet2"}]'
+        )
+
+        status = BastionProvisioner.check_prerequisites("my-rg", "eastus")
+
+        assert status.vnet_exists is True
+        assert status.vnet_name == "vnet1"  # First VNet
+
+
+class TestProvisionBastion:
+    """Test full bastion provisioning workflow."""
+
+    @patch("azlin.modules.bastion_provisioner.BastionProvisioner.check_prerequisites")
+    @patch("azlin.modules.bastion_provisioner.BastionProvisioner._create_vnet")
+    @patch("azlin.modules.bastion_provisioner.BastionProvisioner._create_bastion_subnet")
+    @patch("azlin.modules.bastion_provisioner.BastionProvisioner._create_public_ip")
+    @patch("azlin.modules.bastion_provisioner.BastionProvisioner._create_bastion")
+    def test_provision_bastion_creates_all_resources(
+        self,
+        mock_create_bastion,
+        mock_create_ip,
+        mock_create_subnet,
+        mock_create_vnet,
+        mock_check_prereqs,
+    ):
+        """Provision should create all missing resources."""
+        # Mock prerequisites - nothing exists
+        mock_check_prereqs.return_value = PrerequisiteStatus(
+            vnet_exists=False,
+            subnet_exists=False,
+            public_ip_exists=False,
+            quota_available=True,
+        )
+
+        result = BastionProvisioner.provision_bastion(
+            bastion_name="my-bastion",
+            resource_group="my-rg",
+            location="eastus",
+            wait_for_completion=False,
+        )
+
+        assert result.success is True
+        assert "vnet" in str(result.resources_created)
+        assert "subnet" in str(result.resources_created)
+        assert "public-ip" in str(result.resources_created)
+        assert "bastion" in str(result.resources_created)
+
+        # Verify all create methods called
+        assert mock_create_vnet.called
+        assert mock_create_subnet.called
+        assert mock_create_ip.called
+        assert mock_create_bastion.called
+
+    @patch("azlin.modules.bastion_provisioner.BastionProvisioner.check_prerequisites")
+    @patch("azlin.modules.bastion_provisioner.BastionProvisioner._create_bastion")
+    def test_provision_bastion_uses_existing_resources(
+        self, mock_create_bastion, mock_check_prereqs
+    ):
+        """Provision should use existing resources when available."""
+        # Mock prerequisites - everything exists
+        mock_check_prereqs.return_value = PrerequisiteStatus(
+            vnet_exists=True,
+            subnet_exists=True,
+            public_ip_exists=True,
+            quota_available=True,
+            vnet_name="existing-vnet",
+            subnet_name="AzureBastionSubnet",
+            public_ip_name="existing-ip",
+        )
+
+        result = BastionProvisioner.provision_bastion(
+            bastion_name="my-bastion",
+            resource_group="my-rg",
+            location="eastus",
+            wait_for_completion=False,
+        )
+
+        assert result.success is True
+        # Should only create bastion, not other resources
+        assert len(result.resources_created) == 1
+        assert "bastion:my-bastion" in result.resources_created
+
+    @patch("azlin.modules.bastion_provisioner.BastionProvisioner.check_prerequisites")
+    def test_provision_bastion_validation_error(self, mock_check_prereqs):
+        """Provision with invalid input should fail gracefully."""
+        result = BastionProvisioner.provision_bastion(
+            bastion_name="",  # Invalid
+            resource_group="my-rg",
+            location="eastus",
+        )
+
+        assert result.success is False
+        assert result.error_message is not None
+
+
+class TestWaitForBastionReady:
+    """Test bastion provisioning polling."""
+
+    @patch("azlin.modules.bastion_provisioner.BastionDetector.get_bastion")
+    def test_wait_for_bastion_succeeded(self, mock_get_bastion):
+        """Wait should return when bastion reaches Succeeded state."""
+        # Mock bastion in Succeeded state
+        mock_get_bastion.return_value = {
+            "name": "my-bastion",
+            "provisioningState": "Succeeded",
+        }
+
+        state = BastionProvisioner.wait_for_bastion_ready(
+            "my-bastion", "my-rg", timeout=60, poll_interval=1
+        )
+
+        assert state == "Succeeded"
+
+    @patch("azlin.modules.bastion_provisioner.BastionDetector.get_bastion")
+    @patch("azlin.modules.bastion_provisioner.time.sleep")
+    def test_wait_for_bastion_eventually_succeeds(self, mock_sleep, mock_get_bastion):
+        """Wait should poll until bastion succeeds."""
+        # Mock progression: Creating -> Updating -> Succeeded
+        mock_get_bastion.side_effect = [
+            {"name": "my-bastion", "provisioningState": "Creating"},
+            {"name": "my-bastion", "provisioningState": "Updating"},
+            {"name": "my-bastion", "provisioningState": "Succeeded"},
+        ]
+
+        state = BastionProvisioner.wait_for_bastion_ready(
+            "my-bastion", "my-rg", timeout=300, poll_interval=1
+        )
+
+        assert state == "Succeeded"
+        assert mock_get_bastion.call_count == 3
+
+    @patch("azlin.modules.bastion_provisioner.BastionDetector.get_bastion")
+    def test_wait_for_bastion_failed(self, mock_get_bastion):
+        """Wait should raise error when bastion fails."""
+        mock_get_bastion.return_value = {
+            "name": "my-bastion",
+            "provisioningState": "Failed",
+        }
+
+        with pytest.raises(BastionProvisionerError, match="provisioning failed"):
+            BastionProvisioner.wait_for_bastion_ready("my-bastion", "my-rg")
+
+    @patch("azlin.modules.bastion_provisioner.BastionDetector.get_bastion")
+    def test_wait_for_bastion_not_found(self, mock_get_bastion):
+        """Wait should raise error if bastion not found."""
+        mock_get_bastion.return_value = None
+
+        with pytest.raises(BastionProvisionerError, match="not found"):
+            BastionProvisioner.wait_for_bastion_ready("my-bastion", "my-rg")
+
+
+class TestRollbackBastion:
+    """Test bastion rollback functionality."""
+
+    @patch("azlin.modules.bastion_provisioner.BastionProvisioner._delete_bastion")
+    @patch("azlin.modules.bastion_provisioner.BastionProvisioner._delete_public_ip")
+    @patch("azlin.modules.bastion_provisioner.BastionProvisioner._delete_vnet")
+    def test_rollback_deletes_in_reverse_order(
+        self, mock_delete_vnet, mock_delete_ip, mock_delete_bastion
+    ):
+        """Rollback should delete resources in reverse order."""
+        resources = [
+            "vnet:my-vnet",
+            "subnet:AzureBastionSubnet",
+            "public-ip:my-ip",
+            "bastion:my-bastion",
+        ]
+
+        BastionProvisioner.rollback_bastion(
+            "my-bastion", "my-rg", resources, delete_bastion=True
+        )
+
+        # Verify deletion order (bastion first, vnet last)
+        assert mock_delete_bastion.called
+        assert mock_delete_ip.called
+        assert mock_delete_vnet.called
+
+    @patch("azlin.modules.bastion_provisioner.BastionProvisioner._delete_bastion")
+    def test_rollback_skip_bastion_if_requested(self, mock_delete_bastion):
+        """Rollback should skip bastion deletion if delete_bastion=False."""
+        resources = ["bastion:my-bastion"]
+
+        BastionProvisioner.rollback_bastion(
+            "my-bastion", "my-rg", resources, delete_bastion=False
+        )
+
+        assert not mock_delete_bastion.called
+
+    @patch("azlin.modules.bastion_provisioner.BastionProvisioner._delete_public_ip")
+    def test_rollback_handles_deletion_failure(self, mock_delete_ip):
+        """Rollback should continue even if deletion fails."""
+        mock_delete_ip.side_effect = Exception("Deletion failed")
+
+        resources = ["public-ip:my-ip"]
+
+        status = BastionProvisioner.rollback_bastion("my-bastion", "my-rg", resources)
+
+        # Should record failure but not raise
+        assert "public-ip:my-ip" in status
+        assert status["public-ip:my-ip"] is False
+
+
+class TestHelperMethods:
+    """Test private helper methods."""
+
+    @patch("azlin.modules.bastion_provisioner.subprocess.run")
+    def test_check_vnet_exists_true(self, mock_run):
+        """Check VNet should return True when exists."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        exists = BastionProvisioner._check_vnet_exists("my-vnet", "my-rg")
+
+        assert exists is True
+
+    @patch("azlin.modules.bastion_provisioner.subprocess.run")
+    def test_check_vnet_exists_false(self, mock_run):
+        """Check VNet should return False when doesn't exist."""
+        mock_run.return_value = MagicMock(returncode=1)
+
+        exists = BastionProvisioner._check_vnet_exists("missing-vnet", "my-rg")
+
+        assert exists is False
+
+    @patch("azlin.modules.bastion_provisioner.subprocess.run")
+    def test_create_vnet_success(self, mock_run):
+        """Create VNet should call Azure CLI."""
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"name": "my-vnet"}')
+
+        # Should not raise
+        BastionProvisioner._create_vnet("my-vnet", "my-rg", "eastus", "10.0.0.0/16")
+
+        assert mock_run.called
+        call_args = str(mock_run.call_args)
+        assert "az" in call_args
+        assert "vnet" in call_args
+        assert "create" in call_args
+
+    @patch("azlin.modules.bastion_provisioner.subprocess.run")
+    def test_create_vnet_failure(self, mock_run):
+        """Create VNet failure should raise error."""
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, "az", stderr="QuotaExceeded"
+        )
+
+        with pytest.raises(BastionProvisionerError, match="Quota exceeded"):
+            BastionProvisioner._create_vnet("my-vnet", "my-rg", "eastus", "10.0.0.0/16")
+
+    @patch("azlin.modules.bastion_provisioner.subprocess.run")
+    def test_create_bastion_subnet_success(self, mock_run):
+        """Create bastion subnet should call Azure CLI."""
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"name": "AzureBastionSubnet"}')
+
+        # Should not raise
+        BastionProvisioner._create_bastion_subnet("my-vnet", "my-rg", "10.0.1.0/26")
+
+        assert mock_run.called
+        call_args = str(mock_run.call_args)
+        assert "subnet" in call_args
+        assert "AzureBastionSubnet" in call_args
+
+    @patch("azlin.modules.bastion_provisioner.subprocess.run")
+    def test_create_public_ip_success(self, mock_run):
+        """Create public IP should call Azure CLI."""
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"name": "my-ip"}')
+
+        # Should not raise
+        BastionProvisioner._create_public_ip("my-ip", "my-rg", "eastus")
+
+        assert mock_run.called
+        call_args = str(mock_run.call_args)
+        assert "public-ip" in call_args
+        assert "Standard" in call_args
+
+    @patch("azlin.modules.bastion_provisioner.subprocess.run")
+    def test_delete_bastion_success(self, mock_run):
+        """Delete bastion should call Azure CLI."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        # Should not raise
+        BastionProvisioner._delete_bastion("my-bastion", "my-rg")
+
+        assert mock_run.called
+        call_args = str(mock_run.call_args)
+        assert "bastion" in call_args
+        assert "delete" in call_args
+
+
+class TestConstants:
+    """Test module constants are properly defined."""
+
+    def test_bastion_subnet_name(self):
+        """BASTION_SUBNET_NAME should be defined."""
+        assert BastionProvisioner.BASTION_SUBNET_NAME == "AzureBastionSubnet"
+
+    def test_bastion_subnet_prefix_length(self):
+        """BASTION_SUBNET_PREFIX_LENGTH should be /26."""
+        assert BastionProvisioner.BASTION_SUBNET_PREFIX_LENGTH == 26
+
+    def test_default_vnet_prefix(self):
+        """DEFAULT_VNET_PREFIX should be defined."""
+        assert BastionProvisioner.DEFAULT_VNET_PREFIX == "10.0.0.0/16"
+
+    def test_default_bastion_subnet_prefix(self):
+        """DEFAULT_BASTION_SUBNET_PREFIX should be defined."""
+        assert BastionProvisioner.DEFAULT_BASTION_SUBNET_PREFIX == "10.0.1.0/26"
+
+    def test_timeouts_defined(self):
+        """Timeout constants should be defined."""
+        assert BastionProvisioner.DEFAULT_PROVISIONING_TIMEOUT == 900
+        assert BastionProvisioner.DEFAULT_COMMAND_TIMEOUT == 60

--- a/tests/unit/modules/test_cleanup_orchestrator.py
+++ b/tests/unit/modules/test_cleanup_orchestrator.py
@@ -1,0 +1,630 @@
+"""Unit tests for cleanup_orchestrator module.
+
+Tests orphan detection, cleanup decisions, and resource deletion.
+"""
+
+import json
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from azlin.modules.cleanup_orchestrator import (
+    BastionCleanupError,
+    BastionCleanupResult,
+    CleanupDecision,
+    CleanupOrchestrator,
+    CleanupOrchestratorError,
+    OrphanedBastionInfo,
+)
+from azlin.modules.interaction_handler import MockInteractionHandler
+from azlin.vm_manager import VMInfo
+
+
+class TestOrphanedBastionInfo:
+    """Test OrphanedBastionInfo dataclass."""
+
+    def test_calculate_cost_basic_sku(self):
+        """Basic SKU cost calculation."""
+        bastion = OrphanedBastionInfo(
+            name="my-bastion",
+            resource_group="my-rg",
+            location="eastus",
+            sku="Basic",
+        )
+
+        bastion.calculate_cost()
+
+        assert bastion.estimated_monthly_cost == Decimal("143.65")  # 140 + 3.65
+
+    def test_calculate_cost_standard_sku(self):
+        """Standard SKU cost calculation."""
+        bastion = OrphanedBastionInfo(
+            name="my-bastion",
+            resource_group="my-rg",
+            location="eastus",
+            sku="Standard",
+        )
+
+        bastion.calculate_cost()
+
+        assert bastion.estimated_monthly_cost == Decimal("292.65")  # 289 + 3.65
+
+    def test_calculate_cost_no_sku(self):
+        """No SKU should default to Basic cost."""
+        bastion = OrphanedBastionInfo(
+            name="my-bastion",
+            resource_group="my-rg",
+            location="eastus",
+        )
+
+        bastion.calculate_cost()
+
+        assert bastion.estimated_monthly_cost == Decimal("143.65")
+
+
+class TestCleanupDecision:
+    """Test CleanupDecision dataclass."""
+
+    def test_approved_decision(self):
+        """Approved cleanup decision."""
+        decision = CleanupDecision(
+            approved=True,
+            resources_to_delete=["bastion1", "bastion2"],
+            estimated_savings=Decimal("287.30"),
+        )
+
+        assert decision.approved is True
+        assert len(decision.resources_to_delete) == 2
+
+    def test_cancelled_decision(self):
+        """Cancelled cleanup decision."""
+        decision = CleanupDecision(cancelled=True)
+
+        assert decision.cancelled is True
+        assert decision.approved is False
+
+
+class TestBastionCleanupResult:
+    """Test BastionCleanupResult dataclass."""
+
+    def test_successful_cleanup(self):
+        """Successful cleanup result."""
+        result = BastionCleanupResult(
+            bastion_name="my-bastion",
+            resource_group="my-rg",
+            deleted_resources=["my-bastion", "my-bastion-pip"],
+            estimated_monthly_savings=Decimal("143.65"),
+        )
+
+        assert result.was_successful() is True
+        assert len(result.deleted_resources) == 2
+
+    def test_partial_cleanup(self):
+        """Partial cleanup with some failures."""
+        result = BastionCleanupResult(
+            bastion_name="my-bastion",
+            resource_group="my-rg",
+            deleted_resources=["my-bastion"],
+            failed_resources=["my-bastion-pip"],
+            estimated_monthly_savings=Decimal("143.65"),
+        )
+
+        assert result.was_successful() is False
+        assert len(result.failed_resources) == 1
+
+    def test_cleanup_with_errors(self):
+        """Cleanup with error messages."""
+        result = BastionCleanupResult(
+            bastion_name="my-bastion",
+            resource_group="my-rg",
+            errors=["Failed to delete public IP"],
+        )
+
+        assert result.was_successful() is False
+
+
+class TestDetectOrphanedBastions:
+    """Test orphaned Bastion detection."""
+
+    @patch("azlin.modules.cleanup_orchestrator.VMManager.list_vms")
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator._list_bastions")
+    def test_detect_orphaned_no_vms(self, mock_list_bastions, mock_list_vms):
+        """Bastion with no VMs should be detected as orphaned."""
+        # No VMs
+        mock_list_vms.return_value = []
+
+        # One Bastion
+        mock_list_bastions.return_value = [
+            {
+                "name": "orphaned-bastion",
+                "location": "eastus",
+                "provisioningState": "Succeeded",
+                "sku": {"name": "Basic"},
+            }
+        ]
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        orphaned = orchestrator.detect_orphaned_bastions()
+
+        assert len(orphaned) == 1
+        assert orphaned[0].name == "orphaned-bastion"
+        assert orphaned[0].vm_count == 0
+
+    @patch("azlin.modules.cleanup_orchestrator.VMManager.list_vms")
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator._list_bastions")
+    def test_detect_bastion_with_vms_not_orphaned(self, mock_list_bastions, mock_list_vms):
+        """Bastion with VMs should not be detected as orphaned."""
+        # VM without public IP (uses Bastion)
+        mock_list_vms.return_value = [
+            VMInfo(
+                name="vm1",
+                resource_group="my-rg",
+                location="eastus",
+                power_state="running",
+                vm_size="Standard_B2s",
+                public_ip=None,  # No public IP = uses Bastion
+                private_ip="10.0.0.4",
+            )
+        ]
+
+        # One Bastion in same region
+        mock_list_bastions.return_value = [
+            {
+                "name": "active-bastion",
+                "location": "eastus",
+                "provisioningState": "Succeeded",
+                "sku": {"name": "Basic"},
+            }
+        ]
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        orphaned = orchestrator.detect_orphaned_bastions()
+
+        assert len(orphaned) == 0
+
+    @patch("azlin.modules.cleanup_orchestrator.VMManager.list_vms")
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator._list_bastions")
+    def test_detect_bastion_different_region_orphaned(self, mock_list_bastions, mock_list_vms):
+        """Bastion in different region from VMs should be orphaned."""
+        # VM in eastus
+        mock_list_vms.return_value = [
+            VMInfo(
+                name="vm1",
+                resource_group="my-rg",
+                location="eastus",
+                power_state="running",
+                vm_size="Standard_B2s",
+                public_ip=None,
+                private_ip="10.0.0.4",
+            )
+        ]
+
+        # Bastion in westus (different region)
+        mock_list_bastions.return_value = [
+            {
+                "name": "westus-bastion",
+                "location": "westus",
+                "provisioningState": "Succeeded",
+                "sku": {"name": "Basic"},
+            }
+        ]
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        orphaned = orchestrator.detect_orphaned_bastions()
+
+        assert len(orphaned) == 1
+        assert orphaned[0].name == "westus-bastion"
+        assert orphaned[0].vm_count == 0
+
+    @patch("azlin.modules.cleanup_orchestrator.VMManager.list_vms")
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator._list_bastions")
+    def test_detect_skips_failed_bastions(self, mock_list_bastions, mock_list_vms):
+        """Failed Bastions should be skipped."""
+        mock_list_vms.return_value = []
+
+        # Bastion in Failed state
+        mock_list_bastions.return_value = [
+            {
+                "name": "failed-bastion",
+                "location": "eastus",
+                "provisioningState": "Failed",  # Not Succeeded
+                "sku": {"name": "Basic"},
+            }
+        ]
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        orphaned = orchestrator.detect_orphaned_bastions()
+
+        assert len(orphaned) == 0
+
+
+class TestCleanupBastion:
+    """Test individual Bastion cleanup."""
+
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator._delete_bastion")
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator._delete_public_ip")
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator._detect_bastion_public_ip")
+    def test_cleanup_bastion_success(self, mock_detect_ip, mock_delete_ip, mock_delete_bastion):
+        """Successful Bastion cleanup."""
+        mock_detect_ip.return_value = "my-bastion-pip"
+        mock_delete_bastion.return_value = True
+        mock_delete_ip.return_value = True
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        result = orchestrator.cleanup_bastion("my-bastion", "eastus")
+
+        assert result.was_successful() is True
+        assert "my-bastion" in result.deleted_resources
+        assert "my-bastion-pip" in result.deleted_resources
+        assert result.estimated_monthly_savings > 0
+
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator._delete_bastion")
+    def test_cleanup_bastion_deletion_fails(self, mock_delete_bastion):
+        """Failed Bastion deletion should be recorded."""
+        mock_delete_bastion.return_value = False
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        result = orchestrator.cleanup_bastion("my-bastion", "eastus")
+
+        assert result.was_successful() is False
+        assert "my-bastion" in result.failed_resources
+
+    def test_cleanup_bastion_dry_run(self):
+        """Dry run should not delete resources."""
+        orchestrator = CleanupOrchestrator("my-rg", dry_run=True)
+        result = orchestrator.cleanup_bastion("my-bastion", "eastus")
+
+        # Should mark as deleted but with [DRY RUN] prefix
+        assert len(result.deleted_resources) > 0
+        assert "[DRY RUN]" in str(result.deleted_resources)
+
+
+class TestCleanupOrphanedBastions:
+    """Test full orphaned Bastion cleanup workflow."""
+
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator.detect_orphaned_bastions")
+    def test_cleanup_no_orphaned_bastions(self, mock_detect):
+        """No orphaned Bastions should return empty results."""
+        mock_detect.return_value = []
+
+        handler = MockInteractionHandler()
+        orchestrator = CleanupOrchestrator("my-rg", interaction_handler=handler)
+
+        results = orchestrator.cleanup_orphaned_bastions()
+
+        assert len(results) == 0
+
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator.detect_orphaned_bastions")
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator.cleanup_bastion")
+    @patch("builtins.input")
+    def test_cleanup_user_confirms_deletion(
+        self, mock_input, mock_cleanup_bastion, mock_detect
+    ):
+        """User confirming should delete Bastions."""
+        # Mock orphaned Bastion
+        orphaned_bastion = OrphanedBastionInfo(
+            name="orphaned-bastion",
+            resource_group="my-rg",
+            location="eastus",
+            sku="Basic",
+        )
+        orphaned_bastion.calculate_cost()
+        mock_detect.return_value = [orphaned_bastion]
+
+        # User types "delete"
+        mock_input.return_value = "delete"
+
+        # Mock successful cleanup
+        mock_cleanup_bastion.return_value = BastionCleanupResult(
+            bastion_name="orphaned-bastion",
+            resource_group="my-rg",
+            deleted_resources=["orphaned-bastion", "orphaned-bastion-pip"],
+            estimated_monthly_savings=Decimal("143.65"),
+        )
+
+        handler = MockInteractionHandler()
+        orchestrator = CleanupOrchestrator("my-rg", interaction_handler=handler)
+
+        results = orchestrator.cleanup_orphaned_bastions()
+
+        assert len(results) == 1
+        assert mock_cleanup_bastion.called
+
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator.detect_orphaned_bastions")
+    @patch("builtins.input")
+    def test_cleanup_user_cancels(self, mock_input, mock_detect):
+        """User canceling should not delete anything."""
+        orphaned_bastion = OrphanedBastionInfo(
+            name="orphaned-bastion",
+            resource_group="my-rg",
+            location="eastus",
+        )
+        orphaned_bastion.calculate_cost()
+        mock_detect.return_value = [orphaned_bastion]
+
+        # User types "cancel"
+        mock_input.return_value = "cancel"
+
+        handler = MockInteractionHandler()
+        orchestrator = CleanupOrchestrator("my-rg", interaction_handler=handler)
+
+        results = orchestrator.cleanup_orphaned_bastions()
+
+        assert len(results) == 0
+
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator.detect_orphaned_bastions")
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator.cleanup_bastion")
+    def test_cleanup_force_skips_confirmation(self, mock_cleanup_bastion, mock_detect):
+        """Force flag should skip confirmation."""
+        orphaned_bastion = OrphanedBastionInfo(
+            name="orphaned-bastion",
+            resource_group="my-rg",
+            location="eastus",
+        )
+        orphaned_bastion.calculate_cost()
+        mock_detect.return_value = [orphaned_bastion]
+
+        mock_cleanup_bastion.return_value = BastionCleanupResult(
+            bastion_name="orphaned-bastion",
+            resource_group="my-rg",
+            deleted_resources=["orphaned-bastion"],
+            estimated_monthly_savings=Decimal("143.65"),
+        )
+
+        handler = MockInteractionHandler()
+        orchestrator = CleanupOrchestrator("my-rg", interaction_handler=handler)
+
+        results = orchestrator.cleanup_orphaned_bastions(force=True)
+
+        assert len(results) == 1
+        assert mock_cleanup_bastion.called
+
+
+class TestGetVMsUsingBastion:
+    """Test VM filtering by Bastion usage."""
+
+    @patch("azlin.modules.cleanup_orchestrator.VMManager.list_vms")
+    def test_get_vms_using_bastion_no_public_ip(self, mock_list_vms):
+        """VMs without public IP should be returned."""
+        mock_list_vms.return_value = [
+            VMInfo(
+                name="vm1",
+                resource_group="my-rg",
+                location="eastus",
+                power_state="running",
+                vm_size="Standard_B2s",
+                public_ip=None,  # No public IP
+                private_ip="10.0.0.4",
+            ),
+            VMInfo(
+                name="vm2",
+                resource_group="my-rg",
+                location="eastus",
+                power_state="running",
+                vm_size="Standard_B2s",
+                public_ip="20.1.2.3",  # Has public IP
+                private_ip="10.0.0.5",
+            ),
+        ]
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        bastion_vms = orchestrator.get_vms_using_bastion("eastus")
+
+        assert len(bastion_vms) == 1
+        assert bastion_vms[0].name == "vm1"
+
+    @patch("azlin.modules.cleanup_orchestrator.VMManager.list_vms")
+    def test_get_vms_filters_by_region(self, mock_list_vms):
+        """Should filter VMs by region."""
+        mock_list_vms.return_value = [
+            VMInfo(
+                name="vm-eastus",
+                resource_group="my-rg",
+                location="eastus",
+                power_state="running",
+                vm_size="Standard_B2s",
+                public_ip=None,
+                private_ip="10.0.0.4",
+            ),
+            VMInfo(
+                name="vm-westus",
+                resource_group="my-rg",
+                location="westus",
+                power_state="running",
+                vm_size="Standard_B2s",
+                public_ip=None,
+                private_ip="10.0.0.5",
+            ),
+        ]
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        eastus_vms = orchestrator.get_vms_using_bastion("eastus")
+
+        assert len(eastus_vms) == 1
+        assert eastus_vms[0].name == "vm-eastus"
+
+
+class TestHelperMethods:
+    """Test private helper methods."""
+
+    @patch("azlin.modules.cleanup_orchestrator.subprocess.run")
+    def test_list_bastions_success(self, mock_run):
+        """List Bastions should parse JSON output."""
+        bastions_json = json.dumps([
+            {"name": "bastion1", "location": "eastus"},
+            {"name": "bastion2", "location": "westus"},
+        ])
+        mock_run.return_value = MagicMock(returncode=0, stdout=bastions_json)
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        bastions = orchestrator._list_bastions()
+
+        assert len(bastions) == 2
+        assert bastions[0]["name"] == "bastion1"
+
+    @patch("azlin.modules.cleanup_orchestrator.subprocess.run")
+    def test_list_bastions_error(self, mock_run):
+        """List Bastions error should raise exception."""
+        mock_run.return_value = MagicMock(returncode=1, stderr="Error")
+
+        orchestrator = CleanupOrchestrator("my-rg")
+
+        with pytest.raises(BastionCleanupError):
+            orchestrator._list_bastions()
+
+    @patch("azlin.modules.cleanup_orchestrator.subprocess.run")
+    def test_delete_bastion_success(self, mock_run):
+        """Delete Bastion should return True on success."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        success = orchestrator._delete_bastion("my-bastion")
+
+        assert success is True
+
+    @patch("azlin.modules.cleanup_orchestrator.subprocess.run")
+    def test_delete_bastion_failure(self, mock_run):
+        """Delete Bastion should return False on failure."""
+        mock_run.return_value = MagicMock(returncode=1, stderr="Error")
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        success = orchestrator._delete_bastion("my-bastion")
+
+        assert success is False
+
+    @patch("azlin.modules.cleanup_orchestrator.subprocess.run")
+    def test_delete_public_ip_success(self, mock_run):
+        """Delete public IP should return True on success."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        success = orchestrator._delete_public_ip("my-ip")
+
+        assert success is True
+
+    @patch("azlin.modules.cleanup_orchestrator.subprocess.run")
+    def test_detect_bastion_public_ip_found(self, mock_run):
+        """Detect public IP should find common naming patterns."""
+        # First attempt succeeds
+        mock_run.return_value = MagicMock(returncode=0)
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        ip_name = orchestrator._detect_bastion_public_ip("my-bastion")
+
+        assert ip_name == "my-bastionPublicIP"
+
+    @patch("azlin.modules.cleanup_orchestrator.subprocess.run")
+    def test_detect_bastion_public_ip_not_found(self, mock_run):
+        """Detect public IP should return None if not found."""
+        # All attempts fail
+        mock_run.return_value = MagicMock(returncode=1)
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        ip_name = orchestrator._detect_bastion_public_ip("my-bastion")
+
+        assert ip_name is None
+
+
+class TestCleanupAllOrphanedResources:
+    """Test comprehensive cleanup of all resource types."""
+
+    @patch("azlin.modules.cleanup_orchestrator.CleanupOrchestrator.cleanup_orphaned_bastions")
+    @patch("azlin.modules.cleanup_orchestrator.ResourceCleanup.cleanup_resources")
+    def test_cleanup_all_resources(self, mock_resource_cleanup, mock_cleanup_bastions):
+        """Should cleanup both Bastions and other resources."""
+        # Mock Bastion cleanup
+        mock_cleanup_bastions.return_value = [
+            BastionCleanupResult(
+                bastion_name="bastion1",
+                resource_group="my-rg",
+                deleted_resources=["bastion1"],
+                estimated_monthly_savings=Decimal("143.65"),
+            )
+        ]
+
+        # Mock other resource cleanup
+        mock_resource_cleanup.return_value = MagicMock(
+            deleted_count=3,
+            failed_count=0,
+            estimated_monthly_savings=20.0,
+        )
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        results = orchestrator.cleanup_all_orphaned_resources()
+
+        assert results["total_deleted"] == 4  # 1 bastion + 3 other
+        assert results["total_savings"] > 0
+        assert mock_cleanup_bastions.called
+        assert mock_resource_cleanup.called
+
+
+class TestGroupVMsByRegion:
+    """Test VM grouping by region."""
+
+    def test_group_vms_by_region(self):
+        """VMs should be grouped by region."""
+        vms = [
+            VMInfo(
+                name="vm1",
+                resource_group="rg",
+                location="eastus",
+                power_state="running",
+                vm_size="Standard_B2s",
+                public_ip=None,
+                private_ip="10.0.0.4",
+            ),
+            VMInfo(
+                name="vm2",
+                resource_group="rg",
+                location="eastus",
+                power_state="running",
+                vm_size="Standard_B2s",
+                public_ip=None,
+                private_ip="10.0.0.5",
+            ),
+            VMInfo(
+                name="vm3",
+                resource_group="rg",
+                location="westus",
+                power_state="running",
+                vm_size="Standard_B2s",
+                public_ip=None,
+                private_ip="10.0.1.4",
+            ),
+        ]
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        grouped = orchestrator._group_vms_by_region(vms)
+
+        assert len(grouped["eastus"]) == 2
+        assert len(grouped["westus"]) == 1
+
+    def test_group_vms_filters_public_ip(self):
+        """VMs with public IP should be excluded."""
+        vms = [
+            VMInfo(
+                name="vm-no-ip",
+                resource_group="rg",
+                location="eastus",
+                power_state="running",
+                vm_size="Standard_B2s",
+                public_ip=None,
+                private_ip="10.0.0.4",
+            ),
+            VMInfo(
+                name="vm-with-ip",
+                resource_group="rg",
+                location="eastus",
+                power_state="running",
+                vm_size="Standard_B2s",
+                public_ip="20.1.2.3",
+                private_ip="10.0.0.5",
+            ),
+        ]
+
+        orchestrator = CleanupOrchestrator("my-rg")
+        grouped = orchestrator._group_vms_by_region(vms)
+
+        assert len(grouped["eastus"]) == 1
+        assert grouped["eastus"][0].name == "vm-no-ip"

--- a/tests/unit/modules/test_cost_estimator.py
+++ b/tests/unit/modules/test_cost_estimator.py
@@ -1,0 +1,242 @@
+"""Unit tests for cost_estimator module.
+
+Tests all pricing calculations, input validation, and edge cases.
+"""
+
+import pytest
+
+from azlin.modules.cost_estimator import CostEstimator
+
+
+class TestBastionCostEstimation:
+    """Test Azure Bastion cost estimation."""
+
+    def test_basic_sku_cost(self):
+        """Basic SKU should return correct cost including public IP."""
+        cost = CostEstimator.estimate_bastion_cost("Basic")
+        assert cost == 143.65  # 140.00 + 3.65
+
+    def test_standard_sku_cost(self):
+        """Standard SKU should return correct cost including public IP."""
+        cost = CostEstimator.estimate_bastion_cost("Standard")
+        assert cost == 292.65  # 289.00 + 3.65
+
+    def test_basic_sku_lowercase(self):
+        """SKU name should be case-insensitive."""
+        cost = CostEstimator.estimate_bastion_cost("basic")
+        assert cost == 143.65
+
+    def test_standard_sku_mixed_case(self):
+        """SKU name should handle mixed case."""
+        cost = CostEstimator.estimate_bastion_cost("StAnDaRd")
+        assert cost == 292.65
+
+    def test_basic_sku_with_whitespace(self):
+        """SKU name should handle whitespace."""
+        cost = CostEstimator.estimate_bastion_cost("  Basic  ")
+        assert cost == 143.65
+
+    def test_invalid_sku_raises_error(self):
+        """Invalid SKU should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid Bastion SKU"):
+            CostEstimator.estimate_bastion_cost("Premium")
+
+    def test_empty_sku_raises_error(self):
+        """Empty SKU should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid Bastion SKU"):
+            CostEstimator.estimate_bastion_cost("")
+
+    def test_none_sku_raises_error(self):
+        """None SKU should raise error."""
+        with pytest.raises(AttributeError):
+            CostEstimator.estimate_bastion_cost(None)  # type: ignore
+
+
+class TestPrivateEndpointCostEstimation:
+    """Test private endpoint cost estimation."""
+
+    def test_default_data_transfer(self):
+        """Default 100GB data transfer should return correct cost."""
+        cost = CostEstimator.estimate_private_endpoint_cost()
+        assert cost == 8.30  # 7.30 + (100 * 0.01)
+
+    def test_zero_data_transfer(self):
+        """Zero data transfer should return base cost only."""
+        cost = CostEstimator.estimate_private_endpoint_cost(0)
+        assert cost == 7.30
+
+    def test_small_data_transfer(self):
+        """Small data transfer should calculate correctly."""
+        cost = CostEstimator.estimate_private_endpoint_cost(10)
+        assert cost == pytest.approx(7.40)  # 7.30 + (10 * 0.01)
+
+    def test_large_data_transfer(self):
+        """Large data transfer (1TB) should calculate correctly."""
+        cost = CostEstimator.estimate_private_endpoint_cost(1024)
+        assert cost == 17.54  # 7.30 + (1024 * 0.01)
+
+    def test_float_data_transfer(self):
+        """Fractional GB should be handled correctly."""
+        cost = CostEstimator.estimate_private_endpoint_cost(50.5)
+        assert cost == 7.805  # 7.30 + (50.5 * 0.01)
+
+    def test_negative_data_transfer_raises_error(self):
+        """Negative data transfer should raise ValueError."""
+        with pytest.raises(ValueError, match="non-negative"):
+            CostEstimator.estimate_private_endpoint_cost(-100)
+
+    def test_negative_fractional_raises_error(self):
+        """Negative fractional value should raise ValueError."""
+        with pytest.raises(ValueError, match="non-negative"):
+            CostEstimator.estimate_private_endpoint_cost(-0.1)
+
+
+class TestNFSCostEstimation:
+    """Test NFS storage cost estimation."""
+
+    def test_premium_100gb(self):
+        """100GB Premium NFS should calculate correctly."""
+        cost = CostEstimator.estimate_nfs_cost(100, "Premium")
+        assert cost == 20.00  # 100 * 0.20
+
+    def test_premium_500gb(self):
+        """500GB Premium NFS should calculate correctly."""
+        cost = CostEstimator.estimate_nfs_cost(500, "Premium")
+        assert cost == 100.00  # 500 * 0.20
+
+    def test_standard_100gb(self):
+        """100GB Standard NFS should calculate correctly."""
+        cost = CostEstimator.estimate_nfs_cost(100, "Standard")
+        assert cost == 6.00  # 100 * 0.06
+
+    def test_standard_500gb(self):
+        """500GB Standard NFS should calculate correctly."""
+        cost = CostEstimator.estimate_nfs_cost(500, "Standard")
+        assert cost == 30.00  # 500 * 0.06
+
+    def test_premium_1tb(self):
+        """1TB Premium NFS should calculate correctly."""
+        cost = CostEstimator.estimate_nfs_cost(1024, "Premium")
+        assert cost == 204.80  # 1024 * 0.20
+
+    def test_tier_case_insensitive(self):
+        """Tier should be case-insensitive."""
+        cost1 = CostEstimator.estimate_nfs_cost(100, "premium")
+        cost2 = CostEstimator.estimate_nfs_cost(100, "PREMIUM")
+        assert cost1 == cost2 == 20.00
+
+    def test_tier_with_whitespace(self):
+        """Tier should handle whitespace."""
+        cost = CostEstimator.estimate_nfs_cost(100, "  Premium  ")
+        assert cost == 20.00
+
+    def test_zero_size_raises_error(self):
+        """Zero size should raise ValueError."""
+        with pytest.raises(ValueError, match="positive"):
+            CostEstimator.estimate_nfs_cost(0, "Premium")
+
+    def test_negative_size_raises_error(self):
+        """Negative size should raise ValueError."""
+        with pytest.raises(ValueError, match="positive"):
+            CostEstimator.estimate_nfs_cost(-100, "Premium")
+
+    def test_invalid_tier_raises_error(self):
+        """Invalid tier should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid tier"):
+            CostEstimator.estimate_nfs_cost(100, "Basic")
+
+    def test_empty_tier_raises_error(self):
+        """Empty tier should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid tier"):
+            CostEstimator.estimate_nfs_cost(100, "")
+
+
+class TestCostFormatting:
+    """Test cost formatting for display."""
+
+    def test_format_basic_cost(self):
+        """Basic cost should format with 2 decimals."""
+        formatted = CostEstimator.format_cost(143.65)
+        assert formatted == "$143.65/month"
+
+    def test_format_zero_cost(self):
+        """Zero cost should format correctly."""
+        formatted = CostEstimator.format_cost(0)
+        assert formatted == "$0.00/month"
+
+    def test_format_large_cost(self):
+        """Large cost should format correctly."""
+        formatted = CostEstimator.format_cost(1234.5)
+        assert formatted == "$1234.50/month"
+
+    def test_format_rounds_correctly(self):
+        """Cost should round to 2 decimals."""
+        formatted = CostEstimator.format_cost(123.456789)
+        assert formatted == "$123.46/month"
+
+    def test_format_fractional_cent(self):
+        """Fractional cents should round correctly."""
+        formatted = CostEstimator.format_cost(10.005)
+        assert formatted == "$10.01/month"  # Banker's rounding
+
+    def test_format_negative_cost(self):
+        """Negative cost should format with minus sign."""
+        formatted = CostEstimator.format_cost(-50.00)
+        assert formatted == "$-50.00/month"
+
+
+class TestCostConstants:
+    """Test that cost constants are correctly defined."""
+
+    def test_bastion_basic_constant(self):
+        """BASTION_BASIC constant should be defined."""
+        assert CostEstimator.BASTION_BASIC == 140.00
+
+    def test_bastion_standard_constant(self):
+        """BASTION_STANDARD constant should be defined."""
+        assert CostEstimator.BASTION_STANDARD == 289.00
+
+    def test_public_ip_static_constant(self):
+        """PUBLIC_IP_STATIC constant should be defined."""
+        assert CostEstimator.PUBLIC_IP_STATIC == 3.65
+
+    def test_private_endpoint_constant(self):
+        """PRIVATE_ENDPOINT constant should be defined."""
+        assert CostEstimator.PRIVATE_ENDPOINT == 7.30
+
+    def test_vnet_peering_gb_constant(self):
+        """VNET_PEERING_GB constant should be defined."""
+        assert CostEstimator.VNET_PEERING_GB == 0.01
+
+    def test_nfs_premium_gb_constant(self):
+        """NFS_PREMIUM_GB constant should be defined."""
+        assert CostEstimator.NFS_PREMIUM_GB == 0.20
+
+    def test_nfs_standard_gb_constant(self):
+        """NFS_STANDARD_GB constant should be defined."""
+        assert CostEstimator.NFS_STANDARD_GB == 0.06
+
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    def test_very_small_data_transfer(self):
+        """Very small data transfer should work."""
+        cost = CostEstimator.estimate_private_endpoint_cost(0.001)
+        assert cost == pytest.approx(7.30001)
+
+    def test_very_large_storage(self):
+        """Very large storage (100TB) should calculate correctly."""
+        cost = CostEstimator.estimate_nfs_cost(102400, "Premium")  # 100TB
+        assert cost == 20480.00
+
+    def test_minimum_valid_storage(self):
+        """Minimum valid storage (1GB) should work."""
+        cost = CostEstimator.estimate_nfs_cost(1, "Premium")
+        assert cost == 0.20
+
+    def test_bastion_cost_breakdown(self):
+        """Verify Bastion cost includes host + IP."""
+        basic_cost = CostEstimator.estimate_bastion_cost("Basic")
+        expected = CostEstimator.BASTION_BASIC + CostEstimator.PUBLIC_IP_STATIC
+        assert basic_cost == expected

--- a/tests/unit/modules/test_interaction_handler.py
+++ b/tests/unit/modules/test_interaction_handler.py
@@ -1,0 +1,366 @@
+"""Unit tests for interaction_handler module.
+
+Tests CLI and Mock handlers for user interaction abstraction.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from azlin.modules.interaction_handler import (
+    CLIInteractionHandler,
+    MockInteractionHandler,
+)
+
+
+class TestCLIInteractionHandler:
+    """Test CLI interaction handler."""
+
+    def test_instantiation(self):
+        """CLI handler should instantiate without errors."""
+        handler = CLIInteractionHandler()
+        assert handler is not None
+
+    @patch("azlin.modules.interaction_handler.click.prompt")
+    @patch("azlin.modules.interaction_handler.click.echo")
+    @patch("azlin.modules.interaction_handler.click.secho")
+    def test_prompt_choice_valid_selection(self, mock_secho, mock_echo, mock_prompt):
+        """Valid choice selection should return correct index."""
+        mock_prompt.return_value = "2"
+
+        handler = CLIInteractionHandler()
+        choices = [
+            ("small", "Small instance", 10.0),
+            ("medium", "Medium instance", 20.0),
+            ("large", "Large instance", 30.0),
+        ]
+
+        result = handler.prompt_choice("Select size:", choices)
+
+        assert result == 1  # Zero-indexed
+        assert mock_echo.called
+        assert mock_secho.called
+
+    @patch("azlin.modules.interaction_handler.click.prompt")
+    @patch("azlin.modules.interaction_handler.click.echo")
+    @patch("azlin.modules.interaction_handler.click.secho")
+    def test_prompt_choice_first_option(self, mock_secho, mock_echo, mock_prompt):
+        """Selecting first option should return index 0."""
+        mock_prompt.return_value = "1"
+
+        handler = CLIInteractionHandler()
+        choices = [("a", "Option A", 5.0), ("b", "Option B", 10.0)]
+
+        result = handler.prompt_choice("Choose:", choices)
+
+        assert result == 0
+
+    @patch("azlin.modules.interaction_handler.click.prompt")
+    @patch("azlin.modules.interaction_handler.click.echo")
+    @patch("azlin.modules.interaction_handler.click.secho")
+    def test_prompt_choice_last_option(self, mock_secho, mock_echo, mock_prompt):
+        """Selecting last option should return correct index."""
+        mock_prompt.return_value = "3"
+
+        handler = CLIInteractionHandler()
+        choices = [("a", "A", 0.0), ("b", "B", 0.0), ("c", "C", 0.0)]
+
+        result = handler.prompt_choice("Choose:", choices)
+
+        assert result == 2
+
+    def test_prompt_choice_empty_choices_raises_error(self):
+        """Empty choices should raise ValueError."""
+        handler = CLIInteractionHandler()
+
+        with pytest.raises(ValueError, match="choices cannot be empty"):
+            handler.prompt_choice("Choose:", [])
+
+    @patch("azlin.modules.interaction_handler.click.confirm")
+    def test_confirm_default_true(self, mock_confirm):
+        """Confirm with default True should work."""
+        mock_confirm.return_value = True
+
+        handler = CLIInteractionHandler()
+        result = handler.confirm("Continue?", default=True)
+
+        assert result is True
+        assert mock_confirm.called
+
+    @patch("azlin.modules.interaction_handler.click.confirm")
+    def test_confirm_default_false(self, mock_confirm):
+        """Confirm with default False should work."""
+        mock_confirm.return_value = False
+
+        handler = CLIInteractionHandler()
+        result = handler.confirm("Delete?", default=False)
+
+        assert result is False
+
+    @patch("azlin.modules.interaction_handler.click.secho")
+    def test_show_warning(self, mock_secho):
+        """Show warning should call click.secho with yellow."""
+        handler = CLIInteractionHandler()
+        handler.show_warning("This is a warning")
+
+        mock_secho.assert_called_once()
+        call_args = mock_secho.call_args
+        assert "Warning: This is a warning" in str(call_args)
+        assert call_args[1]["fg"] == "yellow"
+        assert call_args[1]["err"] is True
+
+    @patch("azlin.modules.interaction_handler.click.secho")
+    def test_show_info(self, mock_secho):
+        """Show info should call click.secho with green."""
+        handler = CLIInteractionHandler()
+        handler.show_info("This is info")
+
+        mock_secho.assert_called_once()
+        call_args = mock_secho.call_args
+        assert "This is info" in str(call_args)
+        assert call_args[1]["fg"] == "green"
+
+
+class TestMockInteractionHandler:
+    """Test mock interaction handler for testing."""
+
+    def test_instantiation_empty(self):
+        """Mock handler should instantiate with empty responses."""
+        handler = MockInteractionHandler()
+        assert handler is not None
+        assert handler.choice_responses == []
+        assert handler.confirm_responses == []
+        assert handler.interactions == []
+
+    def test_instantiation_with_responses(self):
+        """Mock handler should store provided responses."""
+        handler = MockInteractionHandler(
+            choice_responses=[0, 1, 2],
+            confirm_responses=[True, False],
+        )
+        assert handler.choice_responses == [0, 1, 2]
+        assert handler.confirm_responses == [True, False]
+
+    def test_prompt_choice_returns_programmed_response(self):
+        """Prompt choice should return pre-programmed response."""
+        handler = MockInteractionHandler(choice_responses=[1])
+
+        choices = [("a", "Option A", 0.0), ("b", "Option B", 10.0)]
+        result = handler.prompt_choice("Choose:", choices)
+
+        assert result == 1
+
+    def test_prompt_choice_tracks_interaction(self):
+        """Prompt choice should track the interaction."""
+        handler = MockInteractionHandler(choice_responses=[0])
+
+        choices = [("a", "Option A", 5.0)]
+        handler.prompt_choice("Select:", choices)
+
+        assert len(handler.interactions) == 1
+        assert handler.interactions[0]["type"] == "choice"
+        assert handler.interactions[0]["message"] == "Select:"
+        assert handler.interactions[0]["response"] == 0
+
+    def test_prompt_choice_multiple_calls(self):
+        """Multiple prompt_choice calls should use sequential responses."""
+        handler = MockInteractionHandler(choice_responses=[0, 2, 1])
+
+        choices = [("a", "A", 0.0), ("b", "B", 0.0), ("c", "C", 0.0)]
+
+        assert handler.prompt_choice("Q1", choices) == 0
+        assert handler.prompt_choice("Q2", choices) == 2
+        assert handler.prompt_choice("Q3", choices) == 1
+
+    def test_prompt_choice_no_responses_raises_error(self):
+        """Prompt choice with no responses should raise IndexError."""
+        handler = MockInteractionHandler()
+
+        choices = [("a", "A", 0.0)]
+
+        with pytest.raises(IndexError, match="No more choice responses"):
+            handler.prompt_choice("Choose:", choices)
+
+    def test_prompt_choice_exhausted_responses_raises_error(self):
+        """Exhausted responses should raise IndexError."""
+        handler = MockInteractionHandler(choice_responses=[0])
+
+        choices = [("a", "A", 0.0)]
+
+        handler.prompt_choice("Q1", choices)  # Uses the only response
+
+        with pytest.raises(IndexError, match="No more choice responses"):
+            handler.prompt_choice("Q2", choices)
+
+    def test_prompt_choice_invalid_response_raises_error(self):
+        """Invalid pre-programmed response should raise ValueError."""
+        handler = MockInteractionHandler(choice_responses=[5])
+
+        choices = [("a", "A", 0.0), ("b", "B", 0.0)]  # Only 2 choices
+
+        with pytest.raises(ValueError, match="Invalid pre-programmed response"):
+            handler.prompt_choice("Choose:", choices)
+
+    def test_prompt_choice_empty_choices_raises_error(self):
+        """Empty choices should raise ValueError."""
+        handler = MockInteractionHandler(choice_responses=[0])
+
+        with pytest.raises(ValueError, match="choices cannot be empty"):
+            handler.prompt_choice("Choose:", [])
+
+    def test_confirm_returns_programmed_response(self):
+        """Confirm should return pre-programmed response."""
+        handler = MockInteractionHandler(confirm_responses=[True])
+
+        result = handler.confirm("Continue?")
+
+        assert result is True
+
+    def test_confirm_tracks_interaction(self):
+        """Confirm should track the interaction."""
+        handler = MockInteractionHandler(confirm_responses=[False])
+
+        handler.confirm("Delete?", default=True)
+
+        assert len(handler.interactions) == 1
+        assert handler.interactions[0]["type"] == "confirm"
+        assert handler.interactions[0]["message"] == "Delete?"
+        assert handler.interactions[0]["default"] is True
+        assert handler.interactions[0]["response"] is False
+
+    def test_confirm_multiple_calls(self):
+        """Multiple confirm calls should use sequential responses."""
+        handler = MockInteractionHandler(confirm_responses=[True, False, True])
+
+        assert handler.confirm("Q1") is True
+        assert handler.confirm("Q2") is False
+        assert handler.confirm("Q3") is True
+
+    def test_confirm_no_responses_raises_error(self):
+        """Confirm with no responses should raise IndexError."""
+        handler = MockInteractionHandler()
+
+        with pytest.raises(IndexError, match="No more confirm responses"):
+            handler.confirm("Continue?")
+
+    def test_show_warning_tracks_interaction(self):
+        """Show warning should track the message."""
+        handler = MockInteractionHandler()
+
+        handler.show_warning("Warning message")
+
+        assert len(handler.interactions) == 1
+        assert handler.interactions[0]["type"] == "warning"
+        assert handler.interactions[0]["message"] == "Warning message"
+
+    def test_show_info_tracks_interaction(self):
+        """Show info should track the message."""
+        handler = MockInteractionHandler()
+
+        handler.show_info("Info message")
+
+        assert len(handler.interactions) == 1
+        assert handler.interactions[0]["type"] == "info"
+        assert handler.interactions[0]["message"] == "Info message"
+
+    def test_reset_clears_interactions(self):
+        """Reset should clear interaction history."""
+        handler = MockInteractionHandler(choice_responses=[0, 1])
+
+        choices = [("a", "A", 0.0), ("b", "B", 0.0)]
+        handler.prompt_choice("Q1", choices)
+
+        assert len(handler.interactions) == 1
+
+        handler.reset()
+
+        assert len(handler.interactions) == 0
+
+    def test_reset_resets_response_indices(self):
+        """Reset should reset response indices to 0."""
+        handler = MockInteractionHandler(choice_responses=[0, 1])
+
+        choices = [("a", "A", 0.0), ("b", "B", 0.0)]
+        handler.prompt_choice("Q1", choices)  # Uses index 0
+
+        handler.reset()
+
+        result = handler.prompt_choice("Q2", choices)  # Should use index 0 again
+        assert result == 0
+
+    def test_get_interactions_by_type_choice(self):
+        """Get interactions by type should filter correctly."""
+        handler = MockInteractionHandler(choice_responses=[0], confirm_responses=[True])
+
+        choices = [("a", "A", 0.0)]
+        handler.prompt_choice("Q1", choices)
+        handler.confirm("Confirm?")
+        handler.show_info("Info")
+
+        choice_interactions = handler.get_interactions_by_type("choice")
+
+        assert len(choice_interactions) == 1
+        assert choice_interactions[0]["type"] == "choice"
+
+    def test_get_interactions_by_type_confirm(self):
+        """Get confirm interactions should work."""
+        handler = MockInteractionHandler(confirm_responses=[True, False])
+
+        handler.confirm("Q1")
+        handler.confirm("Q2")
+        handler.show_warning("Warning")
+
+        confirm_interactions = handler.get_interactions_by_type("confirm")
+
+        assert len(confirm_interactions) == 2
+        assert all(i["type"] == "confirm" for i in confirm_interactions)
+
+    def test_get_interactions_by_type_warning(self):
+        """Get warning interactions should work."""
+        handler = MockInteractionHandler()
+
+        handler.show_warning("Warn 1")
+        handler.show_info("Info")
+        handler.show_warning("Warn 2")
+
+        warning_interactions = handler.get_interactions_by_type("warning")
+
+        assert len(warning_interactions) == 2
+        assert all(i["type"] == "warning" for i in warning_interactions)
+
+    def test_get_interactions_by_type_info(self):
+        """Get info interactions should work."""
+        handler = MockInteractionHandler()
+
+        handler.show_info("Info 1")
+        handler.show_warning("Warn")
+        handler.show_info("Info 2")
+        handler.show_info("Info 3")
+
+        info_interactions = handler.get_interactions_by_type("info")
+
+        assert len(info_interactions) == 3
+        assert all(i["type"] == "info" for i in info_interactions)
+
+    def test_complex_interaction_flow(self):
+        """Test complex interaction flow with multiple types."""
+        handler = MockInteractionHandler(
+            choice_responses=[0, 1],
+            confirm_responses=[True, False],
+        )
+
+        choices = [("a", "A", 0.0), ("b", "B", 0.0)]
+
+        handler.show_info("Starting")
+        handler.prompt_choice("Choose 1", choices)
+        handler.show_warning("Warning")
+        handler.confirm("Confirm 1")
+        handler.prompt_choice("Choose 2", choices)
+        handler.confirm("Confirm 2")
+        handler.show_info("Done")
+
+        assert len(handler.interactions) == 7
+        assert len(handler.get_interactions_by_type("choice")) == 2
+        assert len(handler.get_interactions_by_type("confirm")) == 2
+        assert len(handler.get_interactions_by_type("info")) == 2
+        assert len(handler.get_interactions_by_type("warning")) == 1

--- a/tests/unit/modules/test_nfs_provisioner.py
+++ b/tests/unit/modules/test_nfs_provisioner.py
@@ -1,0 +1,578 @@
+"""Unit tests for nfs_provisioner module.
+
+Tests cross-region NFS access, private endpoints, and data replication.
+"""
+
+import subprocess
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from azlin.modules.nfs_provisioner import (
+    AccessAnalysis,
+    AccessStrategy,
+    NFSProvisioner,
+    NFSProvisionerError,
+    NetworkConfigurationError,
+    PrivateDNSZoneInfo,
+    PrivateEndpointInfo,
+    ReplicationResult,
+    ValidationError,
+    VNetPeeringInfo,
+    _validate_resource_id,
+    _validate_resource_name,
+)
+
+
+class TestResourceNameValidation:
+    """Test resource name validation for security."""
+
+    def test_valid_resource_name(self):
+        """Valid resource names should pass."""
+        assert _validate_resource_name("my-resource", "test") == "my-resource"
+        assert _validate_resource_name("resource_123", "test") == "resource_123"
+        assert _validate_resource_name("Resource-ABC", "test") == "Resource-ABC"
+
+    def test_empty_resource_name_raises_error(self):
+        """Empty resource name should raise error."""
+        with pytest.raises(ValidationError, match="non-empty string"):
+            _validate_resource_name("", "test")
+
+    def test_none_resource_name_raises_error(self):
+        """None resource name should raise error."""
+        with pytest.raises(ValidationError, match="non-empty string"):
+            _validate_resource_name(None, "test")  # type: ignore
+
+    def test_command_injection_semicolon_raises_error(self):
+        """Semicolon should be rejected (command injection)."""
+        with pytest.raises(ValidationError, match="unsafe character"):
+            _validate_resource_name("resource;rm -rf", "test")
+
+    def test_command_injection_ampersand_raises_error(self):
+        """Ampersand should be rejected (command injection)."""
+        with pytest.raises(ValidationError, match="unsafe character"):
+            _validate_resource_name("resource&&whoami", "test")
+
+    def test_command_injection_pipe_raises_error(self):
+        """Pipe should be rejected (command injection)."""
+        with pytest.raises(ValidationError, match="unsafe character"):
+            _validate_resource_name("resource|cat", "test")
+
+    def test_path_traversal_raises_error(self):
+        """Path traversal should be rejected."""
+        with pytest.raises(ValidationError, match="path traversal"):
+            _validate_resource_name("../etc/passwd", "test")
+
+    def test_forward_slash_raises_error(self):
+        """Forward slash should be rejected."""
+        with pytest.raises(ValidationError, match="path traversal"):
+            _validate_resource_name("path/to/resource", "test")
+
+
+class TestResourceIDValidation:
+    """Test Azure resource ID validation."""
+
+    def test_valid_resource_id(self):
+        """Valid Azure resource ID should pass."""
+        resource_id = "/subscriptions/sub-123/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet"
+        assert _validate_resource_id(resource_id) == resource_id
+
+    def test_empty_resource_id_raises_error(self):
+        """Empty resource ID should raise error."""
+        with pytest.raises(ValidationError, match="non-empty string"):
+            _validate_resource_id("")
+
+    def test_invalid_format_raises_error(self):
+        """Invalid format should raise error."""
+        with pytest.raises(ValidationError, match="Invalid Azure resource ID"):
+            _validate_resource_id("not-a-resource-id")
+
+    def test_command_injection_in_resource_id_raises_error(self):
+        """Command injection in resource ID should be rejected."""
+        with pytest.raises(ValidationError, match="unsafe character"):
+            _validate_resource_id("/subscriptions/sub;whoami/resourceGroups/rg")
+
+
+class TestAccessStrategy:
+    """Test AccessStrategy enumeration."""
+
+    def test_strategy_values(self):
+        """Access strategy values should be defined."""
+        assert AccessStrategy.DIRECT.value == "direct"
+        assert AccessStrategy.PRIVATE_ENDPOINT.value == "private_endpoint"
+        assert AccessStrategy.NEW_STORAGE.value == "new_storage"
+        assert AccessStrategy.REPLICATE.value == "replicate"
+
+
+class TestAnalyzeNFSAccess:
+    """Test NFS access strategy analysis."""
+
+    @patch("azlin.modules.storage_manager.StorageManager.get_storage")
+    def test_same_region_recommends_direct(self, mock_get_storage):
+        """Same region should recommend direct access."""
+        mock_get_storage.return_value = MagicMock(
+            name="myaccount",
+            size_gb=100,
+            tier="Premium",
+        )
+
+        analysis = NFSProvisioner.analyze_nfs_access(
+            storage_account="myaccount",
+            source_region="eastus",
+            target_region="eastus",
+            resource_group="my-rg",
+        )
+
+        assert analysis.same_region is True
+        assert analysis.recommended_strategy == AccessStrategy.DIRECT
+        assert analysis.estimated_cost_monthly == 0.0
+
+    @patch("azlin.modules.storage_manager.StorageManager.get_storage")
+    def test_cross_region_evaluates_strategies(self, mock_get_storage):
+        """Cross-region should evaluate multiple strategies."""
+        mock_get_storage.return_value = MagicMock(
+            name="myaccount",
+            size_gb=100,
+            tier="Premium",
+        )
+
+        analysis = NFSProvisioner.analyze_nfs_access(
+            storage_account="myaccount",
+            source_region="eastus",
+            target_region="westus",
+            resource_group="my-rg",
+        )
+
+        assert analysis.same_region is False
+        # Should have multiple strategies
+        assert AccessStrategy.PRIVATE_ENDPOINT in analysis.strategies
+        assert AccessStrategy.NEW_STORAGE in analysis.strategies
+        assert AccessStrategy.REPLICATE in analysis.strategies
+
+    @patch("azlin.modules.storage_manager.StorageManager.get_storage")
+    def test_strategy_includes_costs(self, mock_get_storage):
+        """Strategy analysis should include cost estimates."""
+        mock_get_storage.return_value = MagicMock(
+            name="myaccount",
+            size_gb=100,
+            tier="Premium",
+        )
+
+        analysis = NFSProvisioner.analyze_nfs_access(
+            storage_account="myaccount",
+            source_region="eastus",
+            target_region="westus",
+            resource_group="my-rg",
+        )
+
+        # Private endpoint strategy should have cost
+        pe_strategy = analysis.strategies[AccessStrategy.PRIVATE_ENDPOINT]
+        assert "cost_monthly" in pe_strategy
+        assert pe_strategy["cost_monthly"] > 0
+
+    @patch("azlin.modules.storage_manager.StorageManager.get_storage")
+    def test_invalid_storage_account_raises_error(self, mock_get_storage):
+        """Invalid storage account should raise error."""
+        mock_get_storage.side_effect = Exception("Not found")
+
+        with pytest.raises(NFSProvisionerError):
+            NFSProvisioner.analyze_nfs_access(
+                storage_account="missing-account",
+                source_region="eastus",
+                target_region="westus",
+                resource_group="my-rg",
+            )
+
+
+class TestCreatePrivateEndpoint:
+    """Test private endpoint creation."""
+
+    @patch("azlin.modules.nfs_provisioner.subprocess.run")
+    def test_create_private_endpoint_success(self, mock_run):
+        """Private endpoint creation should succeed."""
+        # Mock storage account ID query
+        storage_id = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/myaccount"
+        subnet_id = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+
+        # Mock subprocess calls
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=storage_id),  # storage ID query
+            MagicMock(returncode=0, stdout=subnet_id),  # subnet ID query
+            MagicMock(  # private endpoint create
+                returncode=0,
+                stdout='{"name": "my-pe", "provisioningState": "Succeeded", "customDnsConfigs": [{"ipAddresses": ["10.0.0.4"]}]}',
+            ),
+        ]
+
+        endpoint = NFSProvisioner.create_private_endpoint(
+            name="my-pe",
+            resource_group="my-rg",
+            region="eastus",
+            vnet_name="my-vnet",
+            subnet_name="my-subnet",
+            storage_account="myaccount",
+            storage_resource_group="storage-rg",
+        )
+
+        assert endpoint.name == "my-pe"
+        assert endpoint.private_ip == "10.0.0.4"
+        assert endpoint.connection_state == "Succeeded"
+        assert mock_run.call_count == 3
+
+    @patch("azlin.modules.nfs_provisioner.subprocess.run")
+    def test_create_private_endpoint_validation_error(self, mock_run):
+        """Invalid inputs should raise validation error."""
+        with pytest.raises(ValidationError):
+            NFSProvisioner.create_private_endpoint(
+                name="pe;whoami",  # Invalid character
+                resource_group="my-rg",
+                region="eastus",
+                vnet_name="vnet",
+                subnet_name="subnet",
+                storage_account="storage",
+                storage_resource_group="rg",
+            )
+
+    @patch("azlin.modules.nfs_provisioner.subprocess.run")
+    def test_create_private_endpoint_command_failure(self, mock_run):
+        """Command failure should raise NetworkConfigurationError."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "az", stderr="Error")
+
+        with pytest.raises(NetworkConfigurationError):
+            NFSProvisioner.create_private_endpoint(
+                name="my-pe",
+                resource_group="my-rg",
+                region="eastus",
+                vnet_name="vnet",
+                subnet_name="subnet",
+                storage_account="storage",
+                storage_resource_group="rg",
+            )
+
+
+class TestCreateVNetPeering:
+    """Test VNet peering creation."""
+
+    @patch("azlin.modules.nfs_provisioner.subprocess.run")
+    def test_create_vnet_peering_success(self, mock_run):
+        """VNet peering should create bidirectional connection."""
+        remote_vnet_id = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/remote-vnet"
+        local_vnet_id = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/local-vnet"
+
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=remote_vnet_id),  # remote vnet ID
+            MagicMock(  # local peering create
+                returncode=0,
+                stdout='{"name": "peer1", "peeringState": "Connected"}',
+            ),
+            MagicMock(returncode=0, stdout=local_vnet_id),  # local vnet ID
+            MagicMock(returncode=0),  # remote peering create
+        ]
+
+        peering = NFSProvisioner.create_vnet_peering(
+            name="my-peering",
+            resource_group="local-rg",
+            local_vnet="local-vnet",
+            remote_vnet="remote-vnet",
+            remote_vnet_resource_group="remote-rg",
+        )
+
+        assert peering.name == "my-peering"
+        assert peering.peering_state == "Connected"
+        assert peering.local_vnet == "local-vnet"
+        assert peering.remote_vnet == "remote-vnet"
+        # Should create both directions
+        assert mock_run.call_count == 4
+
+    @patch("azlin.modules.nfs_provisioner.subprocess.run")
+    def test_create_vnet_peering_with_forwarded_traffic(self, mock_run):
+        """Peering with forwarded traffic should set flag."""
+        remote_vnet_id = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/remote-vnet"
+        local_vnet_id = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/local-vnet"
+
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=remote_vnet_id),
+            MagicMock(returncode=0, stdout='{"name": "peer", "peeringState": "Connected"}'),
+            MagicMock(returncode=0, stdout=local_vnet_id),
+            MagicMock(returncode=0),
+        ]
+
+        peering = NFSProvisioner.create_vnet_peering(
+            name="my-peering",
+            resource_group="local-rg",
+            local_vnet="local-vnet",
+            remote_vnet="remote-vnet",
+            remote_vnet_resource_group="remote-rg",
+            allow_forwarded_traffic=True,
+        )
+
+        assert peering.allow_forwarded_traffic is True
+
+
+class TestConfigurePrivateDNSZone:
+    """Test private DNS zone configuration."""
+
+    @patch("azlin.modules.nfs_provisioner.subprocess.run")
+    def test_configure_dns_zone_success(self, mock_run):
+        """DNS zone configuration should succeed."""
+        vnet_id = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet"
+
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # create zone
+            MagicMock(returncode=0, stdout=vnet_id),  # get vnet ID
+            MagicMock(returncode=0),  # link vnet
+            MagicMock(returncode=0),  # create zone group
+        ]
+
+        dns_zone = NFSProvisioner.configure_private_dns_zone(
+            resource_group="my-rg",
+            vnet_names=["my-vnet"],
+            storage_account="myaccount",
+            private_endpoint_name="my-pe",
+        )
+
+        assert dns_zone.name == "privatelink.file.core.windows.net"
+        assert "my-vnet" in dns_zone.linked_vnets
+        assert dns_zone.record_count == 1
+
+    @patch("azlin.modules.nfs_provisioner.subprocess.run")
+    def test_configure_dns_zone_multiple_vnets(self, mock_run):
+        """DNS zone should link multiple VNets."""
+        vnet1_id = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet1"
+        vnet2_id = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet2"
+
+        mock_run.side_effect = [
+            MagicMock(returncode=0),  # create zone
+            MagicMock(returncode=0, stdout=vnet1_id),  # vnet1 ID
+            MagicMock(returncode=0),  # link vnet1
+            MagicMock(returncode=0, stdout=vnet2_id),  # vnet2 ID
+            MagicMock(returncode=0),  # link vnet2
+            MagicMock(returncode=0),  # create zone group
+        ]
+
+        dns_zone = NFSProvisioner.configure_private_dns_zone(
+            resource_group="my-rg",
+            vnet_names=["vnet1", "vnet2"],
+            storage_account="myaccount",
+            private_endpoint_name="my-pe",
+        )
+
+        assert len(dns_zone.linked_vnets) == 2
+        assert "vnet1" in dns_zone.linked_vnets
+        assert "vnet2" in dns_zone.linked_vnets
+
+
+class TestSetupPrivateEndpointAccess:
+    """Test complete private endpoint access setup."""
+
+    @patch("azlin.modules.nfs_provisioner.NFSProvisioner.create_private_endpoint")
+    @patch("azlin.modules.nfs_provisioner.NFSProvisioner.create_vnet_peering")
+    @patch("azlin.modules.nfs_provisioner.NFSProvisioner.configure_private_dns_zone")
+    def test_setup_without_peering(
+        self, mock_dns, mock_peering, mock_endpoint
+    ):
+        """Setup without source VNet should skip peering."""
+        mock_endpoint.return_value = PrivateEndpointInfo(
+            name="my-pe",
+            resource_group="my-rg",
+            region="eastus",
+            storage_account="storage",
+            vnet_name="target-vnet",
+            subnet_name="subnet",
+            private_ip="10.0.0.4",
+            connection_state="Succeeded",
+            dns_configured=False,
+            created=datetime.now(),
+        )
+
+        mock_dns.return_value = PrivateDNSZoneInfo(
+            name="privatelink.file.core.windows.net",
+            resource_group="my-rg",
+            linked_vnets=["target-vnet"],
+            record_count=1,
+        )
+
+        endpoint, peering, dns = NFSProvisioner.setup_private_endpoint_access(
+            storage_account="myaccount",
+            storage_resource_group="storage-rg",
+            target_region="eastus",
+            target_resource_group="my-rg",
+            target_vnet="target-vnet",
+            target_subnet="subnet",
+        )
+
+        assert endpoint.name == "my-pe"
+        assert peering is None  # No peering created
+        assert dns.name == "privatelink.file.core.windows.net"
+
+    @patch("azlin.modules.nfs_provisioner.NFSProvisioner.create_private_endpoint")
+    @patch("azlin.modules.nfs_provisioner.NFSProvisioner.create_vnet_peering")
+    @patch("azlin.modules.nfs_provisioner.NFSProvisioner.configure_private_dns_zone")
+    def test_setup_with_peering(self, mock_dns, mock_peering, mock_endpoint):
+        """Setup with source VNet should create peering."""
+        mock_endpoint.return_value = PrivateEndpointInfo(
+            name="my-pe",
+            resource_group="my-rg",
+            region="eastus",
+            storage_account="storage",
+            vnet_name="target-vnet",
+            subnet_name="subnet",
+            private_ip="10.0.0.4",
+            connection_state="Succeeded",
+            dns_configured=False,
+            created=datetime.now(),
+        )
+
+        mock_peering.return_value = VNetPeeringInfo(
+            name="peering",
+            resource_group="my-rg",
+            local_vnet="target-vnet",
+            remote_vnet="source-vnet",
+            peering_state="Connected",
+            allow_forwarded_traffic=True,
+            allow_gateway_transit=False,
+            use_remote_gateways=False,
+            created=datetime.now(),
+        )
+
+        mock_dns.return_value = PrivateDNSZoneInfo(
+            name="privatelink.file.core.windows.net",
+            resource_group="my-rg",
+            linked_vnets=["target-vnet", "source-vnet"],
+            record_count=1,
+        )
+
+        endpoint, peering, dns = NFSProvisioner.setup_private_endpoint_access(
+            storage_account="myaccount",
+            storage_resource_group="storage-rg",
+            target_region="eastus",
+            target_resource_group="my-rg",
+            target_vnet="target-vnet",
+            target_subnet="subnet",
+            source_vnet="source-vnet",
+            source_resource_group="source-rg",
+        )
+
+        assert endpoint.name == "my-pe"
+        assert peering is not None
+        assert peering.local_vnet == "target-vnet"
+        assert peering.remote_vnet == "source-vnet"
+        assert len(dns.linked_vnets) == 2
+
+
+class TestReplicateNFSData:
+    """Test NFS data replication."""
+
+    @patch("azlin.modules.nfs_provisioner.subprocess.run")
+    def test_replicate_data_success(self, mock_run):
+        """Data replication should succeed."""
+        # Mock storage key queries and azcopy
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="source-key"),  # source key
+            MagicMock(returncode=0, stdout="target-key"),  # target key
+            MagicMock(returncode=0, stdout="sas-token"),  # SAS token
+            MagicMock(returncode=0, stdout="{}"),  # azcopy
+        ]
+
+        result = NFSProvisioner.replicate_nfs_data(
+            source_storage="source-account",
+            source_resource_group="source-rg",
+            target_storage="target-account",
+            target_resource_group="target-rg",
+            share_name="home",
+        )
+
+        assert result.success is True
+        assert "source-account" in result.source_endpoint
+        assert "target-account" in result.target_endpoint
+
+    @patch("azlin.modules.nfs_provisioner.subprocess.run")
+    def test_replicate_data_azcopy_failure(self, mock_run):
+        """Azcopy failure should be reported."""
+        # Mock successful key queries but failed azcopy
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="source-key"),
+            MagicMock(returncode=0, stdout="target-key"),
+            MagicMock(returncode=0, stdout="sas-token"),
+            MagicMock(returncode=1, stderr="Azcopy failed"),  # azcopy failure
+        ]
+
+        result = NFSProvisioner.replicate_nfs_data(
+            source_storage="source",
+            source_resource_group="rg",
+            target_storage="target",
+            target_resource_group="rg",
+        )
+
+        assert result.success is False
+        assert len(result.errors) > 0
+
+    def test_replicate_data_validation_error(self):
+        """Invalid storage names should raise error."""
+        with pytest.raises(ValidationError):
+            NFSProvisioner.replicate_nfs_data(
+                source_storage="source;rm -rf",  # Invalid
+                source_resource_group="rg",
+                target_storage="target",
+                target_resource_group="rg",
+            )
+
+
+class TestDataModels:
+    """Test data model classes."""
+
+    def test_access_analysis_get_strategy_details(self):
+        """AccessAnalysis should return strategy details."""
+        analysis = AccessAnalysis(
+            source_storage="storage",
+            source_region="eastus",
+            target_region="westus",
+            recommended_strategy=AccessStrategy.DIRECT,
+            strategies={
+                AccessStrategy.DIRECT: {"cost": 0},
+                AccessStrategy.PRIVATE_ENDPOINT: {"cost": 10},
+            },
+            same_region=True,
+            estimated_latency_ms=1.0,
+            estimated_cost_monthly=0.0,
+        )
+
+        direct_details = analysis.get_strategy_details(AccessStrategy.DIRECT)
+        assert direct_details == {"cost": 0}
+
+    def test_replication_result_with_errors(self):
+        """ReplicationResult should track errors."""
+        result = ReplicationResult(
+            success=False,
+            source_endpoint="source/share",
+            target_endpoint="target/share",
+            files_copied=0,
+            bytes_copied=0,
+            duration_seconds=10.0,
+            errors=["Error 1", "Error 2"],
+        )
+
+        assert result.success is False
+        assert len(result.errors) == 2
+
+
+class TestConstants:
+    """Test module constants."""
+
+    def test_private_endpoint_constants(self):
+        """Private endpoint constants should be defined."""
+        assert NFSProvisioner.PRIVATE_ENDPOINT_GROUP_ID == "file"
+        assert NFSProvisioner.PRIVATE_DNS_ZONE_NAME == "privatelink.file.core.windows.net"
+
+    def test_cost_constants(self):
+        """Cost constants should be defined."""
+        assert NFSProvisioner.PRIVATE_ENDPOINT_COST == 7.30
+        assert NFSProvisioner.VNET_PEERING_COST_PER_GB == 0.01
+
+    def test_latency_constants(self):
+        """Latency constants should be defined."""
+        assert NFSProvisioner.SAME_REGION_LATENCY == 1.0
+        assert NFSProvisioner.CROSS_REGION_LATENCY == 50.0
+        assert NFSProvisioner.PRIVATE_ENDPOINT_OVERHEAD == 2.0

--- a/tests/unit/modules/test_resource_orchestrator.py
+++ b/tests/unit/modules/test_resource_orchestrator.py
@@ -1,0 +1,546 @@
+"""Unit tests for resource_orchestrator module.
+
+Tests decision workflows, user interaction, and resource tracking.
+"""
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from azlin.modules.interaction_handler import MockInteractionHandler
+from azlin.modules.resource_orchestrator import (
+    BastionOptions,
+    DecisionAction,
+    DependencyError,
+    NFSOptions,
+    OrchestratedResource,
+    OrchestratorError,
+    ResourceDecision,
+    ResourceOrchestrator,
+    ResourceStatus,
+    ResourceType,
+    RollbackError,
+)
+
+
+class TestDecisionAction:
+    """Test DecisionAction enumeration."""
+
+    def test_action_values(self):
+        """Decision action values should be defined."""
+        assert DecisionAction.CREATE.value == "create"
+        assert DecisionAction.USE_EXISTING.value == "use-existing"
+        assert DecisionAction.SKIP.value == "skip"
+        assert DecisionAction.CANCEL.value == "cancel"
+
+
+class TestResourceType:
+    """Test ResourceType enumeration."""
+
+    def test_resource_types(self):
+        """Resource types should be defined."""
+        assert ResourceType.BASTION.value == "bastion"
+        assert ResourceType.NFS.value == "nfs"
+        assert ResourceType.VNET.value == "vnet"
+
+
+class TestResourceDecision:
+    """Test ResourceDecision dataclass."""
+
+    def test_create_decision_with_cost(self):
+        """CREATE decision should include cost estimate."""
+        decision = ResourceDecision(
+            action=DecisionAction.CREATE,
+            resource_type=ResourceType.BASTION,
+            resource_name="my-bastion",
+            cost_estimate=Decimal("292.65"),
+        )
+
+        assert decision.action == DecisionAction.CREATE
+        assert decision.cost_estimate == Decimal("292.65")
+
+    def test_use_existing_decision(self):
+        """USE_EXISTING decision should include resource ID."""
+        decision = ResourceDecision(
+            action=DecisionAction.USE_EXISTING,
+            resource_type=ResourceType.BASTION,
+            resource_id="/subscriptions/.../bastions/existing",
+            resource_name="existing-bastion",
+        )
+
+        assert decision.action == DecisionAction.USE_EXISTING
+        assert decision.resource_id is not None
+
+    def test_skip_decision(self):
+        """SKIP decision with fallback metadata."""
+        decision = ResourceDecision(
+            action=DecisionAction.SKIP,
+            resource_type=ResourceType.BASTION,
+            metadata={"fallback": "public-ip"},
+        )
+
+        assert decision.action == DecisionAction.SKIP
+        assert decision.metadata["fallback"] == "public-ip"
+
+
+class TestEnsureBastion:
+    """Test Bastion orchestration workflow."""
+
+    def test_bastion_exists_returns_use_existing(self):
+        """Existing Bastion should return USE_EXISTING decision."""
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler, dry_run=True)
+
+        # Mock existing Bastion
+        with patch.object(orchestrator, "_check_existing_bastion") as mock_check:
+            mock_check.return_value = {
+                "name": "existing-bastion",
+                "id": "/subscriptions/.../bastions/existing-bastion",
+                "sku": "Basic",
+            }
+
+            options = BastionOptions(
+                region="eastus",
+                resource_group="my-rg",
+                vnet_name="my-vnet",
+            )
+
+            decision = orchestrator.ensure_bastion(options)
+
+            assert decision.action == DecisionAction.USE_EXISTING
+            assert decision.resource_name == "existing-bastion"
+
+    def test_bastion_not_exists_user_chooses_create(self):
+        """User choosing CREATE should return CREATE decision."""
+        handler = MockInteractionHandler(choice_responses=[0])  # Choose first option (create)
+        orchestrator = ResourceOrchestrator(handler)
+
+        with patch.object(orchestrator, "_check_existing_bastion") as mock_check:
+            mock_check.return_value = None  # No existing Bastion
+
+            options = BastionOptions(
+                region="eastus",
+                resource_group="my-rg",
+                vnet_name="my-vnet",
+            )
+
+            decision = orchestrator.ensure_bastion(options)
+
+            assert decision.action == DecisionAction.CREATE
+            assert decision.resource_type == ResourceType.BASTION
+            assert decision.cost_estimate is not None
+
+    def test_bastion_not_exists_user_chooses_public_ip(self):
+        """User choosing public IP should return SKIP decision."""
+        handler = MockInteractionHandler(choice_responses=[1])  # Choose second option (public-ip)
+        orchestrator = ResourceOrchestrator(handler)
+
+        with patch.object(orchestrator, "_check_existing_bastion") as mock_check:
+            mock_check.return_value = None
+
+            options = BastionOptions(
+                region="eastus",
+                resource_group="my-rg",
+                vnet_name="my-vnet",
+                allow_public_ip_fallback=True,
+            )
+
+            decision = orchestrator.ensure_bastion(options)
+
+            assert decision.action == DecisionAction.SKIP
+            assert decision.metadata["fallback"] == "public-ip"
+
+    def test_bastion_not_exists_user_cancels(self):
+        """User choosing cancel should return CANCEL decision."""
+        handler = MockInteractionHandler(choice_responses=[2])  # Choose third option (cancel)
+        orchestrator = ResourceOrchestrator(handler)
+
+        with patch.object(orchestrator, "_check_existing_bastion") as mock_check:
+            mock_check.return_value = None
+
+            options = BastionOptions(
+                region="eastus",
+                resource_group="my-rg",
+                vnet_name="my-vnet",
+            )
+
+            decision = orchestrator.ensure_bastion(options)
+
+            assert decision.action == DecisionAction.CANCEL
+
+    def test_bastion_missing_vnet_auto_generates(self):
+        """Missing VNet name should auto-generate based on region."""
+        handler = MockInteractionHandler(choice_responses=[0])  # User chooses to create
+        orchestrator = ResourceOrchestrator(handler)
+
+        options = BastionOptions(
+            region="eastus",
+            resource_group="my-rg",
+            vnet_name="",  # Empty VNet name
+        )
+
+        with patch.object(orchestrator, "_check_existing_bastion", return_value=None):
+            decision = orchestrator.ensure_bastion(options)
+
+        # Should auto-generate VNet name
+        assert decision.metadata["vnet_name"] == "azlin-vnet-eastus"
+
+
+class TestEnsureNFSAccess:
+    """Test NFS access orchestration workflow."""
+
+    def test_same_region_nfs_returns_use_existing(self):
+        """Same region NFS should return USE_EXISTING."""
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler)
+
+        options = NFSOptions(
+            region="eastus",
+            resource_group="my-rg",
+            storage_account_name="myaccount",
+            storage_account_region="eastus",  # Same region
+            share_name="home",
+        )
+
+        decision = orchestrator.ensure_nfs_access(options)
+
+        assert decision.action == DecisionAction.USE_EXISTING
+        assert decision.metadata["cross_region"] is False
+
+    def test_cross_region_nfs_user_chooses_setup(self):
+        """User choosing cross-region setup should return CREATE."""
+        handler = MockInteractionHandler(choice_responses=[0])  # Choose setup
+        orchestrator = ResourceOrchestrator(handler)
+
+        options = NFSOptions(
+            region="eastus",
+            resource_group="my-rg",
+            storage_account_name="myaccount",
+            storage_account_region="westus",  # Different region
+            share_name="home",
+        )
+
+        decision = orchestrator.ensure_nfs_access(options)
+
+        assert decision.action == DecisionAction.CREATE
+        assert decision.metadata["cross_region"] is True
+        assert decision.cost_estimate is not None
+
+    def test_cross_region_nfs_user_chooses_local_storage(self):
+        """User choosing local storage should return SKIP."""
+        handler = MockInteractionHandler(choice_responses=[1])  # Choose local storage
+        orchestrator = ResourceOrchestrator(handler)
+
+        options = NFSOptions(
+            region="eastus",
+            resource_group="my-rg",
+            storage_account_name="myaccount",
+            storage_account_region="westus",
+            share_name="home",
+        )
+
+        decision = orchestrator.ensure_nfs_access(options)
+
+        assert decision.action == DecisionAction.SKIP
+        assert decision.metadata["fallback"] == "local-storage"
+
+    def test_cross_region_nfs_user_cancels(self):
+        """User canceling should return CANCEL."""
+        handler = MockInteractionHandler(choice_responses=[2])  # Cancel
+        orchestrator = ResourceOrchestrator(handler)
+
+        options = NFSOptions(
+            region="eastus",
+            resource_group="my-rg",
+            storage_account_name="myaccount",
+            storage_account_region="westus",
+            share_name="home",
+        )
+
+        decision = orchestrator.ensure_nfs_access(options)
+
+        assert decision.action == DecisionAction.CANCEL
+
+
+class TestResourceTracking:
+    """Test resource tracking for rollback."""
+
+    def test_track_resource(self):
+        """Track resource should add to list."""
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler)
+
+        resource = orchestrator.track_resource(
+            resource_type=ResourceType.BASTION,
+            resource_id="/subscriptions/.../bastions/my-bastion",
+            resource_name="my-bastion",
+            rollback_cmd="az network bastion delete --ids {resource_id}",
+        )
+
+        assert len(orchestrator.resources) == 1
+        assert resource.status == ResourceStatus.CREATED
+        assert resource.resource_name == "my-bastion"
+
+    def test_track_multiple_resources(self):
+        """Track multiple resources."""
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler)
+
+        orchestrator.track_resource(
+            resource_type=ResourceType.VNET,
+            resource_id="/subscriptions/.../vnets/vnet1",
+            resource_name="vnet1",
+        )
+
+        orchestrator.track_resource(
+            resource_type=ResourceType.BASTION,
+            resource_id="/subscriptions/.../bastions/bastion1",
+            resource_name="bastion1",
+        )
+
+        assert len(orchestrator.resources) == 2
+
+    def test_track_resource_with_dependencies(self):
+        """Track resource with dependencies."""
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler)
+
+        vnet_id = "/subscriptions/.../vnets/vnet1"
+        orchestrator.track_resource(
+            resource_type=ResourceType.VNET,
+            resource_id=vnet_id,
+            resource_name="vnet1",
+        )
+
+        bastion_resource = orchestrator.track_resource(
+            resource_type=ResourceType.BASTION,
+            resource_id="/subscriptions/.../bastions/bastion1",
+            resource_name="bastion1",
+            dependencies=[vnet_id],
+        )
+
+        assert vnet_id in bastion_resource.dependencies
+
+
+class TestRollbackResources:
+    """Test resource rollback functionality."""
+
+    def test_rollback_empty_list(self):
+        """Rollback with no resources should not error."""
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler)
+
+        # Should not raise
+        orchestrator.rollback_resources()
+
+    @patch("azlin.modules.resource_orchestrator.subprocess.run")
+    def test_rollback_single_resource(self, mock_run):
+        """Rollback should delete tracked resource."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler)
+
+        orchestrator.track_resource(
+            resource_type=ResourceType.BASTION,
+            resource_id="/subscriptions/.../bastions/my-bastion",
+            resource_name="my-bastion",
+            rollback_cmd="az network bastion delete --ids {resource_id}",
+        )
+
+        orchestrator.rollback_resources()
+
+        assert mock_run.called
+        assert orchestrator.resources[0].status == ResourceStatus.ROLLED_BACK
+
+    @patch("azlin.modules.resource_orchestrator.subprocess.run")
+    def test_rollback_multiple_resources_reverse_order(self, mock_run):
+        """Rollback should process resources in reverse order."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler)
+
+        # Add resources in order
+        orchestrator.track_resource(
+            resource_type=ResourceType.VNET,
+            resource_id="/subscriptions/.../vnets/vnet1",
+            resource_name="vnet1",
+            rollback_cmd="az network vnet delete --ids {resource_id}",
+        )
+
+        orchestrator.track_resource(
+            resource_type=ResourceType.BASTION,
+            resource_id="/subscriptions/.../bastions/bastion1",
+            resource_name="bastion1",
+            rollback_cmd="az network bastion delete --ids {resource_id}",
+        )
+
+        orchestrator.rollback_resources()
+
+        # Both should be rolled back
+        assert all(r.status == ResourceStatus.ROLLED_BACK for r in orchestrator.resources)
+
+    @patch("azlin.modules.resource_orchestrator.subprocess.run")
+    def test_rollback_failure_raises_error(self, mock_run):
+        """Rollback failure should raise RollbackError."""
+        mock_run.return_value = MagicMock(returncode=1, stderr="Error")
+
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler)
+
+        orchestrator.track_resource(
+            resource_type=ResourceType.BASTION,
+            resource_id="/subscriptions/.../bastions/my-bastion",
+            resource_name="my-bastion",
+            rollback_cmd="az network bastion delete --ids {resource_id}",
+        )
+
+        with pytest.raises(RollbackError):
+            orchestrator.rollback_resources()
+
+    def test_rollback_dry_run(self):
+        """Dry run rollback should not execute commands."""
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler, dry_run=True)
+
+        orchestrator.track_resource(
+            resource_type=ResourceType.BASTION,
+            resource_id="/subscriptions/.../bastions/my-bastion",
+            resource_name="my-bastion",
+            rollback_cmd="az network bastion delete --ids {resource_id}",
+        )
+
+        orchestrator.rollback_resources()
+
+        # Should be marked as rolled back without actual execution
+        assert orchestrator.resources[0].status == ResourceStatus.ROLLED_BACK
+
+
+class TestGetResourceSummary:
+    """Test resource summary reporting."""
+
+    def test_summary_empty(self):
+        """Summary with no resources."""
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler)
+
+        summary = orchestrator.get_resource_summary()
+
+        assert summary["total_resources"] == 0
+        assert len(summary["resources"]) == 0
+
+    def test_summary_multiple_resources(self):
+        """Summary with multiple resources."""
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler)
+
+        orchestrator.track_resource(
+            resource_type=ResourceType.VNET,
+            resource_id="/subscriptions/.../vnets/vnet1",
+            resource_name="vnet1",
+        )
+
+        orchestrator.track_resource(
+            resource_type=ResourceType.BASTION,
+            resource_id="/subscriptions/.../bastions/bastion1",
+            resource_name="bastion1",
+        )
+
+        summary = orchestrator.get_resource_summary()
+
+        assert summary["total_resources"] == 2
+        assert summary["by_type"][ResourceType.VNET.value] == 1
+        assert summary["by_type"][ResourceType.BASTION.value] == 1
+
+    def test_summary_status_counts(self):
+        """Summary should count resources by status."""
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler)
+
+        orchestrator.track_resource(
+            resource_type=ResourceType.VNET,
+            resource_id="/subscriptions/.../vnets/vnet1",
+            resource_name="vnet1",
+        )
+
+        # Manually set one to failed
+        orchestrator.resources[0].status = ResourceStatus.FAILED
+
+        summary = orchestrator.get_resource_summary()
+
+        assert summary["by_status"]["failed"] == 1
+
+
+class TestCostEstimation:
+    """Test cost estimation integration."""
+
+    def test_estimate_bastion_cost_no_estimator(self):
+        """Should use default costs when no estimator provided."""
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler, cost_estimator=None)
+
+        estimate = orchestrator._estimate_bastion_cost("eastus", "Basic")
+
+        assert "hourly" in estimate
+        assert "monthly" in estimate
+        assert estimate["monthly"] > 0
+
+    def test_estimate_cross_region_nfs_cost(self):
+        """Should estimate cross-region NFS costs."""
+        handler = MockInteractionHandler()
+        orchestrator = ResourceOrchestrator(handler, cost_estimator=None)
+
+        estimate = orchestrator._estimate_cross_region_nfs_cost("eastus", "westus")
+
+        assert "hourly" in estimate
+        assert "monthly" in estimate
+        assert estimate["monthly"] > 0
+
+
+class TestDataModels:
+    """Test data model classes."""
+
+    def test_bastion_options_defaults(self):
+        """BastionOptions should have default values."""
+        options = BastionOptions(
+            region="eastus",
+            resource_group="my-rg",
+            vnet_name="my-vnet",
+        )
+
+        assert options.sku == "Standard"
+        assert options.allow_public_ip_fallback is True
+
+    def test_nfs_options_defaults(self):
+        """NFSOptions should have default values."""
+        options = NFSOptions(
+            region="eastus",
+            resource_group="my-rg",
+            storage_account_name="storage",
+            storage_account_region="eastus",
+            share_name="home",
+        )
+
+        assert options.mount_point == "/home"
+        assert options.cross_region_required is False
+
+    def test_orchestrated_resource_dataclass(self):
+        """OrchestratedResource should store all fields."""
+        import time
+
+        resource = OrchestratedResource(
+            resource_type=ResourceType.BASTION,
+            resource_id="/subscriptions/.../bastions/my-bastion",
+            resource_name="my-bastion",
+            status=ResourceStatus.CREATED,
+            created_at=time.time(),
+            dependencies=["/subscriptions/.../vnets/vnet1"],
+            rollback_cmd="az network bastion delete --ids {resource_id}",
+            metadata={"sku": "Basic"},
+        )
+
+        assert resource.resource_type == ResourceType.BASTION
+        assert len(resource.dependencies) == 1
+        assert resource.metadata["sku"] == "Basic"


### PR DESCRIPTION
## Summary

Changes all Bastion SKU defaults from "Basic" to "Standard" to enable CLI tunneling support via `az network bastion tunnel`.

## Root Cause

- Basic SKU Bastion only supports browser-based SSH access through Azure Portal
- Standard SKU required for `az network bastion tunnel` CLI command used by azlin
- Error encountered: "Bastion Host SKU must be Standard or Premium and Native Client must be enabled"

## Changes

### Code Changes
1. **resource_orchestrator.py:173** - Changed BastionOptions default SKU to "Standard"
2. **cli.py:529** - Updated SKU parameter in VM provisioning workflow
3. **cost_estimator.py:54** - Changed default parameter in estimate_bastion_cost()
4. **cost_estimator.py:46** - Updated BASTION_STANDARD constant (no change needed, already $289)
5. **cleanup_orchestrator.py:111** - Updated Standard SKU cost calculation from $230 to $289
6. **resource_orchestrator.py:742** - Updated fallback cost estimate for Standard

### Cost Updates
- Basic SKU: $140/month → remains same
- Standard SKU: $230/month → $289/month (corrected pricing)
- Total with public IP: $292.65/month (289.00 + 3.65)
- Break-even point: 47 VMs → 96 VMs per Bastion

### Test Updates
- Updated 8 test files with correct Standard SKU costs
- Fixed test assertions: 143.65 (Basic) vs 292.65 (Standard)
- Renamed incorrectly labeled "Premium" tests to "Basic" (Premium not valid for Bastion)
- Updated VNet auto-generation test (no longer expects error)
- All 104 unit tests passing

### Documentation
- **README.md** - Added Standard SKU requirement explanation
- Documented CLI tunneling vs browser-based access distinction
- Updated all cost examples and break-even calculations
- Added clear note about why Standard is required

## Testing

✅ All unit tests passing (104/104)
- test_cost_estimator.py: 43 tests
- test_resource_orchestrator.py: 30 tests  
- test_cleanup_orchestrator.py: 31 tests

Integration tests show 14 pre-existing failures unrelated to SKU changes (VMInfo constructor issues, etc.)

## Impact

- **Cost increase**: $140/month → $289/month per Bastion host
- **Enables**: Full CLI-based automation and tmux integration
- **Required for**: azlin's programmatic SSH connection management
- **User impact**: All new Bastion deployments will use Standard SKU

## Closes

Fixes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>