### PR TITLE
fix: Make NFS orchestrator respect auto_approve flag

### DIFF
--- a/src/azlin/cli.py
+++ b/src/azlin/cli.py
@@ -1368,7 +1368,18 @@ chmod 600 /home/azureuser/.ssh/authorized_keys
                 )
 
                 # Use orchestrator to handle cross-region decision
-                orchestrator = ResourceOrchestrator(interaction_handler=CLIInteractionHandler())
+                # Use same interaction handler pattern as Bastion creation
+                if self.auto_approve:
+                    from azlin.modules.interaction_handler import MockInteractionHandler
+
+                    nfs_interaction_handler = MockInteractionHandler(
+                        choice_responses=[0, 0, 0, 0],  # Auto-select CREATE for all prompts
+                        confirm_responses=[True, True, True, True],
+                    )
+                else:
+                    nfs_interaction_handler = CLIInteractionHandler()
+
+                orchestrator = ResourceOrchestrator(interaction_handler=nfs_interaction_handler)
 
                 nfs_options = NFSOptions(
                     region=vm_details.location,


### PR DESCRIPTION
NFS cross-region prompts now respect --yes flag by using MockInteractionHandler in auto-approve mode.