### PR TITLE
fix: Update pre-commit dependencies to match pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,4 @@ repos:
           - click>=8.1.0
           - pyyaml>=6.0.0
           - rich>=13.7.0
-          - tomli-w>=1.0.0
+          - tomlkit>=0.12.0


### PR DESCRIPTION
## Summary

Fixes mismatch between local pre-commit checks and CI by updating pyright dependencies.

## Problem

**.pre-commit-config.yaml** had stale dependencies:
- Listed `tomli-w>=1.0.0`
- But `pyproject.toml` now uses `tomlkit>=0.12.0`

This caused local pre-commit to pass while CI failed (or vice versa).

## Solution

Update `.pre-commit-config.yaml` line 37:
- Remove: `tomli-w>=1.0.0`
- Add: `tomlkit>=0.12.0`

## Impact

- Local pre-commit checks now match CI environment
- Prevents "works locally but fails in CI" scenarios
- Consistent developer experience

🤖 Generated with [Claude Code](https://claude.com/claude-code)