### PR TITLE
fix: Pass VM location to Bastion detection for region-aware selection

### DIFF
--- a/src/azlin/vm_connector.py
+++ b/src/azlin/vm_connector.py
@@ -49,6 +49,7 @@ class ConnectionInfo:
     resource_group: str
     ssh_user: str = "azureuser"
     ssh_key_path: Path | None = None
+    location: str | None = None  # VM region for Bastion matching
 
 
 class VMConnector:
@@ -144,7 +145,10 @@ class VMConnector:
             if not should_use_bastion and not cls.is_valid_ip(vm_identifier):
                 # Auto-detect Bastion if not connecting by IP
                 bastion_info = cls._check_bastion_routing(
-                    conn_info.vm_name, conn_info.resource_group, use_bastion
+                    conn_info.vm_name,
+                    conn_info.resource_group,
+                    use_bastion,
+                    conn_info.location,  # Pass VM location for region filtering
                 )
                 should_use_bastion = bastion_info is not None
 
@@ -395,6 +399,7 @@ class VMConnector:
                 resource_group=resource_group or "unknown",
                 ssh_user=ssh_user,
                 ssh_key_path=ssh_key_path,
+                location=None,  # No location for IP-based connections
             )
 
         # Otherwise, treat as VM name - need to resolve IP
@@ -446,6 +451,7 @@ class VMConnector:
                 resource_group=resource_group,
                 ssh_user=ssh_user,
                 ssh_key_path=ssh_key_path,
+                location=vm_info.location,  # Capture VM region for Bastion matching
             )
 
         except VMManagerError as e:
@@ -453,7 +459,11 @@ class VMConnector:
 
     @classmethod
     def _check_bastion_routing(
-        cls, vm_name: str, resource_group: str, force_bastion: bool
+        cls,
+        vm_name: str,
+        resource_group: str,
+        force_bastion: bool,
+        vm_location: str | None = None,
     ) -> BastionInfo | None:
         """Check if Bastion routing should be used for VM.
 
@@ -463,6 +473,7 @@ class VMConnector:
             vm_name: VM name
             resource_group: Resource group
             force_bastion: Force use of Bastion
+            vm_location: VM region for Bastion region filtering (optional)
 
         Returns:
             Dict with bastion name and resource_group if should use Bastion, None otherwise
@@ -496,7 +507,9 @@ class VMConnector:
 
         # Auto-detect Bastion
         try:
-            bastion_info = BastionDetector.detect_bastion_for_vm(vm_name, resource_group)
+            bastion_info = BastionDetector.detect_bastion_for_vm(
+                vm_name, resource_group, vm_location
+            )
 
             if bastion_info:
                 # Prompt user (default changed to True for security by default)


### PR DESCRIPTION
## Summary

Fixes #318 - Bastion detection now filters by VM region to select correct regional Bastion host.

When connecting to a VM in a multi-region environment with multiple Bastions, the system now:
- Captures VM location from VMInfo
- Passes location to BastionDetector
- Filters Bastions by matching region
- Selects correct regional Bastion

## Changes

- **ConnectionInfo**: Added `location: str | None = None` field
- **_resolve_connection_info()**: Captures `vm_info.location`  
- **_check_bastion_routing()**: Accepts `vm_location` parameter
- **detect_bastion_for_vm()**: Now receives vm_location for filtering

Existing region filtering logic in BastionDetector activates automatically.

## Test Results

### End-to-End Test  
Tested with real Azure VM (`seldon-dev` / `azlin-vm-1762653587`):

**Before Fix:**
```
Detected Bastion host 'azlin-bastion-westus' (region: westus)
[Connection times out - wrong region]
```

**After Fix:**
```
Detected Bastion host 'azlin-bastion-westus2' (region: westus2)
[Correct Bastion selected!]
```

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| VM in westus2, Bastions in westus & westus2 | Selects westus (WRONG) ❌ | Selects westus2 (CORRECT) ✅ |
| VM region filtering | Not applied | Applied automatically |
| Bastion selection | Alphabetical | Region-aware |

## Impact

- **Severity**: High - Users can now connect to VMs in multi-region environments
- **Breaking Changes**: None - location field is optional
- **Backward Compatibility**: ✅ IP connections, single-region deployments unaffected

## Test Plan

- [x] Correct Bastion detection verified (westus2 selected)
- [x] Backward compatibility maintained (optional field)
- [ ] Full end-to-end connection test pending (may require tunnel fix)
- [ ] CI tests will validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)