### PR TITLE
CRITICAL: Fix single-word commands treated as tmux sessions

### DIFF
--- a/src/azlin/cli.py
+++ b/src/azlin/cli.py
@@ -4797,20 +4797,8 @@ def connect(
             vm_identifier = _interactive_vm_selection(rg, config, no_tmux, tmux_session)
 
         # Parse remote command and key path
-        # SPECIAL CASE: If remote_command is a single word with no command chars,
-        # treat it as tmux session name, not a remote command
-        command = None
-        if remote_command:
-            if len(remote_command) == 1 and not any(
-                char in remote_command[0] for char in [" ", "|", ">", "<", ";", "&", "`", "$"]
-            ):
-                # Single word with no command characters = tmux session name
-                if not tmux_session:  # Only if not already explicitly set
-                    tmux_session = remote_command[0]
-                    logger.info(f"Treating '{remote_command[0]}' as tmux session name")
-            else:
-                # Has command characters or multiple words = actual remote command
-                command = " ".join(remote_command)
+        # If using -- separator, ALL arguments after it are the remote command
+        command = " ".join(remote_command) if remote_command else None
 
         key_path = Path(key).expanduser() if key else None
 


### PR DESCRIPTION
Fixes #369

CRITICAL BUG: Commands like 'w', 'ls', 'pwd' were treated as tmux session names.

Root cause: Special case logic in cli.py lines 4800-4809.

Fix: Removed special case - when using --, ALL args are the command.

Tested:
```bash
azlin connect amplifier-dev -- w
# Now shows w output in current terminal ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>