### PR TITLE
fix: Make --yes flag bypass bastion confirmation prompt

### DIFF
--- a/src/azlin/cli.py
+++ b/src/azlin/cli.py
@@ -434,7 +434,7 @@ class CLIOrchestrator:
                 f"This exposes your VM directly to the internet, which is LESS SECURE.\n"
                 f"Continue with public IP?"
             )
-            if not click.confirm(warning_message, default=False):
+            if not self.auto_approve and not click.confirm(warning_message, default=False):
                 self.progress.update("User cancelled VM creation", ProgressStage.WARNING)
                 raise click.Abort
 


### PR DESCRIPTION
## Summary

Fixes #382 - The `--yes` flag now properly bypasses the `click.confirm()` prompt in `_check_bastion_availability()`, enabling full automation of VM provisioning in scripts and CI/CD pipelines.

## Problem

The `--yes` flag was not bypassing the security confirmation prompt at line 510 when using `--no-bastion`, causing:
- Scripts and CI/CD pipelines to hang waiting for user input
- Impossible to fully automate VM provisioning
- Inconsistent behavior with other confirmation prompts

## Solution

**Single Line Change** at `src/azlin/cli.py:510`:

```python
# Before:
if not click.confirm(warning_message, default=False):

# After:
if not self.auto_approve and not click.confirm(warning_message, default=False):
```

When `self.auto_approve` is True (from `--yes` flag), the confirmation is bypassed using short-circuit evaluation.

## Key Discovery

Code analysis revealed only **ONE location** needed fixing:
- ✅ **Line 510**: `--no-bastion` security warning - **FIXED**
- ✅ **Line 562**: Existing bastion found - Already working (early return at lines 547-553)
- ✅ **Line 591**: Create new bastion - Already working (conditional at lines 577-582)

## Changes

**Files Changed:** 1 file, +1 insertion, -1 deletion

## Impact

### Before Fix
```bash
azlin new --yes --no-bastion  # ❌ Hangs waiting for confirmation
```

### After Fix
```bash
azlin new --yes --no-bastion  # ✅ Completes without prompts
```

### Preserved Behavior
- ✅ Security audit logging preserved (SecurityAuditLogger.log_bastion_opt_out)
- ✅ Interactive mode still prompts for safety (no `--yes` flag)
- ✅ Progress messages unchanged
- ✅ Error handling preserved (raises click.Abort on decline)

## Testing

**Manual Testing Command:**
```bash
uvx --from git+https://github.com/rysweet/azlin@fix/issue-382-yes-flag-clean azlin new --yes --no-bastion --size s --name test-vm
```

**Expected Result:**
- No confirmation prompt appears
- VM is created with public IP automatically
- Security audit log entry created

## Review Checklist

- [x] Single line change, surgical fix
- [x] Follows existing patterns in codebase (lines 547, 577)
- [x] Security logging preserved
- [x] Interactive mode unchanged (safety preserved)
- [x] Philosophy compliance (ruthless simplicity)
- [x] Clean branch from main (no unrelated changes)

## Risk Assessment

**Risk Level:** LOW
- Minimal change (1 line)
- Follows existing patterns
- Preserves security logging
- Interactive mode safety preserved

---

**Note:** This replaces PR #383 which inadvertently included unrelated changes from a feature branch. This PR contains ONLY the fix for issue #382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)