### PR TITLE
fix: Complete --yes flag bypass for remaining bastion prompts

### DIFF
--- a/src/azlin/cli.py
+++ b/src/azlin/cli.py
@@ -559,7 +559,7 @@ class CLIOrchestrator:
                     f"  - No Bastion: Public IP (direct SSH, less secure)\n"
                     f"\nUse Bastion for secure access (recommended)?"
                 )
-                if click.confirm(message, default=True):
+                if self.auto_approve or click.confirm(message, default=True):
                     self.progress.update(
                         f"Using Bastion: {bastion_info['name']}", ProgressStage.IN_PROGRESS
                     )
@@ -588,7 +588,7 @@ class CLIOrchestrator:
                     f"  - No: Less secure (public IP, direct internet access)\n"
                     f"\nCreate VM with Bastion access?"
                 )
-                if not click.confirm(message, default=True):
+                if not self.auto_approve and not click.confirm(message, default=True):
                     # User declined - abort per security policy
                     self.progress.update("User declined Bastion creation", ProgressStage.FAILED)
                     click.echo(


### PR DESCRIPTION
## Summary

Completes the fix for issue #382 by addressing the remaining two bastion prompts that were still ignoring the `--yes` flag.

PR #384 fixed line 437, but the `_check_bastion_availability()` method has THREE prompts total. This PR fixes the other two.

## Problem

After PR #384 merged, two bastion prompts still blocked automation:
- Line 562: "Use Bastion?" prompt  
- Line 591: "Create Bastion?" prompt

Both were missing `self.auto_approve` checks.

## Solution

Added `auto_approve` checks to both locations:

**Line 562** (Use existing Bastion):
```python
# Before:
if click.confirm(message, default=True):

# After:
if self.auto_approve or click.confirm(message, default=True):
```

**Line 591** (Create new Bastion):
```python
# Before:
if not click.confirm(message, default=True):

# After:
if not self.auto_approve and not click.confirm(message, default=True):
```

## Testing

Tested with `uvx --from git...` syntax:
```bash
uvx --from git+https://github.com/rysweet/azlin@fix/bastion-prompts-complete azlin new --name test --size s --region westus --yes
```

**Result**: ✅ NO PROMPTS - Auto-approved Bastion creation, proceeded without interaction

## All Three Prompts Now Fixed

1. ✅ Line 437: Fixed in PR #384
2. ✅ Line 562: Fixed in this PR
3. ✅ Line 591: Fixed in this PR

## Changes

**Files Changed:** 1 file, +2 insertions, -2 deletions

Related to #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)