### PR TITLE
fix: Add ripgrep to cloud-init packages

### DIFF
--- a/src/azlin/vm_provisioning.py
+++ b/src/azlin/vm_provisioning.py
@@ -757,6 +757,7 @@ packages:
   - wget
   - build-essential
   - software-properties-common
+  - ripgrep
 
 runcmd:
   # Python 3.12+ from deadsnakes PPA


### PR DESCRIPTION
## Summary

Adds ripgrep (`rg`) to the pre-installed packages list in cloud-init configuration.

## Problem

Users were getting 'Missing Prerequisites: rg' errors when connecting to new VMs because ripgrep was not included in the cloud-init packages.

## Solution

Added `- ripgrep` to the packages list in `_generate_cloud_init()` method at line 760.

```python
packages:
  - docker.io
  - git
  - tmux  
  - curl
  - wget
  - build-essential
  - software-properties-common
  - ripgrep  # Added
```

## Testing

Will test by creating a VM with this branch and verifying `rg --version` works.

## Changes

**Files Changed:** 1 file, +1 insertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)