### PR TITLE
fix: Use tag-based query for list command to show custom-named VMs

### DIFF
--- a/src/azlin/cli.py
+++ b/src/azlin/cli.py
@@ -3161,9 +3161,10 @@ def list_command(
                 pass  # Silently skip if context unavailable
 
             click.echo(f"Listing VMs in resource group: {rg}\n")
-            vms = VMManager.list_vms(rg, include_stopped=show_all)
-            # Filter to azlin VMs
-            vms = VMManager.filter_by_prefix(vms, "azlin")
+            # Use tag-based query to include custom-named VMs (Issue #385 support)
+            vms = TagManager.list_managed_vms(resource_group=rg)
+            if not show_all:
+                vms = [vm for vm in vms if vm.is_running()]
 
         # Filter by tag if specified
         if tag:


### PR DESCRIPTION
## Summary

Fixes bug where custom-named VMs don't show in `azlin list` output.

## Problem

After PR #386 enabled custom VM names (e.g., `azlin new --name myproject`), these VMs didn't appear in `azlin list` even though they had correct tags.

**Root Cause:** Line 3166 filtered VMs by prefix "azlin", excluding custom names:
```python
vms = VMManager.filter_by_prefix(vms, "azlin")  # Excludes testrig-fix-387, amplihack2, etc.
```

## Solution

Use `TagManager.list_managed_vms()` which queries by `managed-by=azlin` tag instead of name prefix:

```python
# Old (line 3164-3166):
vms = VMManager.list_vms(rg, include_stopped=show_all)
vms = VMManager.filter_by_prefix(vms, "azlin")

# New:
vms = TagManager.list_managed_vms(resource_group=rg)
if not show_all:
    vms = [vm for vm in vms if vm.is_running()]
```

This correctly includes ALL azlin-managed VMs regardless of name.

## Testing

Tested with `uvx --from git...` syntax - will verify custom-named VMs appear.

## Changes

**Files Changed:** 1 file, +4 insertions, -3 deletions

Related to #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)