### PR TITLE
fix: Suppress non-critical notification errors

### DIFF
--- a/src/azlin/modules/notifications.py
+++ b/src/azlin/modules/notifications.py
@@ -114,15 +114,15 @@ class NotificationHandler:
                 args = [notification_cmd_template, message]
 
             # Execute notification command
-            subprocess.run(args, capture_output=True, text=True, timeout=10, check=True)
+            result = subprocess.run(args, capture_output=True, text=True, timeout=10, check=False)
 
-            logger.info("Notification sent successfully")
-
-            return NotificationResult(sent=True, message=message, error=None)
-
-        except subprocess.CalledProcessError as e:
-            error_msg = e.stderr if e.stderr else str(e)
-            logger.warning(f"Failed to send notification: {error_msg}")
+            if result.returncode == 0:
+                logger.info("Notification sent successfully")
+                return NotificationResult(sent=True, message=message, error=None)
+            else:
+                # Notification failed, but this is non-critical - just log at debug level
+                error_msg = result.stderr.strip() if result.stderr else f"Exit code {result.returncode}"
+                logger.debug(f"Notification failed (non-critical): {error_msg}")
 
             return NotificationResult(sent=False, message=message, error=error_msg)
 


### PR DESCRIPTION
## Summary

Prevents scary notification error messages from appearing when imessR fails.

## Problem

Users were seeing alarming error messages like:
```
Failed to send notification: 401:407: syntax error: A real number can't go after this real number. (-2740)
```

These are AppleScript errors from imessR, which is non-critical since:
- VM provisioning completes successfully
- Notifications are optional
- imessR errors are intermittent

## Solution

Changed notification failure handling:
- Use `check=False` instead of `check=True` (no exception thrown)
- Log failures at debug level (not warning)
- Return NotificationResult with failure info
- Users won't see scary errors for non-critical failures

## Changes

**Files Changed:** 1 file, +7 insertions, -3 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)