### PR TITLE
fix: Apply ruff formatting to notifications.py

### DIFF
--- a/src/azlin/modules/notifications.py
+++ b/src/azlin/modules/notifications.py
@@ -119,10 +119,9 @@ class NotificationHandler:
             if result.returncode == 0:
                 logger.info("Notification sent successfully")
                 return NotificationResult(sent=True, message=message, error=None)
-            else:
-                # Notification failed, but this is non-critical - just log at debug level
-                error_msg = result.stderr.strip() if result.stderr else f"Exit code {result.returncode}"
-                logger.debug(f"Notification failed (non-critical): {error_msg}")
+            # Notification failed, but this is non-critical - just log at debug level
+            error_msg = result.stderr.strip() if result.stderr else f"Exit code {result.returncode}"
+            logger.debug(f"Notification failed (non-critical): {error_msg}")
 
             return NotificationResult(sent=False, message=message, error=error_msg)
 


### PR DESCRIPTION
## Summary

Apply ruff formatting fix to notifications.py that was missed in PR #392.

## Changes

- Remove unnecessary else clause after return statement (RET505)
- This fixes the pre-commit check failure

## Context

PR #392 was merged with a pre-commit failure. This PR applies the automatic ruff formatting fix to resolve the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)