### PR TITLE
fix: Allow storage mount/unmount on Bastion-only VMs

### DIFF
--- a/src/azlin/commands/storage.py
+++ b/src/azlin/commands/storage.py
@@ -431,8 +431,11 @@ def mount_storage(storage_name: str, vm: str, resource_group: str | None):
             )
             sys.exit(1)
 
-        # Public IP check removed - Bastion VMs use private IPs (Issue #372)
-        # Connection handling (public vs Bastion) is done by NFSMountManager
+        # Use public IP if available, otherwise private IP for Bastion-only VMs (Issue #372)
+        vm_ip = vm_obj.public_ip or vm_obj.private_ip
+        if not vm_ip:
+            click.echo(f"Error: VM '{vm}' has no IP address (neither public nor private)", err=True)
+            sys.exit(1)
 
         # Get SSH key
         ssh_key_path = Path.home() / ".ssh" / "azlin"
@@ -444,10 +447,10 @@ def mount_storage(storage_name: str, vm: str, resource_group: str | None):
         click.echo("Mounting storage on VM...")
         click.echo(f"  Storage: {storage_name}")
         click.echo(f"  Endpoint: {storage.nfs_endpoint}")
-        click.echo(f"  VM: {vm_obj.name} ({vm_obj.public_ip})")
+        click.echo(f"  VM: {vm_obj.name} ({vm_ip})")
 
         result = NFSMountManager.mount_storage(
-            vm_ip=vm_obj.public_ip,
+            vm_ip=vm_ip,
             ssh_key=ssh_key_path,
             nfs_endpoint=storage.nfs_endpoint,
         )
@@ -526,8 +529,11 @@ def unmount_storage(vm: str, resource_group: str | None):
             )
             sys.exit(1)
 
-        # Public IP check removed - Bastion VMs use private IPs (Issue #372)
-        # Connection handling (public vs Bastion) is done by NFSMountManager
+        # Use public IP if available, otherwise private IP for Bastion-only VMs (Issue #372)
+        vm_ip = vm_obj.public_ip or vm_obj.private_ip
+        if not vm_ip:
+            click.echo(f"Error: VM '{vm}' has no IP address (neither public nor private)", err=True)
+            sys.exit(1)
 
         # Get SSH key
         ssh_key_path = Path.home() / ".ssh" / "azlin"
@@ -537,10 +543,10 @@ def unmount_storage(vm: str, resource_group: str | None):
 
         # Unmount storage
         click.echo("Unmounting storage from VM...")
-        click.echo(f"  VM: {vm_obj.name} ({vm_obj.public_ip})")
+        click.echo(f"  VM: {vm_obj.name} ({vm_ip})")
 
         result = NFSMountManager.unmount_storage(
-            vm_ip=vm_obj.public_ip,
+            vm_ip=vm_ip,
             ssh_key=ssh_key_path,
         )
 


### PR DESCRIPTION
Closes #372

Removed public IP requirement that blocked storage mount on Bastion VMs.

NFSMountManager already handles Bastion connections (fixed in #360).

🤖 Generated with [Claude Code](https://claude.com/claude-code)