### PR TITLE
fix: Add westcentralus to VALID_REGIONS (Issue #421)

### DIFF
--- a/src/azlin/vm_provisioning.py
+++ b/src/azlin/vm_provisioning.py
@@ -301,6 +301,9 @@ class VMProvisioner:
     }
 
     # Valid Azure regions whitelist
+    # All regions supported by azlin VM provisioning
+    # Note: COMMON_REGIONS (config_manager.py) must be subset of VALID_REGIONS
+    # This constraint is enforced by tests/unit/test_region_consistency.py
     VALID_REGIONS: ClassVar[set[str]] = {
         "eastus",
         "eastus2",
@@ -310,6 +313,7 @@ class VMProvisioner:
         "centralus",
         "northcentralus",
         "southcentralus",
+        "westcentralus",  # Issue #421 fix
         "northeurope",
         "westeurope",
         "uksouth",

--- a/tests/unit/test_region_consistency.py
+++ b/tests/unit/test_region_consistency.py
@@ -1,0 +1,98 @@
+"""Test region consistency between config_manager and vm_provisioning.
+
+This test prevents Issue #421 from recurring by ensuring all regions in
+COMMON_REGIONS are also in VALID_REGIONS.
+
+Testing Philosophy:
+- TDD approach: Tests written BEFORE implementation
+- Clear error messages showing which regions are missing
+- Regression test for specific issue (#421)
+- Fast unit tests with no external dependencies
+"""
+
+from azlin.config_manager import COMMON_REGIONS
+from azlin.vm_provisioning import VMProvisioner
+
+
+class TestRegionConsistency:
+    """Ensure region configuration consistency across modules."""
+
+    def test_common_regions_are_valid(self):
+        """All regions in COMMON_REGIONS must be in VALID_REGIONS.
+
+        This test prevents configuration drift where COMMON_REGIONS
+        contains regions not recognized as valid by the provisioning system.
+
+        Should FAIL initially because westcentralus is in COMMON_REGIONS
+        but not in VALID_REGIONS.
+        """
+        # Find regions in COMMON_REGIONS that are not in VALID_REGIONS
+        invalid_common_regions = [
+            region for region in COMMON_REGIONS if region not in VMProvisioner.VALID_REGIONS
+        ]
+
+        # Build detailed error message
+        error_msg = (
+            f"Found {len(invalid_common_regions)} region(s) in COMMON_REGIONS "
+            f"that are not in VALID_REGIONS: {invalid_common_regions}\n"
+            f"COMMON_REGIONS: {COMMON_REGIONS}\n"
+            f"VALID_REGIONS: {VMProvisioner.VALID_REGIONS}\n"
+            f"All COMMON_REGIONS must also be in VALID_REGIONS to prevent "
+            f"provisioning failures."
+        )
+
+        assert len(invalid_common_regions) == 0, error_msg
+
+    def test_westcentralus_specifically(self):
+        """Regression test for Issue #421: westcentralus must be valid.
+
+        Issue #421 occurred because westcentralus was in COMMON_REGIONS
+        but not in VALID_REGIONS, causing provisioning to fail.
+
+        This test explicitly verifies the fix for that specific issue.
+
+        Should FAIL initially because westcentralus is not in VALID_REGIONS.
+        """
+        assert "westcentralus" in VMProvisioner.VALID_REGIONS, (
+            "westcentralus must be in VALID_REGIONS (Issue #421 fix). "
+            f"Current VALID_REGIONS: {VMProvisioner.VALID_REGIONS}"
+        )
+
+    def test_valid_regions_not_empty(self):
+        """VALID_REGIONS must contain at least one region.
+
+        Sanity check to ensure VALID_REGIONS is properly configured.
+        """
+        assert len(VMProvisioner.VALID_REGIONS) > 0, (
+            "VALID_REGIONS must contain at least one region"
+        )
+
+    def test_common_regions_not_empty(self):
+        """COMMON_REGIONS must contain at least one region.
+
+        Sanity check to ensure COMMON_REGIONS is properly configured.
+        """
+        assert len(COMMON_REGIONS) > 0, "COMMON_REGIONS must contain at least one region"
+
+
+class TestRegionDataStructures:
+    """Verify the data structures of region constants."""
+
+    def test_valid_regions_is_set(self):
+        """VALID_REGIONS should be a set (immutable, no duplicates)."""
+        assert isinstance(VMProvisioner.VALID_REGIONS, set), (
+            f"VALID_REGIONS should be a set, got {type(VMProvisioner.VALID_REGIONS)}"
+        )
+
+    def test_common_regions_is_list(self):
+        """COMMON_REGIONS should be a list for order preservation."""
+        assert isinstance(COMMON_REGIONS, list), (
+            f"COMMON_REGIONS should be a list, got {type(COMMON_REGIONS)}"
+        )
+
+    def test_no_duplicate_common_regions(self):
+        """COMMON_REGIONS should not contain duplicates."""
+        assert len(COMMON_REGIONS) == len(set(COMMON_REGIONS)), (
+            f"COMMON_REGIONS contains duplicates: "
+            f"{[r for r in COMMON_REGIONS if COMMON_REGIONS.count(r) > 1]}"
+        )


### PR DESCRIPTION
## Summary

Fixes #421 - westcentralus region validation bug

**Problem:**
- User command `azlin new --region westcentralus` failed with `ValueError: Invalid region: westcentralus`
- Bastion creation succeeded in westcentralus, but VM provisioning failed immediately after
- Root cause: westcentralus exists in COMMON_REGIONS but was missing from VALID_REGIONS

**Solution:**
1. Added `westcentralus` to VALID_REGIONS set (vm_provisioning.py:316)
2. Added inline documentation explaining COMMON_REGIONS ⊆ VALID_REGIONS relationship
3. Created comprehensive test suite (test_region_consistency.py) preventing recurrence

**Changes:**
- `src/azlin/vm_provisioning.py`: Added westcentralus + documentation (5 lines)
- `tests/unit/test_region_consistency.py`: NEW FILE - 7 tests for consistency validation

## Test Results

### Unit Tests (111 passed)
- ✅ All 7 new consistency tests pass
- ✅ All 40 config_manager tests pass
- ✅ All 64 vm_provisioning_validation tests pass
- ✅ No regressions detected

### Local Validation
```python
>>> VMProvisioner().validate_region('westcentralus')
True  # Was False before fix
```

### E2E Test (uvx --from git)
```bash
$ uvx --from "git+https://github.com/rysweet/azlin@fix/issue-421-westcentralus-region" \
  --with ipython ipython -c "from azlin.vm_provisioning import VMProvisioner; ..."
✓ E2E Test: validate_region("westcentralus") = True
✓ Total regions in VALID_REGIONS: 34 (was 33)
✓ E2E TEST PASSED
```

### TDD Verification
- 🔴 Tests FAILED before fix (as expected)
- 🟢 Tests PASS after fix (TDD green phase)

## Test Plan

- [x] Unit tests: All 111 tests pass
- [x] Pre-commit hooks: All passed
- [x] Local validation: westcentralus accepted
- [x] E2E test: uvx --from git installation and validation works
- [ ] CI: Waiting for automated checks
- [ ] Manual: Would require actual Azure VM provisioning (expensive, deferred)

## Philosophy Compliance

- ✅ **Ruthless Simplicity**: One-line fix + preventive test
- ✅ **Zero-BS**: No stubs, TODOs, or placeholders
- ✅ **TDD**: Tests written first, failed, then passed
- ✅ **Modular**: Clean change to single module

**Code Review Score**: 9/10 (LGTM with documentation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)