### PR TITLE
feat: Multiple source files for cp command (Issue #323)

### DIFF
--- a/benchmarks/benchmark_parallel_vm_list.py
+++ b/benchmarks/benchmark_parallel_vm_list.py
@@ -11,7 +11,6 @@ Usage:
 """
 
 import argparse
-import asyncio
 import json
 import statistics
 import sys
@@ -147,8 +146,12 @@ class ParallelVMListBenchmark:
         parallel_warm_mean = statistics.mean(parallel_warm_times)
 
         # Calculate improvement percentages
-        cold_improvement = ((baseline_mean - parallel_cold_mean) / baseline_mean) * 100 if baseline_mean > 0 else 0
-        warm_improvement = ((baseline_mean - parallel_warm_mean) / baseline_mean) * 100 if baseline_mean > 0 else 0
+        cold_improvement = (
+            ((baseline_mean - parallel_cold_mean) / baseline_mean) * 100 if baseline_mean > 0 else 0
+        )
+        warm_improvement = (
+            ((baseline_mean - parallel_warm_mean) / baseline_mean) * 100 if baseline_mean > 0 else 0
+        )
 
         report = {
             "benchmark": "parallel_vm_list",
@@ -169,7 +172,9 @@ class ParallelVMListBenchmark:
             "parallel_warm": {
                 "mean": parallel_warm_mean,
                 "median": statistics.median(parallel_warm_times),
-                "stddev": statistics.stdev(parallel_warm_times) if len(parallel_warm_times) > 1 else 0.0,
+                "stddev": statistics.stdev(parallel_warm_times)
+                if len(parallel_warm_times) > 1
+                else 0.0,
                 "min": min(parallel_warm_times),
                 "max": max(parallel_warm_times),
                 "improvement_pct": warm_improvement,
@@ -202,7 +207,7 @@ class ParallelVMListBenchmark:
         print("\nPARALLEL (Cold Start - No Cache):")
         print(f"  Mean:        {parallel_cold['mean']:.3f}s")
         print(f"  Improvement: {parallel_cold['improvement_pct']:.1f}%")
-        if parallel_cold['improvement_pct'] < 0:
+        if parallel_cold["improvement_pct"] < 0:
             print("  ⚠️  SLOWER than baseline (expected for cold start)")
 
         parallel_warm = report["parallel_warm"]
@@ -215,19 +220,23 @@ class ParallelVMListBenchmark:
         print(f"  Improvement: {parallel_warm['improvement_pct']:.1f}%")
 
         print("\nPERFORMANCE SUMMARY:")
-        if parallel_warm['improvement_pct'] >= 70:
-            print(f"  ✅ SUCCESS: {parallel_warm['improvement_pct']:.1f}% improvement (target: 70%)")
-        elif parallel_warm['improvement_pct'] >= 50:
-            print(f"  ⚠️  PARTIAL: {parallel_warm['improvement_pct']:.1f}% improvement (target: 70%)")
+        if parallel_warm["improvement_pct"] >= 70:
+            print(
+                f"  ✅ SUCCESS: {parallel_warm['improvement_pct']:.1f}% improvement (target: 70%)"
+            )
+        elif parallel_warm["improvement_pct"] >= 50:
+            print(
+                f"  ⚠️  PARTIAL: {parallel_warm['improvement_pct']:.1f}% improvement (target: 70%)"
+            )
         else:
             print(f"  ❌ FAILED: {parallel_warm['improvement_pct']:.1f}% improvement (target: 70%)")
 
         # Print cache effectiveness
-        if report['cache_stats']:
+        if report["cache_stats"]:
             avg_hit_rate = statistics.mean(
-                stats['cache_hit_rate'] for _, stats in report['cache_stats'] if _ == 'warm'
+                stats["cache_hit_rate"] for _, stats in report["cache_stats"] if _ == "warm"
             )
-            print(f"\nCACHE EFFECTIVENESS:")
+            print("\nCACHE EFFECTIVENESS:")
             print(f"  Average Hit Rate: {avg_hit_rate:.1%}")
             if avg_hit_rate >= 0.8:
                 print("  Status: Excellent cache performance ✅")
@@ -295,6 +304,7 @@ def main():
     except Exception as e:
         print(f"\n\nERROR: Benchmark failed: {e}")
         import traceback
+
         traceback.print_exc()
         sys.exit(1)
 

--- a/src/azlin/cli.py
+++ b/src/azlin/cli.py
@@ -5825,12 +5825,13 @@ def cp(
                     err=True,
                 )
                 sys.exit(1)
-            if first_source.session and src_endpoint.session:
-                if first_source.session.name != src_endpoint.session.name:
-                    click.echo(
-                        "Error: All remote sources must be from the same VM", err=True
-                    )
-                    sys.exit(1)
+            if (
+                first_source.session
+                and src_endpoint.session
+                and first_source.session.name != src_endpoint.session.name
+            ):
+                click.echo("Error: All remote sources must be from the same VM", err=True)
+                sys.exit(1)
 
         # Display transfer plan
         click.echo("\nTransfer Plan:")
@@ -5890,7 +5891,9 @@ def cp(
             else:
                 all_errors.extend(result.errors)
                 if len(source_endpoints) > 1:
-                    click.echo(f"  ✗ Failed: {result.errors[0] if result.errors else 'Unknown error'}")
+                    click.echo(
+                        f"  ✗ Failed: {result.errors[0] if result.errors else 'Unknown error'}"
+                    )
 
         # Display summary
         if all_errors:
@@ -7390,10 +7393,15 @@ def _doit_old_impl(
                                                 stderr=stderr,
                                             )
                                         except Exception as pipe_error:
-                                            click.echo(f"  ⚠️  Pipe execution failed: {pipe_error}", err=True)
+                                            click.echo(
+                                                f"  ⚠️  Pipe execution failed: {pipe_error}",
+                                                err=True,
+                                            )
                                             continue
 
-                                    elif any(char in cmd for char in [">", "<", ";", "&", "`", "$("]):
+                                    elif any(
+                                        char in cmd for char in [">", "<", ";", "&", "`", "$("]
+                                    ):
                                         # Redirects, command chains, and substitutions are not supported
                                         click.echo(
                                             "  ⚠️  Skipped: Redirects, command chains, and substitutions not supported",

--- a/src/azlin/modules/key_audit_logger.py
+++ b/src/azlin/modules/key_audit_logger.py
@@ -36,7 +36,6 @@ from typing import Any
 
 from azlin.network_security.security_audit import (
     AuditEvent,
-    AuditEventType,
     SecurityAuditLogger,
 )
 

--- a/tests/unit/cli/test_cp_multi_source.py
+++ b/tests/unit/cli/test_cp_multi_source.py
@@ -9,11 +9,9 @@ Tests for multiple source file support in cp command:
 - Progress indicators for multiple files
 """
 
-import subprocess
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-import pytest
 from click.testing import CliRunner
 
 from azlin.cli import main
@@ -322,8 +320,7 @@ class TestCpMultiSourceValidation:
                         # Assert
                         assert result.exit_code != 0
                         assert (
-                            "same VM" in result.output
-                            or "same location" in result.output.lower()
+                            "same VM" in result.output or "same location" in result.output.lower()
                         )
 
 

--- a/tests/unit/test_key_audit_logger.py
+++ b/tests/unit/test_key_audit_logger.py
@@ -314,9 +314,7 @@ class TestKeyAuditLogger:
 
         monkeypatch.setenv("USER", "testuser")
 
-        logger.log_key_generation(
-            vm_name="test-vm", key_path=Path("/home/user/.ssh/azlin_key")
-        )
+        logger.log_key_generation(vm_name="test-vm", key_path=Path("/home/user/.ssh/azlin_key"))
 
         event = mock_audit.log_event.call_args[0][0]
         assert event.user == "testuser"
@@ -325,9 +323,7 @@ class TestKeyAuditLogger:
         """Test that timestamps are in correct UTC format."""
         logger, mock_audit = audit_logger
 
-        logger.log_key_generation(
-            vm_name="test-vm", key_path=Path("/home/user/.ssh/azlin_key")
-        )
+        logger.log_key_generation(vm_name="test-vm", key_path=Path("/home/user/.ssh/azlin_key"))
 
         event = mock_audit.log_event.call_args[0][0]
         assert event.timestamp.tzinfo is not None  # Timezone-aware

--- a/tests/unit/test_vm_list_cache.py
+++ b/tests/unit/test_vm_list_cache.py
@@ -10,14 +10,11 @@ Tests cover:
 """
 
 import json
-import os
 import time
-from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
-from azlin.cache.vm_list_cache import VMCacheEntry, VMListCache, VMListCacheError
+from azlin.cache.vm_list_cache import VMCacheEntry, VMListCache
 
 
 class TestVMCacheEntry:
@@ -223,9 +220,13 @@ class TestVMListCache:
         temp_cache.immutable_ttl = 1  # 1 second
         temp_cache.mutable_ttl = 1
 
-        temp_cache.set_full("expired-vm", "test-rg", {"name": "expired-vm"}, {"power_state": "VM running"})
+        temp_cache.set_full(
+            "expired-vm", "test-rg", {"name": "expired-vm"}, {"power_state": "VM running"}
+        )
 
-        temp_cache.set_full("valid-vm", "test-rg", {"name": "valid-vm"}, {"power_state": "VM running"})
+        temp_cache.set_full(
+            "valid-vm", "test-rg", {"name": "valid-vm"}, {"power_state": "VM running"}
+        )
 
         # Wait for first entry to expire
         time.sleep(2)
@@ -289,7 +290,9 @@ class TestVMListCache:
         # Set entry with very short TTL
         temp_cache.immutable_ttl = 1
         temp_cache.mutable_ttl = 1
-        temp_cache.set_full("test-vm", "test-rg", {"name": "test-vm"}, {"power_state": "VM running"})
+        temp_cache.set_full(
+            "test-vm", "test-rg", {"name": "test-vm"}, {"power_state": "VM running"}
+        )
 
         # Wait for expiration
         time.sleep(2)

--- a/tests/unit/test_vm_manager_async.py
+++ b/tests/unit/test_vm_manager_async.py
@@ -8,9 +8,8 @@ Tests cover:
 - Backward compatibility with VMManager
 """
 
-import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -117,7 +116,7 @@ class TestAsyncVMManager:
         with patch("asyncio.create_subprocess_exec") as mock_exec:
             # Mock command that times out
             mock_process = AsyncMock()
-            mock_process.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+            mock_process.communicate = AsyncMock(side_effect=TimeoutError())
             mock_exec.return_value = mock_process
 
             with pytest.raises(VMManagerError, match="timed out"):
@@ -180,9 +179,7 @@ class TestAsyncVMManager:
         manager = AsyncVMManager("test-rg", cache=mock_cache)
 
         instance_data = {
-            "statuses": [
-                {"code": "PowerState/running", "displayStatus": "VM running"}
-            ]
+            "statuses": [{"code": "PowerState/running", "displayStatus": "VM running"}]
         }
 
         with patch.object(manager, "_run_az_command") as mock_cmd:
@@ -236,9 +233,7 @@ class TestAsyncVMManager:
         }
 
         instance_data = {
-            "statuses": [
-                {"code": "PowerState/running", "displayStatus": "VM running"}
-            ]
+            "statuses": [{"code": "PowerState/running", "displayStatus": "VM running"}]
         }
 
         with patch.object(manager, "_get_instance_view") as mock_view:
@@ -268,10 +263,11 @@ class TestAsyncVMManager:
             }
         ]
 
-        with patch.object(manager, "_get_vms_list") as mock_list, \
-             patch.object(manager, "_get_public_ips") as mock_ips, \
-             patch.object(manager, "_enrich_vm_with_cache") as mock_enrich:
-
+        with (
+            patch.object(manager, "_get_vms_list") as mock_list,
+            patch.object(manager, "_get_public_ips") as mock_ips,
+            patch.object(manager, "_enrich_vm_with_cache") as mock_enrich,
+        ):
             mock_list.return_value = vms_data
             mock_ips.return_value = {}
             mock_enrich.return_value = VMInfo(
@@ -308,10 +304,11 @@ class TestAsyncVMManager:
             },
         ]
 
-        with patch.object(manager, "_get_vms_list") as mock_list, \
-             patch.object(manager, "_get_public_ips") as mock_ips, \
-             patch.object(manager, "_enrich_vm_with_cache") as mock_enrich:
-
+        with (
+            patch.object(manager, "_get_vms_list") as mock_list,
+            patch.object(manager, "_get_public_ips") as mock_ips,
+            patch.object(manager, "_enrich_vm_with_cache") as mock_enrich,
+        ):
             mock_list.return_value = vms_data
             mock_ips.return_value = {}
 
@@ -344,9 +341,16 @@ class TestSyncWrappers:
         """Test synchronous list_vms_parallel wrapper."""
         with patch("azlin.vm_manager_async.AsyncVMManager") as mock_manager_class:
             mock_manager = Mock()
-            mock_manager.list_vms = AsyncMock(return_value=[
-                VMInfo(name="test-vm", resource_group="test-rg", location="westus2", power_state="VM running")
-            ])
+            mock_manager.list_vms = AsyncMock(
+                return_value=[
+                    VMInfo(
+                        name="test-vm",
+                        resource_group="test-rg",
+                        location="westus2",
+                        power_state="VM running",
+                    )
+                ]
+            )
             mock_manager_class.return_value = mock_manager
 
             vms = list_vms_parallel("test-rg", cache=mock_cache)
@@ -365,10 +369,19 @@ class TestSyncWrappers:
                 api_calls=2,
                 vms_found=1,
             )
-            mock_manager.list_vms_with_stats = AsyncMock(return_value=(
-                [VMInfo(name="test-vm", resource_group="test-rg", location="westus2", power_state="VM running")],
-                mock_stats
-            ))
+            mock_manager.list_vms_with_stats = AsyncMock(
+                return_value=(
+                    [
+                        VMInfo(
+                            name="test-vm",
+                            resource_group="test-rg",
+                            location="westus2",
+                            power_state="VM running",
+                        )
+                    ],
+                    mock_stats,
+                )
+            )
             mock_manager_class.return_value = mock_manager
 
             vms, stats = list_vms_parallel_with_stats("test-rg", cache=mock_cache)


### PR DESCRIPTION
## Summary

Implements multiple source file support for `azlin cp` command, resolving Issue #323.

Users can now copy multiple files in a single command:
```bash
azlin cp file1.txt file2.txt file3.py vm:~/
```

## Changes

### Command Interface
- Modified cp command to accept variadic arguments (`nargs=-1`)
- Parse all arguments except last as sources, last as destination
- Updated help text and examples to show multi-source usage

### Core Logic
- Loop through source files and transfer each individually
- Display progress indicators: `[1/3] Transferring file1.txt... ✓ 1.2 KB`
- Show detailed transfer plan listing all source files
- Aggregate transfer statistics across all files

### Validation
- All sources must be from same location (all local or all from same VM)
- Reject mixed local/remote sources with clear error message
- Reject sources from different VMs
- Security filtering maintained for all sources

### Backward Compatibility
- Single source usage unchanged
- All existing functionality preserved
- All 32 existing bastion cp tests pass

## Testing

Added comprehensive test suite (`test_cp_multi_source.py`):
- ✅ 11 new tests covering multi-source functionality
- ✅ Single source backward compatibility
- ✅ Multiple local files to remote VM
- ✅ Progress indicators and dry-run display  
- ✅ Validation: reject mixed local/remote sources
- ✅ Error handling for partial failures
- ✅ All existing tests pass (32 bastion cp tests)

## Examples

**Multiple local files to VM:**
```bash
$ azlin cp file1.txt file2.md file3.py amplifier-dev:~/

Transfer Plan:
  Sources: 3 files
    - file1.txt (local)
    - file2.md (local)
    - file3.py (local)
  Dest:   amplifier-dev:~/ (remote)

[1/3] Transferring file1.txt...
  ✓ 1.2 KB in 0.5s
[2/3] Transferring file2.md...
  ✓ 3.4 KB in 0.6s
[3/3] Transferring file3.py...
  ✓ 5.6 KB in 0.7s

Success! Transferred 3 files (10.2 KB) in 1.8s
```

**Single file (backward compatible):**
```bash
$ azlin cp test.txt vm:~/
Success! Transferred 1 files (1.2 KB) in 0.5s
```

## Impact

- **Priority**: P3 LOW
- **Risk**: LOW - Backward compatible, no breaking changes
- **Effort**: 1 week
- **Status**: Complete, all tests passing

Closes #323

🤖 Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>