### PR TITLE
feat: Add hostname and session name to tmux status line

### DIFF
--- a/src/azlin/vm_provisioning.py
+++ b/src/azlin/vm_provisioning.py
@@ -821,9 +821,9 @@ runcmd:
   # Tmux configuration for session name display
   - |
     cat > /home/azureuser/.tmux.conf << 'EOF'
-    # Display session name in status bar
-    set -g status-left-length 40
-    set -g status-left "#[fg=green]Session: #S #[fg=yellow]| "
+    # Display hostname and session name in status bar
+    set -g status-left-length 50
+    set -g status-left "#[fg=cyan][#h]#[fg=green] #S #[fg=yellow]| "
     set -g status-right "#[fg=cyan]%Y-%m-%d %H:%M"
 
     # Additional useful settings


### PR DESCRIPTION
## Summary

Enhanced tmux status line configuration to display both hostname and session name for better context awareness when working with Azure VMs.

## Changes

- **Modified**: `src/azlin/vm_provisioning.py` (cloud-init tmux configuration)
  - Changed status-left from `"Session: #S"` to `"[#h] #S"`
  - Increased status-left-length from 40 to 50 characters
  - Updated comment to reflect hostname + session name display

## Visual Example

**Before**: `Session: azlin | 2025-12-18 14:30`
**After**: `[azlin-vm-eastus-abc123] azlin | 2025-12-18 14:30`

## Test Plan

- [x] Configuration syntax verified
- [x] Pre-commit hooks passing
- [ ] Provision new VM and verify status line displays correctly
- [ ] Test from macOS client
- [ ] Test from Linux client
- [ ] Test from WSL client

## Technical Details

- **Tmux Variables**: `#h` = short hostname, `#S` = session name
- **Deployment**: Via cloud-init during VM provisioning
- **Location**: `/home/azureuser/.tmux.conf` on remote Azure VM
- **Scope**: Only affects NEW VMs (existing VMs unchanged)

## Testing Notes

This is a cloud-init configuration change that only affects NEW VMs. Full testing requires:
1. Provisioning a new VM with this change
2. Connecting via `azlin ssh <vm-name>`
3. Verifying the tmux status line shows: `[hostname] session-name |`

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)