### PR TITLE
fix: Status command not showing VMs + Add NFS quota monitoring

### DIFF
--- a/src/azlin/cli.py
+++ b/src/azlin/cli.py
@@ -5168,9 +5168,7 @@ def connect(
                 nfs_info = NFSQuotaManager.check_vm_nfs_storage(vm_identifier, rg)
                 if nfs_info:
                     storage_account, share_name, _ = nfs_info
-                    quota_info = NFSQuotaManager.get_nfs_quota_info(
-                        storage_account, share_name, rg
-                    )
+                    quota_info = NFSQuotaManager.get_nfs_quota_info(storage_account, share_name, rg)
                     warning = NFSQuotaManager.check_quota_warning(quota_info)
 
                     if warning.is_warning and not yes:

--- a/src/azlin/modules/nfs_quota_manager.py
+++ b/src/azlin/modules/nfs_quota_manager.py
@@ -264,9 +264,7 @@ class NFSQuotaManager:
         )
 
     @classmethod
-    def prompt_and_expand_quota(
-        cls, quota_info: QuotaInfo, expansion_gb: int = 100
-    ) -> bool:
+    def prompt_and_expand_quota(cls, quota_info: QuotaInfo, expansion_gb: int = 100) -> bool:
         """Prompt user and expand quota if confirmed.
 
         Args:
@@ -283,7 +281,7 @@ class NFSQuotaManager:
         cost_increase = expansion_gb * cls.COST_PER_GB_PREMIUM
         new_quota = quota_info.quota_gb + expansion_gb
 
-        click.echo(f"\nNFS Storage Quota Expansion:")
+        click.echo("\nNFS Storage Quota Expansion:")
         click.echo(f"  Storage: {quota_info.storage_account}/{quota_info.share_name}")
         click.echo(f"  Current: {quota_info.quota_gb}GB")
         click.echo(f"  New: {new_quota}GB (+{expansion_gb}GB)")
@@ -403,8 +401,8 @@ class NFSQuotaManager:
 
 # Public API
 __all__ = [
+    "ExpansionResult",
     "NFSQuotaManager",
     "QuotaInfo",
     "QuotaWarning",
-    "ExpansionResult",
 ]


### PR DESCRIPTION
## Summary

This PR fixes two critical issues discovered during VM connectivity troubleshooting:

### 1. Status Command Bug (Critical)

**Problem:**
- `azlin status` showed "No VMs found"  
- `azlin list` worked correctly and showed all VMs

**Root Cause:**
- `status` used `VMManager.list_vms()` + `filter_by_prefix(vms, "azlin")` 
- This filtered for VMs starting with "azlin-" prefix
- User's VMs (amplihack, simserv-dev, atg-dev2, haymaker) don't match prefix
- Result: All VMs filtered out → "No VMs found"

**Fix:**
- Changed `status` to use `TagManager.list_managed_vms()` 
- Filters by `tags."managed-by"=='azlin'` (same as list)
- Now consistent with list command behavior

**Files Changed:**
- `src/azlin/cli.py:6650-6653` - Use TagManager instead of VMManager + prefix filter

---

### 2. NFS Quota Monitoring (Prevention)

**Problem:**
- NFS shared home directory (rysweethomedir17) filled to 100% (100GB/100GB)
- `/home/azureuser/.ssh/authorized_keys` became empty (couldn't write - no space)
- SSH authentication failed for ALL VMs using shared NFS
- Bastion worked, but SSH rejected connections
- Created deadlock: Can't SSH to clean disk, can't clean disk without SSH

**Solution:**
- New module: `src/azlin/modules/nfs_quota_manager.py`
- Monitors NFS quota during `azlin connect`
- Alerts when <10% free (90% threshold)
- Interactive prompt to expand quota
- Uses `az storage share-rm update` (proven working)
- Shows cost transparency (+$15.36/month per 100GB)

**User Experience:**
```bash
$ azlin connect amplihack

⚠️  NFS quota warning: 97.0% used (97.0GB / 100GB)
   Available: 3.0GB remaining

NFS Storage Quota Expansion:
  Storage: rysweethomedir17/home
  Current: 100GB
  New: 200GB (+100GB)
  Cost increase: +$15.36/month

Expand quota now? [Y/n]:
```

**Integration Points:**
- `azlin connect` - Check before SSH connection (src/azlin/cli.py:5163-5193)
- Future: `azlin new`, `azlin status`

---

## Test Plan

- [ ] Test `azlin status` shows VMs correctly (matches `azlin list`)
- [ ] Test quota monitoring on VM with NFS storage
- [ ] Test quota expansion prompt and execution
- [ ] Test graceful degradation if quota check fails (shouldn't block connection)
- [ ] Verify no impact on VMs without NFS storage

## Related

- Investigation: Full disk caused SSH failures despite perfect infrastructure
- Resolution: `az storage share-rm update --quota 200` immediately freed space
- Restored SSH access to both VMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)