### PR TITLE
fix: azlin cp remote path validation bug (Issue #507)

### DIFF
--- a/src/azlin/cli.py
+++ b/src/azlin/cli.py
@@ -5987,7 +5987,9 @@ def cp(
 
         if dest_session_name is None:
             # Local destination - resolve from cwd, allow absolute paths
-            dest_path = PathParser.parse_and_validate(dest_path_str, is_local=True)
+            dest_path = PathParser.parse_and_validate(
+                dest_path_str, allow_absolute=True, is_local=True
+            )
             dest_endpoint = TransferEndpoint(path=dest_path, session=None)
         else:
             # Remote destination
@@ -6003,7 +6005,10 @@ def cp(
 
             # Parse remote path (allow relative to home)
             dest_path = PathParser.parse_and_validate(
-                dest_path_str, allow_absolute=True, base_dir=Path("/home") / vm_session.user
+                dest_path_str,
+                allow_absolute=True,
+                base_dir=Path("/home") / vm_session.user,
+                is_local=False,  # Remote path - don't validate against local filesystem
             )
 
             dest_endpoint = TransferEndpoint(path=dest_path, session=vm_session)
@@ -6015,7 +6020,9 @@ def cp(
 
             if source_session_name is None:
                 # Local source - resolve from cwd, allow absolute paths
-                source_path = PathParser.parse_and_validate(source_path_str, is_local=True)
+                source_path = PathParser.parse_and_validate(
+                    source_path_str, allow_absolute=True, is_local=True
+                )
                 source_endpoint = TransferEndpoint(path=source_path, session=None)
             else:
                 # Remote source
@@ -6039,7 +6046,10 @@ def cp(
 
                 # Parse remote path (allow relative to home)
                 source_path = PathParser.parse_and_validate(
-                    source_path_str, allow_absolute=True, base_dir=Path("/home") / vm_session.user
+                    source_path_str,
+                    allow_absolute=True,
+                    base_dir=Path("/home") / vm_session.user,
+                    is_local=False,  # Remote path - don't validate against local filesystem
                 )
 
                 source_endpoint = TransferEndpoint(path=source_path, session=vm_session)


### PR DESCRIPTION
## Summary

Fixes bug where `azlin cp` failed with path validation error when copying files from VMs, even with valid remote paths.

## Problem

\`\`\`bash
azlin cp amplihack2:~/src/amplihack ~/src/test
# Error: Path escapes allowed directory: /System/Volumes/Data/home/azureuser/src/amplihack

azlin cp amplihack2:/home/azureuser/src/amplihack ~/src/test  
# Error: Path escapes allowed directory: /System/Volumes/Data/home/azureuser/src/amplihack
\`\`\`

## Root Cause

**Remote VM paths were being validated against the LOCAL filesystem:**

1. User provides remote path: `/home/azureuser/src/amplihack`
2. Code creates Path object: `Path("/home/azureuser/src/amplihack")`
3. Path.resolve() called on macOS resolves to: `/System/Volumes/Data/home/azureuser/src/amplihack`
4. Security check validates if within `/Users/ryan` (local HOME_DIR)
5. Fails: `/System/Volumes/Data/home/...` is not within `/Users/ryan`
6. Error: "Path escapes allowed directory"

**The bug:** Remote paths were being resolved against the local macOS filesystem, then validated against local home directory boundaries.

## Solution

**Separate validation for local vs remote paths:**

- **Remote paths** (`is_local=False`):
  - Skip filesystem resolution (no `.resolve()`)
  - Skip boundary validation (VM handles security)
  - Skip symlink checks (would check local filesystem)
  - Skip credential file checks (would check local filesystem)
  - Only check: path traversal patterns (..), shell metacharacters, null bytes

- **Local paths** (`is_local=True`):
  - Full validation as before
  - Resolve against filesystem
  - Check boundaries, symlinks, credentials

**Changes:**
1. `src/azlin/modules/file_transfer/path_parser.py`:
   - Early return for remote paths with minimal validation
   - Skip all filesystem-dependent checks for remote paths

2. `src/azlin/cli.py`:
   - Explicitly pass `is_local=False` when parsing remote paths (lines 6009, 6048)

## Test Plan

- [ ] Test `azlin cp vm:/home/azureuser/src/file ~/dest` - should work
- [ ] Test `azlin cp vm:src/file ~/dest` - should work (relative path)
- [ ] Test `azlin cp vm:~/src/file ~/dest` - should work (~ expansion)
- [ ] Test `azlin cp ~/src/file vm:/home/azureuser/dest` - should work (reverse)
- [ ] Test local to local - should still enforce security
- [ ] Test path traversal attack - should still block

## Security

**No security regression:**
- Local paths still fully validated
- Path traversal still detected for both local and remote
- Shell metacharacters still blocked
- Remote security delegated to VM (correct - VM has its own permissions)

Fixes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)