### PR TITLE
fix: Disable sshfs auto-mount prompt (not reliable on macOS)

### DIFF
--- a/src/azlin/vm_connector.py
+++ b/src/azlin/vm_connector.py
@@ -370,14 +370,15 @@ class VMConnector:
                     f"(127.0.0.1:{ssh_port})"
                 )
 
-                # Offer to mount NFS storage locally via sshfs (if VM uses NFS)
-                if not skip_prompts and not remote_command:
-                    cls._offer_sshfs_mount(
-                        vm_name=conn_info.vm_name,
-                        resource_group=conn_info.resource_group,
-                        tunnel_port=ssh_port,
-                        ssh_key=conn_info.ssh_key_path,
-                    )
+                # DISABLED: sshfs auto-mount feature (not working reliably on macOS)
+                # TODO: Re-enable when sshfs-mac installation is more reliable
+                # if not skip_prompts and not remote_command:
+                #     cls._offer_sshfs_mount(
+                #         vm_name=conn_info.vm_name,
+                #         resource_group=conn_info.resource_group,
+                #         tunnel_port=ssh_port,
+                #         ssh_key=conn_info.ssh_key_path,
+                #     )
 
             # Route connection: remote command -> SSHConnector, interactive+reconnect -> SSHReconnectHandler, interactive -> TerminalLauncher
             if remote_command is not None:


### PR DESCRIPTION
## Summary

Temporarily disables the sshfs auto-mount prompt that was added in PR #505. The feature requires sshfs-mac + macFUSE installation which is proving unreliable.

## Problem

The sshfs auto-mount feature prompts users to mount NFS storage locally, but:
- Requires `brew tap gromgit/fuse && brew install sshfs-mac`
- Requires macFUSE kernel extension approval
- Standard `brew install sshfs` fails (Linux-only)
- Many users hit installation barriers

## Solution

**Disable the automatic prompt** by commenting out the `_offer_sshfs_mount()` call in `vm_connector.py` lines 373-381.

The feature infrastructure remains:
- `sshfs_manager.py` module kept for future use
- `_offer_sshfs_mount()` method kept but not called
- `docs/SSHFS_MACOS_INSTALL.md` documentation preserved
- Can be re-enabled with one-line change when installation improves

## Alternatives Available

Users can still transfer files:
- ✅ **azlin cp** - Now fixed in PR #509 (recommended)
- ✅ **Direct SSH** - `azlin connect vm` and work remotely
- ✅ **Manual sshfs** - Follow docs/SSHFS_MACOS_INSTALL.md if desired

## Testing

- [ ] Test azlin connect - should NOT prompt for NFS mount
- [ ] Verify connection still works normally
- [ ] Confirm no regression in bastion functionality

## Related

- PR #505: Original sshfs feature (merged)
- PR #509: azlin cp fix (merged) - provides alternative file transfer
- docs/SSHFS_MACOS_INSTALL.md: Manual installation guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)