### PR TITLE
fix: reduce VMKeySync auto-sync timeout from 30s to 5s

### DIFF
--- a/src/azlin/vm_connector.py
+++ b/src/azlin/vm_connector.py
@@ -288,11 +288,13 @@ class VMConnector:
                         # Instantiate VMKeySync with config dict
                         sync_manager = VMKeySync(config.to_dict())
 
-                        # Call instance method without config parameter
+                        # Call instance method with reduced timeout (5s instead of 30s)
+                        # For first connections, sync will likely timeout anyway
                         sync_manager.ensure_key_authorized(
                             vm_name=conn_info.vm_name,
                             resource_group=conn_info.resource_group,
                             public_key=public_key,
+                            timeout=5,  # Reduced from 30s default for faster failure
                         )
                         logger.info("SSH key auto-sync completed successfully")
             except Exception as e:


### PR DESCRIPTION
## Problem

SSH key auto-sync uses 30s timeout for `az vm run-command invoke`, adding significant delay to EVERY first connection even when it times out and continues gracefully.

Fixes #525

## Evidence

Connection log shows 30s wait:
```
Auto-syncing SSH key to VM authorized_keys: simserv-dev
[30 second wait]
Sync operation timed out for VM simserv-dev
SSH key auto-sync completed successfully
```

## Solution

Reduce timeout from 30s to 5s:
- For new VMs, auto-sync will likely fail anyway (can't connect yet)
- 5s detects failure quickly
- Graceful handling continues on timeout  
- 25s faster connections

## Changes

Modified `vm_connector.py` line 293-298:
- Pass `timeout=5` to `ensure_key_authorized()`
- Reduces from DEFAULT_TIMEOUT (30s) to 5s

## Testing Plan

Test connection time before and after:
```bash
uvx --from git+https://github.com/rysweet/azlin@feat/issue-525-keysync-timeout azlin connect simserv-dev -y -- uptime
```

Expected: Connection completes in ~10-15s (vs 35-40s before)

🤖 Generated with Claude Code