### PR TITLE
fix: close stdin for non-interactive SSH to prevent hangs

### DIFF
--- a/src/azlin/modules/ssh_connector.py
+++ b/src/azlin/modules/ssh_connector.py
@@ -118,7 +118,9 @@ class SSHConnector:
 
         try:
             # Execute SSH (blocking until session ends)
-            result = subprocess.run(ssh_args)
+            # Close stdin for non-interactive sessions to prevent hangs when stdin unavailable
+            stdin_mode = subprocess.DEVNULL if remote_command else None
+            result = subprocess.run(ssh_args, stdin=stdin_mode)
 
             if result.returncode == 0:
                 logger.info("SSH session ended successfully")


### PR DESCRIPTION
## Problem

`azlin connect <vm> -y -- <command>` hangs when run through uvx or background processes because SSH subprocess waits for stdin that is closed/unavailable.

Fixes #527

## Evidence

SSH starts successfully but hangs after host key added:
```
Connecting to azureuser@127.0.0.1...
Pseudo-terminal will not be allocated because stdin is not a terminal.
Warning: Permanently added '[127.0.0.1]:50006' (ED25519) to the list of known hosts.
[HANGS - SSH waiting for stdin]
```

## Root Cause

`SSHConnector.connect()` line 121:
```python
result = subprocess.run(ssh_args)  # stdin defaults to parent's stdin
```

When parent has no stdin (uvx, background), SSH blocks indefinitely.

## Solution

Explicitly close stdin for non-interactive SSH:
```python
stdin_mode = subprocess.DEVNULL if remote_command else None
result = subprocess.run(ssh_args, stdin=stdin_mode)
```

## Changes

- Close stdin (`DEVNULL`) for remote command execution
- Keep stdin open (`None`) for interactive/tmux sessions

## Testing Needed

```bash
uvx --from git+https://github.com/rysweet/azlin@feat/issue-527-ssh-stdin-hang azlin connect simserv-dev -y -- uptime
```

Expected: Command completes successfully, returns VM uptime

🤖 Generated with Claude Code