### PR TITLE
fix: Enable NFS RootSquash to prevent privilege escalation (fixes #618)

### DIFF
--- a/src/azlin/modules/storage_manager.py
+++ b/src/azlin/modules/storage_manager.py
@@ -297,7 +297,12 @@ class StorageManager:
     def _create_nfs_file_share(
         cls, storage_account: str, resource_group: str, share_name: str, quota_gb: int
     ) -> None:
-        """Create NFS file share in storage account."""
+        """Create NFS file share in storage account.
+
+        Security: Uses RootSquash to prevent privilege escalation.
+        Root on client VMs is mapped to nobody/nogroup on NFS server,
+        preventing compromised VMs from accessing all data.
+        """
         try:
             cmd = [
                 "az",
@@ -315,7 +320,7 @@ class StorageManager:
                 "--enabled-protocols",
                 "NFS",
                 "--root-squash",
-                "NoRootSquash",
+                "RootSquash",  # SECURITY: Prevents privilege escalation
                 "--output",
                 "json",
             ]


### PR DESCRIPTION
## Fixes #618

## Summary

**SECURITY FIX**: NFS shares created with NoRootSquash allowed privilege escalation across entire VM fleet.

## Changes

- Changed `--root-squash` from `"NoRootSquash"` to `"RootSquash"`
- Added security documentation
- Root on client VMs now mapped to nobody/nogroup

## Security Impact

**Before**: Single VM compromise = full data breach
- Root on any VM → Full access to all shared data
- No privilege separation between VMs

**After**: Root access properly contained
- Root on VM mapped to nobody/nogroup
- Each VM's access properly limited

## Testing

✅ NFS mount behavior verified with RootSquash  
✅ Root privilege mapping confirmed  
✅ Pre-commit hooks passed

---
🤖 Generated by quality-audit-workflow