### PR TITLE
fix: Use Azure AD auth instead of storage keys (fixes #619)

### DIFF
--- a/src/azlin/modules/storage_manager.py
+++ b/src/azlin/modules/storage_manager.py
@@ -774,27 +774,11 @@ class StorageManager:
                 temp_path = Path(temp_file.name)
 
             try:
-                # Get storage account key for authentication
-                key_cmd = [
-                    "az",
-                    "storage",
-                    "account",
-                    "keys",
-                    "list",
-                    "--account-name",
-                    storage_account,
-                    "--resource-group",
-                    resource_group,
-                    "--query",
-                    "[0].value",
-                    "--output",
-                    "tsv",
-                ]
-
-                key_result = subprocess.run(
-                    key_cmd, capture_output=True, text=True, check=True, timeout=30
-                )
-                account_key = key_result.stdout.strip()
+                # SECURITY: Use Azure AD authentication instead of account keys
+                # This prevents credential exposure in command-line arguments,
+                # process listings, shell history, and logs.
+                # Requires user to be logged in with 'az login' and have
+                # appropriate RBAC permissions (Storage File Data SMB Share Contributor)
 
                 # Create .ssh directory in share
                 mkdir_cmd = [
@@ -808,8 +792,8 @@ class StorageManager:
                     share_name,
                     "--account-name",
                     storage_account,
-                    "--account-key",
-                    account_key,
+                    "--auth-mode",
+                    "login",  # Use Azure AD auth (no keys exposed)
                     "--output",
                     "none",
                 ]
@@ -830,8 +814,8 @@ class StorageManager:
                     ".ssh/authorized_keys",
                     "--account-name",
                     storage_account,
-                    "--account-key",
-                    account_key,
+                    "--auth-mode",
+                    "login",  # Use Azure AD auth (no keys exposed)
                     "--output",
                     "none",
                 ]


### PR DESCRIPTION
## Fixes #619

## Summary

**SECURITY FIX**: Storage account keys exposed in command-line arguments.

## Changes

- Removed account key retrieval
- Use `--auth-mode login` (Azure AD) instead of `--account-key`
- No credentials in command-line arguments

## Security Impact

**Before**: Credential leakage
- Keys visible in `ps aux`
- Keys in shell history
- Keys in error logs

**After**: No credential exposure
- Azure AD tokens used (short-lived)
- No keys in command-line
- No keys in logs

## Requirements

✅ User logged in with `az login`  
✅ RBAC: Storage File Data SMB Share Contributor

---
🤖 Generated by quality-audit-workflow