### PR TITLE
feat: Add logs command for viewing VM logs

### DIFF
--- a/src/azlin/cli.py
+++ b/src/azlin/cli.py
@@ -73,6 +73,8 @@ from azlin.commands import (
     kill,
     killall,
     list_command,
+    # Logs Commands
+    logs,
     # Provisioning Commands
     new,
     # System Commands
@@ -465,6 +467,9 @@ main.add_command(session_group)  # Session save/load/list commands
 main.add_command(w)
 main.add_command(ps)
 main.add_command(top)
+
+# Register logs command (Issue #153)
+main.add_command(logs)
 
 # Register batch commands (Issue #423 refactor)
 main.add_command(batch)

--- a/src/azlin/commands/__init__.py
+++ b/src/azlin/commands/__init__.py
@@ -37,6 +37,9 @@ from .keys import keys_group
 # Lifecycle
 from .lifecycle import destroy, kill, killall, prune, start, stop
 
+# Logs
+from .logs import logs
+
 # Monitoring (split into focused modules - Issue #423)
 from .monitoring_list import get_vm_session_pairs, list_command
 from .monitoring_ps import ps
@@ -106,6 +109,8 @@ __all__ = [
     "killall",
     # Monitoring
     "list_command",
+    # Logs
+    "logs",
     "new",
     # System
     "os_update",

--- a/src/azlin/commands/logs.py
+++ b/src/azlin/commands/logs.py
@@ -1,0 +1,205 @@
+"""Logs command for azlin.
+
+View VM logs (cloud-init, syslog, auth) without a persistent SSH connection.
+
+Commands:
+    logs - View logs from a VM
+"""
+
+import logging
+import subprocess
+import sys
+
+import click
+
+from azlin.cli_helpers import _get_ssh_config_for_vm
+from azlin.config_manager import ConfigError
+from azlin.modules.ssh_connector import SSHConfig
+from azlin.modules.ssh_keys import SSHKeyError
+from azlin.remote_exec import RemoteExecError, RemoteExecutor
+from azlin.vm_manager import VMManagerError
+
+logger = logging.getLogger(__name__)
+
+# Map of log type to the remote command that fetches it.
+LOG_TYPE_COMMANDS: dict[str, str] = {
+    "cloud-init": "sudo cat /var/log/cloud-init-output.log",
+    "syslog": "sudo journalctl --no-pager",
+    "auth": "sudo journalctl --no-pager -u ssh",
+}
+
+# Follow-mode commands (streaming, never terminates on its own).
+LOG_TYPE_FOLLOW_COMMANDS: dict[str, str] = {
+    "cloud-init": "sudo tail -f /var/log/cloud-init-output.log",
+    "syslog": "sudo journalctl -f",
+    "auth": "sudo journalctl -f -u ssh",
+}
+
+VALID_LOG_TYPES = list(LOG_TYPE_COMMANDS.keys())
+
+
+def _build_log_command(log_type: str, lines: int, follow: bool) -> str:
+    """Build the remote command string for the requested log type.
+
+    Args:
+        log_type: One of cloud-init, syslog, auth.
+        lines: Number of trailing lines to show.
+        follow: Whether to stream new lines continuously.
+
+    Returns:
+        Shell command string to execute on the remote VM.
+    """
+    if follow:
+        return LOG_TYPE_FOLLOW_COMMANDS[log_type]
+
+    base = LOG_TYPE_COMMANDS[log_type]
+
+    # Pipe through tail to limit output.
+    if log_type == "cloud-init":
+        return f"{base} | tail -n {lines}"
+    # journalctl supports -n natively.
+    return f"{base} -n {lines}"
+
+
+def _stream_ssh_output(ssh_config: SSHConfig, command: str) -> int:
+    """Run an SSH command and stream stdout/stderr to the terminal in real time.
+
+    Used for --follow mode where output never terminates on its own.
+
+    Returns:
+        Process exit code (130 on KeyboardInterrupt).
+    """
+    ssh_cmd = [
+        "ssh",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "LogLevel=ERROR",
+        "-o",
+        "ConnectTimeout=10",
+        "-i",
+        str(ssh_config.key_path),
+        "-p",
+        str(ssh_config.port),
+        f"{ssh_config.user}@{ssh_config.host}",
+        command,
+    ]
+
+    process = subprocess.Popen(
+        ssh_cmd,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        text=True,
+    )
+    try:
+        process.wait()
+        return process.returncode
+    except KeyboardInterrupt:
+        process.terminate()
+        process.wait()
+        click.echo()  # Newline after ^C
+        return 130
+
+
+@click.command(name="logs")
+@click.argument("vm_identifier", type=str)
+@click.option(
+    "--lines",
+    "-n",
+    default=50,
+    show_default=True,
+    help="Number of log lines to show.",
+    type=int,
+)
+@click.option(
+    "--follow",
+    "-f",
+    is_flag=True,
+    default=False,
+    help="Follow log output (like tail -f). Press Ctrl+C to stop.",
+)
+@click.option(
+    "--type",
+    "-t",
+    "log_type",
+    default="cloud-init",
+    show_default=True,
+    type=click.Choice(VALID_LOG_TYPES, case_sensitive=False),
+    help="Type of log to view.",
+)
+@click.option("--resource-group", "--rg", help="Resource group", type=str)
+@click.option("--config", help="Config file path", type=click.Path())
+def logs(
+    vm_identifier: str,
+    lines: int,
+    follow: bool,
+    log_type: str,
+    resource_group: str | None,
+    config: str | None,
+) -> None:
+    """View VM logs (cloud-init, syslog, auth).
+
+    Connects to the VM via SSH and retrieves the requested log output.
+
+    VM_IDENTIFIER can be:
+    - Session name (resolved to VM)
+    - VM name (requires --resource-group or default config)
+    - IP address (direct connection)
+
+    \b
+    Examples:
+        azlin logs my-vm                          # Last 50 lines of cloud-init log
+        azlin logs my-vm -n 200                   # Last 200 lines
+        azlin logs my-vm --type syslog            # System journal
+        azlin logs my-vm --type auth              # SSH / auth journal
+        azlin logs my-vm --follow                 # Stream cloud-init log
+        azlin logs my-vm -t syslog -f             # Stream system journal
+    """
+    try:
+        ssh_config = _get_ssh_config_for_vm(vm_identifier, resource_group, config)
+
+        remote_command = _build_log_command(log_type, lines, follow)
+
+        if follow:
+            click.echo(f"Streaming {log_type} logs from {vm_identifier} (Ctrl+C to stop)...")
+            exit_code = _stream_ssh_output(ssh_config, remote_command)
+            sys.exit(exit_code)
+        else:
+            click.echo(f"Fetching {log_type} logs from {vm_identifier} (last {lines} lines)...\n")
+            result = RemoteExecutor.execute_command(
+                ssh_config,
+                remote_command,
+                timeout=30,
+            )
+
+            if result.stdout:
+                click.echo(result.stdout)
+            if result.stderr:
+                click.echo(result.stderr, err=True)
+
+            if not result.success:
+                sys.exit(result.exit_code)
+
+    except RemoteExecError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+    except SSHKeyError as e:
+        click.echo(f"SSH key error: {e}", err=True)
+        sys.exit(1)
+    except VMManagerError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+    except ConfigError as e:
+        click.echo(f"Config error: {e}", err=True)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        click.echo("\nCancelled.")
+        sys.exit(130)
+    except Exception as e:
+        click.echo(f"Unexpected error: {e}", err=True)
+        sys.exit(1)
+
+
+__all__ = ["logs"]

--- a/tests/unit/cli/test_logs_command.py
+++ b/tests/unit/cli/test_logs_command.py
@@ -1,0 +1,183 @@
+"""Unit tests for the azlin logs command.
+
+Tests cover:
+- CLI syntax validation (help, options, argument handling)
+- Log command building logic
+- Error handling for invalid log types
+"""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from azlin.cli import main
+from azlin.commands.logs import _build_log_command
+
+
+class TestLogsCommandSyntax:
+    """Test CLI syntax for 'azlin logs' command."""
+
+    def test_logs_help(self):
+        """Test 'azlin logs --help' displays usage."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["logs", "--help"])
+
+        assert result.exit_code == 0
+        assert "VM_IDENTIFIER" in result.output
+        assert "--lines" in result.output
+        assert "--follow" in result.output
+        assert "--type" in result.output
+        assert "cloud-init" in result.output
+
+    def test_logs_no_args_fails(self):
+        """Test 'azlin logs' with no VM identifier fails."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["logs"])
+
+        assert result.exit_code != 0
+        assert "Missing argument" in result.output
+
+    def test_logs_invalid_type_rejected(self):
+        """Test invalid --type value is rejected by click."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["logs", "myvm", "--type", "invalid"])
+
+        assert result.exit_code != 0
+        assert "Invalid value" in result.output or "invalid" in result.output.lower()
+
+    def test_logs_valid_types_accepted(self):
+        """Test all valid log types are listed in help."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["logs", "--help"])
+
+        assert "cloud-init" in result.output
+        assert "syslog" in result.output
+        assert "auth" in result.output
+
+
+class TestBuildLogCommand:
+    """Test the _build_log_command helper."""
+
+    def test_cloud_init_default(self):
+        """cloud-init uses cat + tail."""
+        cmd = _build_log_command("cloud-init", 50, follow=False)
+        assert "cloud-init-output.log" in cmd
+        assert "tail -n 50" in cmd
+
+    def test_cloud_init_custom_lines(self):
+        """cloud-init respects custom line count."""
+        cmd = _build_log_command("cloud-init", 200, follow=False)
+        assert "tail -n 200" in cmd
+
+    def test_syslog_uses_journalctl(self):
+        """syslog uses journalctl with -n."""
+        cmd = _build_log_command("syslog", 100, follow=False)
+        assert "journalctl" in cmd
+        assert "-n 100" in cmd
+        assert "--no-pager" in cmd
+
+    def test_auth_uses_journalctl_ssh(self):
+        """auth targets ssh unit in journalctl."""
+        cmd = _build_log_command("auth", 50, follow=False)
+        assert "journalctl" in cmd
+        assert "-u ssh" in cmd
+        assert "-n 50" in cmd
+
+    def test_follow_cloud_init(self):
+        """Follow mode uses tail -f for cloud-init."""
+        cmd = _build_log_command("cloud-init", 50, follow=True)
+        assert "tail -f" in cmd
+        assert "cloud-init-output.log" in cmd
+
+    def test_follow_syslog(self):
+        """Follow mode uses journalctl -f for syslog."""
+        cmd = _build_log_command("syslog", 50, follow=True)
+        assert "journalctl -f" in cmd
+
+    def test_follow_auth(self):
+        """Follow mode uses journalctl -f -u ssh for auth."""
+        cmd = _build_log_command("auth", 50, follow=True)
+        assert "journalctl -f" in cmd
+        assert "-u ssh" in cmd
+
+
+class TestLogsCommandExecution:
+    """Test logs command execution with mocked SSH."""
+
+    @patch("azlin.commands.logs._get_ssh_config_for_vm")
+    @patch("azlin.commands.logs.RemoteExecutor")
+    def test_logs_fetches_cloud_init_by_default(self, mock_executor_cls, mock_get_ssh):
+        """Default invocation fetches cloud-init log."""
+        mock_ssh_config = MagicMock()
+        mock_get_ssh.return_value = mock_ssh_config
+
+        mock_result = MagicMock()
+        mock_result.stdout = "cloud-init log output here"
+        mock_result.stderr = ""
+        mock_result.success = True
+        mock_executor_cls.execute_command.return_value = mock_result
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["logs", "test-vm"])
+
+        assert result.exit_code == 0
+        assert "cloud-init log output here" in result.output
+        mock_get_ssh.assert_called_once_with("test-vm", None, None)
+
+        # Verify the remote command targets cloud-init
+        call_args = mock_executor_cls.execute_command.call_args
+        remote_cmd = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("command", "")
+        assert "cloud-init" in remote_cmd
+
+    @patch("azlin.commands.logs._get_ssh_config_for_vm")
+    @patch("azlin.commands.logs.RemoteExecutor")
+    def test_logs_with_syslog_type(self, mock_executor_cls, mock_get_ssh):
+        """--type syslog fetches system journal."""
+        mock_ssh_config = MagicMock()
+        mock_get_ssh.return_value = mock_ssh_config
+
+        mock_result = MagicMock()
+        mock_result.stdout = "syslog output"
+        mock_result.stderr = ""
+        mock_result.success = True
+        mock_executor_cls.execute_command.return_value = mock_result
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["logs", "test-vm", "--type", "syslog"])
+
+        assert result.exit_code == 0
+        call_args = mock_executor_cls.execute_command.call_args
+        remote_cmd = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("command", "")
+        assert "journalctl" in remote_cmd
+
+    @patch("azlin.commands.logs._get_ssh_config_for_vm")
+    @patch("azlin.commands.logs.RemoteExecutor")
+    def test_logs_custom_lines(self, mock_executor_cls, mock_get_ssh):
+        """--lines option passes through to remote command."""
+        mock_ssh_config = MagicMock()
+        mock_get_ssh.return_value = mock_ssh_config
+
+        mock_result = MagicMock()
+        mock_result.stdout = "output"
+        mock_result.stderr = ""
+        mock_result.success = True
+        mock_executor_cls.execute_command.return_value = mock_result
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["logs", "test-vm", "-n", "200"])
+
+        assert result.exit_code == 0
+        call_args = mock_executor_cls.execute_command.call_args
+        remote_cmd = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("command", "")
+        assert "200" in remote_cmd
+
+    @patch("azlin.commands.logs._get_ssh_config_for_vm")
+    def test_logs_ssh_key_error(self, mock_get_ssh):
+        """SSHKeyError produces a clear error message."""
+
+        mock_get_ssh.side_effect = SystemExit(1)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["logs", "bad-vm"])
+
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary
- Adds `azlin logs <vm>` command that SSHs into a VM and retrieves log output
- Supports three log types via `--type`: `cloud-init` (default), `syslog`, `auth`
- Supports `--lines` / `-n` to control number of lines (default 50)
- Supports `--follow` / `-f` for real-time streaming (like `tail -f`)
- Follows existing SSH command patterns (`_get_ssh_config_for_vm`, `RemoteExecutor`)

Closes #153

## Changes
- **New**: `src/azlin/commands/logs.py` - logs command implementation
- **Modified**: `src/azlin/commands/__init__.py` - register logs import
- **Modified**: `src/azlin/cli.py` - register logs command with CLI group
- **New**: `tests/unit/cli/test_logs_command.py` - 15 unit tests

## Test plan
- [x] 15 unit tests pass (CLI syntax, command builder logic, mocked execution)
- [x] Pre-commit hooks pass (ruff, pyright, formatting)
- [ ] Manual test: `azlin logs <vm>` fetches cloud-init output
- [ ] Manual test: `azlin logs <vm> --type syslog` fetches journalctl output
- [ ] Manual test: `azlin logs <vm> --follow` streams in real time

🤖 Generated with [Claude Code](https://claude.com/claude-code)