### PR TITLE
feat: Standardize Azure CLI subprocess error handling with retry (#431)

### DIFF
--- a/src/azlin/azure_cli_executor.py
+++ b/src/azlin/azure_cli_executor.py
@@ -1,0 +1,67 @@
+"""Standardized Azure CLI subprocess execution with retry logic.
+
+Provides run_az_command() — a thin wrapper around subprocess.run that adds
+automatic retry with exponential backoff for transient Azure CLI failures
+(CalledProcessError, TimeoutExpired). Uses the existing retry_handler
+infrastructure so retry behavior is consistent across the codebase.
+
+Usage:
+    from azlin.azure_cli_executor import run_az_command
+
+    # Drop-in replacement for subprocess.run(["az", ...], ...)
+    result = run_az_command(["az", "vm", "list", "--output", "json"])
+
+    # With custom timeout and retry attempts
+    result = run_az_command(["az", "vm", "create", ...], timeout=300, max_attempts=5)
+"""
+
+import logging
+import subprocess
+
+from azlin.retry_config import get_retry_config
+from azlin.retry_handler import retry_with_exponential_backoff
+
+logger = logging.getLogger(__name__)
+
+
+def run_az_command(
+    cmd: list[str],
+    *,
+    timeout: int = 30,
+    max_attempts: int | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Execute an Azure CLI command with retry logic.
+
+    Drop-in replacement for subprocess.run(["az", ...]) that adds automatic
+    retry with exponential backoff on transient failures.
+
+    Args:
+        cmd: Command list starting with "az", e.g. ["az", "vm", "list"]
+        timeout: Subprocess timeout in seconds (default: 30)
+        max_attempts: Number of retry attempts (default: from RetryConfig)
+        check: If True, raise CalledProcessError on non-zero exit (default: True)
+
+    Returns:
+        subprocess.CompletedProcess with stdout/stderr
+
+    Raises:
+        subprocess.CalledProcessError: After retries exhausted (when check=True)
+        subprocess.TimeoutExpired: After retries exhausted
+    """
+    config = get_retry_config()
+    attempts = max_attempts or config.azure_cli_max_attempts
+
+    @retry_with_exponential_backoff(
+        max_attempts=attempts,
+        initial_delay=config.azure_cli_initial_delay,
+        max_delay=config.azure_cli_max_delay,
+        retryable_exceptions=(subprocess.CalledProcessError, subprocess.TimeoutExpired),
+    )
+    def _run() -> subprocess.CompletedProcess[str]:
+        return subprocess.run(cmd, capture_output=True, text=True, check=check, timeout=timeout)
+
+    return _run()
+
+
+__all__ = ["run_az_command"]

--- a/src/azlin/modules/nfs_provisioner.py
+++ b/src/azlin/modules/nfs_provisioner.py
@@ -36,6 +36,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from azlin.azure_cli_executor import run_az_command
 from azlin.modules.validation import ValidationError, validate_azure_resource_name
 
 if TYPE_CHECKING:
@@ -409,9 +410,7 @@ class NFSProvisioner:
                 "tsv",
             ]
 
-            result = subprocess.run(
-                storage_id_cmd, capture_output=True, text=True, check=True, timeout=30
-            )
+            result = run_az_command(storage_id_cmd, timeout=30)
             storage_resource_id = result.stdout.strip()
 
             # Get subnet resource ID
@@ -433,9 +432,7 @@ class NFSProvisioner:
                 "tsv",
             ]
 
-            result = subprocess.run(
-                subnet_id_cmd, capture_output=True, text=True, check=True, timeout=30
-            )
+            result = run_az_command(subnet_id_cmd, timeout=30)
             subnet_id = result.stdout.strip()
 
             # Create private endpoint
@@ -466,9 +463,7 @@ class NFSProvisioner:
 
             logger.info(f"Running: az network private-endpoint create --name {name}")
 
-            result = subprocess.run(
-                create_cmd, capture_output=True, text=True, check=True, timeout=300
-            )
+            result = run_az_command(create_cmd, timeout=300)
 
             endpoint_data = json.loads(result.stdout)
 

--- a/src/azlin/modules/snapshot_manager.py
+++ b/src/azlin/modules/snapshot_manager.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from azlin.azure_cli_executor import run_az_command
+
 logger = logging.getLogger(__name__)
 
 
@@ -470,13 +472,7 @@ class SnapshotManager:
                 "json",
             ]
 
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=300,
-                check=True,
-            )
+            result = run_az_command(cmd, timeout=300)
 
             snapshot_data = json.loads(result.stdout)
             logger.debug(f"Created snapshot: {snapshot_data['id']}")
@@ -519,13 +515,7 @@ class SnapshotManager:
                 "tsv",
             ]
 
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=30,
-                check=True,
-            )
+            result = run_az_command(cmd, timeout=30)
 
             disk_id = result.stdout.strip()
             if not disk_id:

--- a/src/azlin/modules/storage_manager.py
+++ b/src/azlin/modules/storage_manager.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import ClassVar
 
+from azlin.azure_cli_executor import run_az_command
+
 logger = logging.getLogger(__name__)
 
 
@@ -232,7 +234,7 @@ class StorageManager:
 
             logger.info(f"Running command: {' '.join(cmd)}")
 
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=300)
+            result = run_az_command(cmd, timeout=300)
 
             storage_data = json.loads(result.stdout)
 
@@ -362,7 +364,7 @@ class StorageManager:
                 "json",
             ]
 
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=60)
+            result = run_az_command(cmd, timeout=60)
 
             accounts = json.loads(result.stdout)
 

--- a/src/azlin/vm_lifecycle.py
+++ b/src/azlin/vm_lifecycle.py
@@ -19,6 +19,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Any
 
+from azlin.azure_cli_executor import run_az_command
 from azlin.config_manager import ConfigManager
 from azlin.connection_tracker import ConnectionTracker
 
@@ -270,9 +271,7 @@ class VMLifecycleManager:
                 "json",
             ]
 
-            result: subprocess.CompletedProcess[str] = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=30, check=True
-            )
+            result = run_az_command(cmd, timeout=30)
 
             vm_details: dict[str, Any] = json.loads(result.stdout)
             return vm_details
@@ -309,9 +308,7 @@ class VMLifecycleManager:
                 "json",
             ]
 
-            result: subprocess.CompletedProcess[str] = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=30, check=True
-            )
+            result = run_az_command(cmd, timeout=30)
 
             vm_names: list[str] = json.loads(result.stdout)
             return vm_names

--- a/src/azlin/vm_manager.py
+++ b/src/azlin/vm_manager.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
+from azlin.azure_cli_executor import run_az_command
+
 logger = logging.getLogger(__name__)
 
 
@@ -250,9 +252,7 @@ class VMManager:
                 "json",
             ]
 
-            result: subprocess.CompletedProcess[str] = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=30, check=True
-            )
+            result = run_az_command(cmd, timeout=30)
 
             # Handle empty stdout (e.g., resource group not found but didn't raise error)
             if not result.stdout or result.stdout.strip() == "":
@@ -366,13 +366,7 @@ class VMManager:
                 "json",
             ]
 
-            result: subprocess.CompletedProcess[str] = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=30,
-                check=True,  # Increased for WSL compatibility (Issue #580)
-            )
+            result = run_az_command(cmd, timeout=30)
 
             vm_data: dict[str, Any] = json.loads(result.stdout)
             return cls._parse_vm_data(vm_data)

--- a/tests/unit/test_azure_cli_executor.py
+++ b/tests/unit/test_azure_cli_executor.py
@@ -1,0 +1,108 @@
+"""Tests for azure_cli_executor module.
+
+Tests the run_az_command helper that wraps subprocess.run with retry logic
+for Azure CLI calls. Proportional testing: ~100 LOC for ~50 LOC implementation.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from azlin.azure_cli_executor import run_az_command
+
+
+class TestRunAzCommand:
+    """Test run_az_command helper function."""
+
+    @patch("azlin.azure_cli_executor.subprocess.run")
+    def test_success_returns_completed_process(self, mock_run: MagicMock) -> None:
+        """Successful az command returns CompletedProcess."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["az", "vm", "list"], returncode=0, stdout='["vm1"]', stderr=""
+        )
+
+        result = run_az_command(["az", "vm", "list"])
+
+        assert result.returncode == 0
+        assert result.stdout == '["vm1"]'
+        mock_run.assert_called_once()
+
+    @patch("azlin.azure_cli_executor.subprocess.run")
+    def test_passes_default_kwargs(self, mock_run: MagicMock) -> None:
+        """Verifies default capture_output, text, check, timeout are passed."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["az", "account", "show"], returncode=0, stdout="{}", stderr=""
+        )
+
+        run_az_command(["az", "account", "show"])
+
+        _, kwargs = mock_run.call_args
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert kwargs["check"] is True
+        assert kwargs["timeout"] == 30
+
+    @patch("azlin.azure_cli_executor.subprocess.run")
+    def test_custom_timeout(self, mock_run: MagicMock) -> None:
+        """Custom timeout is forwarded to subprocess.run."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["az", "vm", "create"], returncode=0, stdout="{}", stderr=""
+        )
+
+        run_az_command(["az", "vm", "create"], timeout=300)
+
+        _, kwargs = mock_run.call_args
+        assert kwargs["timeout"] == 300
+
+    @patch("azlin.azure_cli_executor.subprocess.run")
+    def test_retries_on_called_process_error(self, mock_run: MagicMock) -> None:
+        """Retries on CalledProcessError (transient Azure failure)."""
+        mock_run.side_effect = [
+            subprocess.CalledProcessError(1, "az", stderr="ServiceUnavailable"),
+            subprocess.CompletedProcess(
+                args=["az", "vm", "list"], returncode=0, stdout="[]", stderr=""
+            ),
+        ]
+
+        result = run_az_command(["az", "vm", "list"], max_attempts=3)
+
+        assert result.returncode == 0
+        assert mock_run.call_count == 2
+
+    @patch("azlin.azure_cli_executor.subprocess.run")
+    def test_raises_after_max_attempts(self, mock_run: MagicMock) -> None:
+        """Raises CalledProcessError after exhausting retry attempts."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "az", stderr="InternalError")
+
+        with pytest.raises(subprocess.CalledProcessError):
+            run_az_command(["az", "vm", "list"], max_attempts=2)
+
+        assert mock_run.call_count == 2
+
+    @patch("azlin.azure_cli_executor.subprocess.run")
+    def test_retries_on_timeout(self, mock_run: MagicMock) -> None:
+        """Retries on TimeoutExpired."""
+        mock_run.side_effect = [
+            subprocess.TimeoutExpired("az", 30),
+            subprocess.CompletedProcess(
+                args=["az", "vm", "list"], returncode=0, stdout="[]", stderr=""
+            ),
+        ]
+
+        result = run_az_command(["az", "vm", "list"], max_attempts=3)
+
+        assert result.returncode == 0
+        assert mock_run.call_count == 2
+
+    @patch("azlin.azure_cli_executor.subprocess.run")
+    def test_check_false_no_retry_on_nonzero(self, mock_run: MagicMock) -> None:
+        """When check=False, non-zero return code does not raise or retry."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["az", "vm", "show"], returncode=1, stdout="", stderr="NotFound"
+        )
+
+        result = run_az_command(["az", "vm", "show"], check=False)
+
+        assert result.returncode == 1
+        assert mock_run.call_count == 1


### PR DESCRIPTION
## Summary
- New `azure_cli_executor.py` module with `run_az_command()` — drop-in replacement for `subprocess.run(["az", ...])` with retry
- Uses existing `retry_handler.py` infrastructure (previously unused)
- Applied to 10 call sites across 5 files (Tier 1: Azure CLI operations)

Closes #431

## Files Changed
- **New**: `src/azlin/azure_cli_executor.py` (~67 LOC)
- **New**: `tests/unit/test_azure_cli_executor.py` (~100 LOC, 7 tests)
- **Modified**: `vm_manager.py`, `vm_lifecycle.py`, `storage_manager.py`, `nfs_provisioner.py`, `snapshot_manager.py`

## Step 13: Local Testing Results
**Test Environment**: feat/issue-431-standardize-subprocess, 2026-02-22
**Tests Executed**:
1. Simple: 7 unit tests for run_az_command() → All pass ✅
2. Complex: Pre-commit (ruff, pyright, formatting) → All pass ✅
**Regressions**: No pyright errors introduced ✅

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>