### PR TITLE
fix: Stale cache hides newly created VMs from azlin list

### DIFF
--- a/src/azlin/vm_lifecycle.py
+++ b/src/azlin/vm_lifecycle.py
@@ -156,6 +156,14 @@ class VMLifecycleManager:
             except Exception as e:
                 logger.warning(f"Failed to clean up session name for {vm_name}: {e}")
 
+            # Invalidate cache so deleted VM disappears from next `azlin list`
+            try:
+                from azlin.vm_manager import VMManager
+
+                VMManager.invalidate_cache(vm_name, resource_group)
+            except Exception as e:
+                logger.warning(f"Failed to invalidate cache for {vm_name}: {e}")
+
             return DeletionResult(
                 vm_name=vm_name,
                 success=True,

--- a/src/azlin/vm_provisioning.py
+++ b/src/azlin/vm_provisioning.py
@@ -686,6 +686,14 @@ class VMProvisioner:
             logger.warning(f"Failed to set management tags: {e}")
             report_progress(f"Warning: Failed to set management tags: {e}")
 
+        # Invalidate resource group cache so next `azlin list` discovers the new VM
+        try:
+            from azlin.vm_manager import VMManager
+
+            VMManager.invalidate_resource_group_cache(config.resource_group)
+        except Exception as e:
+            logger.warning(f"Failed to invalidate cache after provisioning: {e}")
+
         report_progress(f"VM provisioned successfully: {vm_details.public_ip}")
         return vm_details
 


### PR DESCRIPTION
## Summary

- **Bug**: When all cached VM entries expired (mutable TTL >5min), `list_vms_with_cache()` used selective refresh (individual `az vm show` per cached VM) instead of full refresh (`az vm list`). Selective refresh only updates VMs already in the cache — it never discovers newly created VMs or removes deleted ones.
- **Fix**: Fall back to full refresh when ALL entries are expired. Also invalidate cache after VM creation and deletion so the next `azlin list` reflects changes immediately.
- **Bonus**: Full refresh is faster than selective when all entries are expired (1 API call vs N individual calls)

## Root Cause

User created a VM named "dev" with `azlin new`, but `azlin list` on their local machine showed 5 VMs instead of 6. The cache contained a stale entry for a deleted VM (`simserv-dev`) and had no entry for the new VM (`dev`). The selective refresh path queried each cached VM individually, so the new VM was invisible.

## Changes

| File | Change |
|------|--------|
| `vm_manager.py` | When all cached entries need refresh, use full `az vm list` instead of N individual `az vm show` calls |
| `vm_provisioning.py` | Invalidate resource group cache after `provision_vm()` succeeds |
| `vm_lifecycle.py` | Invalidate cache entry after `delete_vm()` succeeds |

## Test plan

- [x] Unit tests pass (`test_vm_list_cache.py`, `test_vm_manager_errors.py`)
- [x] Pre-commit hooks pass (ruff, pyright, etc.)
- [x] `azlin list` shows all 6 VMs including newly created "dev"
- [x] `azlin list --no-cache` confirms same result
- [ ] Verify on user's local machine after installing from branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)