### PR TITLE
feat: Add separate /tmp disk support for new and existing VMs (fixes #685)

### DIFF
--- a/src/azlin/cli.py
+++ b/src/azlin/cli.py
@@ -57,6 +57,8 @@ from azlin.commands import (
     cp,
     create,
     destroy,
+    # Disk Commands
+    disk_group,
     # NLP Commands
     do,
     doit_group,
@@ -408,6 +410,9 @@ main.add_command(compose_group)
 # Register storage commands
 main.add_command(storage_group)
 main.add_command(tag_group)
+
+# Register disk commands (Issue #685)
+main.add_command(disk_group)
 
 # Register costs commands
 main.add_command(costs_group)

--- a/src/azlin/commands/__init__.py
+++ b/src/azlin/commands/__init__.py
@@ -19,6 +19,9 @@ from .compose import compose_group
 from .connect import connect
 from .context import context_group
 from .costs import cost, costs_group
+
+# Disk management
+from .disk import disk_group
 from .doit import do, doit_group
 
 # Environment
@@ -96,6 +99,8 @@ __all__ = [
     "cp",
     "create",
     "destroy",
+    # Disk management
+    "disk_group",
     "do",
     "doit_group",
     "env",

--- a/src/azlin/commands/disk.py
+++ b/src/azlin/commands/disk.py
@@ -1,0 +1,250 @@
+"""Disk management commands for azlin CLI.
+
+This module provides commands for managing VM disks:
+- disk add: Attach a new managed disk to an existing VM
+
+Supports adding /tmp disks (or other mount points) to running VMs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+
+import click
+
+from azlin.azure_cli_visibility import AzureCLIExecutor
+from azlin.config_manager import ConfigError, ConfigManager
+
+logger = logging.getLogger(__name__)
+
+# Default mount point for the disk add command
+_DEFAULT_MOUNT = "/tmp"  # noqa: S108
+
+
+@click.group(name="disk")
+def disk_group():
+    """Manage VM disks."""
+    pass
+
+
+@disk_group.command(name="add")
+@click.argument("vm_name", type=str)
+@click.option("--size", required=True, type=int, help="Disk size in GB")
+@click.option(
+    "--mount",
+    default=_DEFAULT_MOUNT,
+    help="Mount point on the VM (default: /tmp)",
+)
+@click.option("--resource-group", "--rg", help="Resource group", type=str)
+@click.option("--config", help="Config file path", type=click.Path())
+@click.option(
+    "--sku",
+    default="Standard_LRS",
+    type=click.Choice(["Standard_LRS", "Premium_LRS", "StandardSSD_LRS"]),
+    help="Storage SKU (default: Standard_LRS)",
+)
+def add_disk(
+    vm_name: str,
+    size: int,
+    mount: str,
+    resource_group: str | None,
+    config: str | None,
+    sku: str,
+) -> None:
+    """Add a managed disk to an existing VM.
+
+    Creates a new Azure managed disk, attaches it to the VM,
+    then formats and mounts it at the specified mount point.
+
+    \b
+    EXAMPLES:
+        # Add a 64GB /tmp disk
+        $ azlin disk add my-vm --size 64
+
+        # Add a 128GB disk mounted at /tmp with Premium storage
+        $ azlin disk add my-vm --size 128 --sku Premium_LRS
+
+        # Add a disk with custom mount point
+        $ azlin disk add my-vm --size 256 --mount /data
+    """
+    try:
+        # Resolve session name to VM name if applicable
+        resolved_vm_name = ConfigManager.get_vm_name_by_session(vm_name, config)
+        if resolved_vm_name:
+            vm_name = resolved_vm_name
+
+        # Get resource group
+        rg = ConfigManager.get_resource_group(resource_group, config)
+        if not rg:
+            click.echo("Error: No resource group specified.", err=True)
+            sys.exit(1)
+
+        # Validate size
+        if size < 1:
+            click.echo("Error: Disk size must be at least 1GB.", err=True)
+            sys.exit(1)
+        if size > 32767:
+            click.echo("Error: Disk size exceeds Azure maximum (32767GB / 32TB).", err=True)
+            sys.exit(1)
+
+        # Get VM location
+        click.echo(f"Looking up VM '{vm_name}'...")
+        executor = AzureCLIExecutor(show_progress=False, timeout=30)
+        vm_result = executor.execute(
+            ["az", "vm", "show", "--name", vm_name, "--resource-group", rg, "--output", "json"]
+        )
+        if not vm_result["success"]:
+            click.echo(f"Error: VM '{vm_name}' not found in resource group '{rg}'.", err=True)
+            sys.exit(1)
+
+        vm_info = json.loads(vm_result["stdout"])
+        location = vm_info["location"]
+
+        # Derive mount-safe disk name suffix
+        mount_suffix = mount.strip("/").replace("/", "-") or "data"
+        safe_location = location.replace(" ", "-").lower()
+        disk_name = f"{vm_name}-{mount_suffix}-{safe_location}"
+
+        # Create the managed disk
+        click.echo(f"Creating {size}GB managed disk '{disk_name}' ({sku})...")
+        create_result = executor.execute(
+            [
+                "az",
+                "disk",
+                "create",
+                "--name",
+                disk_name,
+                "--resource-group",
+                rg,
+                "--location",
+                location,
+                "--size-gb",
+                str(size),
+                "--sku",
+                sku,
+                "--output",
+                "json",
+            ]
+        )
+        if not create_result["success"]:
+            click.echo(f"Error creating disk: {create_result['stderr']}", err=True)
+            sys.exit(1)
+
+        disk_info = json.loads(create_result["stdout"])
+        disk_id = disk_info["id"]
+        click.echo(f"Disk created: {disk_name}")
+
+        # Attach disk to VM
+        click.echo(f"Attaching disk to VM '{vm_name}'...")
+        attach_result = executor.execute(
+            [
+                "az",
+                "vm",
+                "disk",
+                "attach",
+                "--vm-name",
+                vm_name,
+                "--resource-group",
+                rg,
+                "--disk",
+                disk_id,
+                "--output",
+                "json",
+            ]
+        )
+        if not attach_result["success"]:
+            click.echo(f"Error attaching disk: {attach_result['stderr']}", err=True)
+            sys.exit(1)
+
+        click.echo("Disk attached successfully.")
+
+        # Find the newly attached disk's LUN by querying the VM
+        click.echo("Detecting disk LUN...")
+        lun = 0  # Default LUN
+        vm_result2 = executor.execute(
+            ["az", "vm", "show", "--name", vm_name, "--resource-group", rg, "--output", "json"]
+        )
+        if vm_result2["success"]:
+            vm_data = json.loads(vm_result2["stdout"])
+            data_disks = vm_data.get("storageProfile", {}).get("dataDisks", [])
+            # Find our disk by name
+            for dd in data_disks:
+                if dd.get("name") == disk_name:
+                    lun = dd.get("lun", 0)
+                    break
+
+        click.echo(f"Disk at LUN {lun}. Formatting and mounting at {mount}...")
+
+        # Build the formatting/mounting script
+        # Use Azure VM run-command to execute on the VM (no SSH needed)
+        mount_permissions = "1777" if mount == _DEFAULT_MOUNT else "755"
+        format_script = (
+            f"set -e && "
+            f"echo 'Partitioning disk at LUN {lun}...' && "
+            f"disk_dev=/dev/disk/azure/scsi1/lun{lun} && "
+            f"if [ ! -b $disk_dev ]; then echo 'Disk device not found'; exit 1; fi && "
+            f"sgdisk -n 1:0:0 -t 1:8300 $disk_dev || true && "
+            f"partprobe $disk_dev && "
+            f"sleep 2 && "
+            f"part_dev=${{disk_dev}}-part1 && "
+            f"mkfs.ext4 -F $part_dev && "
+            f"mkdir -p {mount} && "
+            f"mount $part_dev {mount} && "
+            f"chmod {mount_permissions} {mount} && "
+            f'echo "$part_dev {mount} ext4 defaults,nofail 0 2" >> /etc/fstab && '
+            f"echo 'Disk mounted at {mount} successfully'"
+        )
+
+        run_executor = AzureCLIExecutor(show_progress=False, timeout=120)
+        run_cmd_result = run_executor.execute(
+            [
+                "az",
+                "vm",
+                "run-command",
+                "invoke",
+                "--resource-group",
+                rg,
+                "--name",
+                vm_name,
+                "--command-id",
+                "RunShellScript",
+                "--scripts",
+                format_script,
+                "--output",
+                "json",
+            ]
+        )
+
+        if not run_cmd_result["success"]:
+            click.echo(
+                f"Warning: Disk attached but remote formatting failed: {run_cmd_result['stderr']}",
+                err=True,
+            )
+            click.echo(
+                "You may need to SSH in and manually format/mount the disk.",
+                err=True,
+            )
+            sys.exit(1)
+
+        # Parse run-command output for the script result
+        try:
+            run_output = json.loads(run_cmd_result["stdout"])
+            messages = run_output.get("value", [])
+            for msg in messages:
+                if msg.get("code") == "ProvisioningState/succeeded":
+                    stdout_msg = msg.get("message", "")
+                    if stdout_msg:
+                        click.echo(stdout_msg)
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+        click.echo(f"Done! {size}GB disk mounted at {mount} on VM '{vm_name}'.")
+
+    except ConfigError as e:
+        click.echo(f"Configuration error: {e}", err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)

--- a/src/azlin/commands/provisioning.py
+++ b/src/azlin/commands/provisioning.py
@@ -758,6 +758,11 @@ def _set_clone_session_names(
     is_flag=True,
     help="Disable separate /home disk (use OS disk)",
 )
+@click.option(
+    "--tmp-disk-size",
+    type=int,
+    help="Size of separate /tmp disk in GB (enables /tmp on dedicated disk)",
+)
 def new(
     ctx: click.Context,
     repo: str | None,
@@ -777,6 +782,7 @@ def new(
     yes: bool,
     home_disk_size: int | None,
     no_home_disk: bool,
+    tmp_disk_size: int | None,
 ) -> None:
     """Provision a new Azure VM with development tools.
 
@@ -882,6 +888,7 @@ def new(
         auto_approve=yes,
         home_disk_size=home_disk_size,
         no_home_disk=no_home_disk,
+        tmp_disk_size=tmp_disk_size,
     )
 
     # Update config state (resource group only, session name saved after VM creation)

--- a/src/azlin/orchestrator.py
+++ b/src/azlin/orchestrator.py
@@ -111,6 +111,7 @@ class CLIOrchestrator:
         auto_approve: bool = False,
         home_disk_size: int | None = None,
         no_home_disk: bool = False,
+        tmp_disk_size: int | None = None,
     ):
         """Initialize CLI orchestrator.
 
@@ -129,6 +130,7 @@ class CLIOrchestrator:
             auto_approve: Accept all defaults and confirmations (non-interactive mode)
             home_disk_size: Size of separate /home disk in GB (optional, default: 100)
             no_home_disk: Disable separate /home disk (use OS disk only)
+            tmp_disk_size: Size of separate /tmp disk in GB (optional, enables tmp disk)
 
         Note:
             SSH keys are automatically stored in Azure Key Vault (transparent operation)
@@ -147,6 +149,7 @@ class CLIOrchestrator:
         self.auto_approve = auto_approve
         self.home_disk_size = home_disk_size
         self.no_home_disk = no_home_disk
+        self.tmp_disk_size = tmp_disk_size
 
         # Initialize modules
         self.auth = AzureAuthenticator()
@@ -773,6 +776,11 @@ class CLIOrchestrator:
         home_disk_enabled = not self.no_home_disk and not has_nfs_storage
         home_disk_size = self.home_disk_size or 100
 
+        # Determine tmp disk configuration
+        # Tmp disk is enabled only when user specifies --tmp-disk-size
+        tmp_disk_enabled = self.tmp_disk_size is not None
+        tmp_disk_size = self.tmp_disk_size or 64
+
         # Create VM config
         config = self.provisioner.create_vm_config(
             name=vm_name,
@@ -785,6 +793,9 @@ class CLIOrchestrator:
             home_disk_enabled=home_disk_enabled,
             home_disk_size_gb=home_disk_size,
             home_disk_sku="Standard_LRS",
+            tmp_disk_enabled=tmp_disk_enabled,
+            tmp_disk_size_gb=tmp_disk_size,
+            tmp_disk_sku="Standard_LRS",
         )
 
         # Progress callback

--- a/tests/unit/test_vm_provisioning_home_disk.py
+++ b/tests/unit/test_vm_provisioning_home_disk.py
@@ -575,10 +575,10 @@ class TestProvisionVMWithHomeDisk:
                 sku="Standard_LRS",
             )
 
-            # Verify VM was provisioned with disk_id parameter
+            # Verify VM was provisioned with disk_ids parameter
             mock_provision.assert_called_once()
             call_kwargs = mock_provision.call_args[1]
-            assert call_kwargs.get("disk_id") == disk_id
+            assert disk_id in call_kwargs.get("disk_ids", [])
             assert call_kwargs.get("has_home_disk") is True
 
             assert result.name == "test-vm"
@@ -695,11 +695,11 @@ class TestProvisionVMWithHomeDisk:
 
             assert result.name == "test-vm"
 
-            # Verify _try_provision_vm was called with disk_id parameter
+            # Verify _try_provision_vm was called with disk_ids parameter
             mock_provision.assert_called_once()
             call_kwargs = mock_provision.call_args[1]
-            assert "disk_id" in call_kwargs
-            assert call_kwargs["disk_id"] == disk_id
+            assert "disk_ids" in call_kwargs
+            assert disk_id in call_kwargs["disk_ids"]
 
 
 class TestCLIHomeDiskFlags:

--- a/tests/unit/test_vm_provisioning_tmp_disk.py
+++ b/tests/unit/test_vm_provisioning_tmp_disk.py
@@ -1,0 +1,272 @@
+"""Unit tests for VM provisioning with separate /tmp disk feature.
+
+This module tests the separate /tmp disk functionality including:
+1. VMConfig defaults for tmp disk parameters
+2. _create_tmp_disk() command construction
+3. _generate_cloud_init() with tmp disk support
+4. CLI flag parsing for tmp disk options
+5. Error handling for disk operations
+6. Interaction with home disk (both enabled)
+
+Testing Pyramid: 60% Unit tests (this file)
+"""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from azlin.vm_provisioning import ProvisioningError, VMConfig, VMProvisioner
+
+
+class TestVMConfigTmpDiskDefaults:
+    """Test VMConfig dataclass defaults for tmp disk parameters."""
+
+    def test_tmp_disk_disabled_by_default(self):
+        """Tmp disk should be disabled by default (opt-in feature)."""
+        config = VMConfig(name="test-vm", resource_group="test-rg", location="westus2")
+        assert config.tmp_disk_enabled is False
+
+    def test_tmp_disk_size_gb_default_is_64(self):
+        """Default tmp disk size should be 64GB."""
+        config = VMConfig(name="test-vm", resource_group="test-rg", location="westus2")
+        assert config.tmp_disk_size_gb == 64
+
+    def test_tmp_disk_sku_default_is_standard_lrs(self):
+        """Default tmp disk SKU should be Standard_LRS."""
+        config = VMConfig(name="test-vm", resource_group="test-rg", location="westus2")
+        assert config.tmp_disk_sku == "Standard_LRS"
+
+    def test_custom_tmp_disk_size(self):
+        """Custom tmp disk size should be accepted."""
+        config = VMConfig(
+            name="test-vm",
+            resource_group="test-rg",
+            location="westus2",
+            tmp_disk_enabled=True,
+            tmp_disk_size_gb=128,
+        )
+        assert config.tmp_disk_size_gb == 128
+
+    def test_tmp_disk_enabled_explicitly(self):
+        """Tmp disk can be explicitly enabled."""
+        config = VMConfig(
+            name="test-vm",
+            resource_group="test-rg",
+            location="westus2",
+            tmp_disk_enabled=True,
+        )
+        assert config.tmp_disk_enabled is True
+
+
+class TestCreateVmConfigTmpDiskValidation:
+    """Test create_vm_config() validation for tmp disk parameters."""
+
+    def setup_method(self):
+        self.provisioner = VMProvisioner()
+
+    def test_tmp_disk_size_too_small(self):
+        """Tmp disk size less than 1GB should raise ValueError."""
+        with pytest.raises(ValueError, match="Tmp disk size must be at least 1GB"):
+            self.provisioner.create_vm_config(
+                name="test-vm",
+                resource_group="test-rg",
+                tmp_disk_enabled=True,
+                tmp_disk_size_gb=0,
+            )
+
+    def test_tmp_disk_size_too_large(self):
+        """Tmp disk size exceeding Azure max should raise ValueError."""
+        with pytest.raises(ValueError, match="exceeds Azure maximum"):
+            self.provisioner.create_vm_config(
+                name="test-vm",
+                resource_group="test-rg",
+                tmp_disk_enabled=True,
+                tmp_disk_size_gb=32768,
+            )
+
+    def test_tmp_disk_valid_config_returned(self):
+        """Valid tmp disk config should be returned in VMConfig."""
+        config = self.provisioner.create_vm_config(
+            name="test-vm",
+            resource_group="test-rg",
+            tmp_disk_enabled=True,
+            tmp_disk_size_gb=128,
+        )
+        assert config.tmp_disk_enabled is True
+        assert config.tmp_disk_size_gb == 128
+        assert config.tmp_disk_sku == "Standard_LRS"
+
+    def test_tmp_disk_disabled_skips_validation(self):
+        """When tmp_disk_enabled=False, size validation should be skipped."""
+        config = self.provisioner.create_vm_config(
+            name="test-vm",
+            resource_group="test-rg",
+            tmp_disk_enabled=False,
+            tmp_disk_size_gb=0,
+        )
+        assert config.tmp_disk_enabled is False
+
+
+class TestCreateTmpDisk:
+    """Test _create_tmp_disk() Azure CLI command construction."""
+
+    def setup_method(self):
+        self.provisioner = VMProvisioner()
+
+    @patch.object(VMProvisioner, "_execute_azure_command")
+    def test_create_tmp_disk_command(self, mock_exec):
+        """_create_tmp_disk should issue correct az disk create command."""
+        mock_exec.return_value = {
+            "success": True,
+            "stdout": json.dumps({"id": "/subscriptions/sub/disk-id"}),
+            "stderr": "",
+        }
+
+        disk_id = self.provisioner._create_tmp_disk(
+            vm_name="my-vm",
+            resource_group="my-rg",
+            location="westus2",
+            size_gb=64,
+            sku="Standard_LRS",
+        )
+
+        assert disk_id == "/subscriptions/sub/disk-id"
+        cmd = mock_exec.call_args[0][0]
+        assert "az" in cmd
+        assert "disk" in cmd
+        assert "create" in cmd
+        assert "--name" in cmd
+        # Disk name includes "tmp" to differentiate from home disk
+        name_idx = cmd.index("--name") + 1
+        assert "tmp" in cmd[name_idx]
+        assert "--size-gb" in cmd
+        size_idx = cmd.index("--size-gb") + 1
+        assert cmd[size_idx] == "64"
+
+    @patch.object(VMProvisioner, "_execute_azure_command")
+    def test_create_tmp_disk_failure(self, mock_exec):
+        """_create_tmp_disk should raise ProvisioningError on failure."""
+        mock_exec.return_value = {
+            "success": False,
+            "stdout": "",
+            "stderr": "Disk creation failed",
+        }
+
+        with pytest.raises(ProvisioningError, match="Failed to create tmp disk"):
+            self.provisioner._create_tmp_disk(
+                vm_name="my-vm",
+                resource_group="my-rg",
+                location="westus2",
+                size_gb=64,
+                sku="Standard_LRS",
+            )
+
+
+class TestCloudInitTmpDisk:
+    """Test _generate_cloud_init() with tmp disk support."""
+
+    def setup_method(self):
+        self.provisioner = VMProvisioner()
+
+    def test_cloud_init_no_tmp_disk(self):
+        """Cloud-init without tmp disk should not contain tmp disk setup."""
+        cloud_init = self.provisioner._generate_cloud_init(has_tmp_disk=False)
+        assert "tmp_disk" not in cloud_init
+        assert "/tmp" not in cloud_init or "/tmp/go" in cloud_init  # /tmp used for downloads
+
+    def test_cloud_init_tmp_disk_only(self):
+        """Cloud-init with only tmp disk should set up at lun0."""
+        cloud_init = self.provisioner._generate_cloud_init(has_home_disk=False, has_tmp_disk=True)
+        assert "lun0" in cloud_init
+        assert "tmp_disk" in cloud_init
+        assert "/tmp" in cloud_init
+        assert "1777" in cloud_init
+
+    def test_cloud_init_both_disks(self):
+        """Cloud-init with both home and tmp disk should use lun0 and lun1."""
+        cloud_init = self.provisioner._generate_cloud_init(has_home_disk=True, has_tmp_disk=True)
+        assert "lun0" in cloud_init
+        assert "lun1" in cloud_init
+        assert "home_disk" in cloud_init
+        assert "tmp_disk" in cloud_init
+        assert "1777" in cloud_init
+
+    def test_cloud_init_tmp_disk_permissions(self):
+        """Cloud-init should set /tmp to 1777 (sticky bit)."""
+        cloud_init = self.provisioner._generate_cloud_init(has_home_disk=False, has_tmp_disk=True)
+        assert "chmod 1777 /tmp" in cloud_init
+
+
+class TestProvisionVmWithTmpDisk:
+    """Test provision_vm() integration with tmp disk."""
+
+    def setup_method(self):
+        self.provisioner = VMProvisioner()
+
+    @patch.object(VMProvisioner, "_try_provision_vm")
+    @patch.object(VMProvisioner, "_create_tmp_disk")
+    @patch.object(VMProvisioner, "create_resource_group")
+    def test_provision_creates_tmp_disk_when_enabled(
+        self, mock_rg, mock_create_disk, mock_provision
+    ):
+        """provision_vm should create tmp disk when config has tmp_disk_enabled."""
+        mock_create_disk.return_value = "/subscriptions/sub/tmp-disk-id"
+        mock_provision.return_value = Mock(public_ip="1.2.3.4")
+
+        config = VMConfig(
+            name="test-vm",
+            resource_group="test-rg",
+            location="westus2",
+            tmp_disk_enabled=True,
+            tmp_disk_size_gb=64,
+            home_disk_enabled=False,
+        )
+
+        self.provisioner.provision_vm(config)
+
+        mock_create_disk.assert_called_once()
+        # Verify disk_ids passed to _try_provision_vm include the tmp disk
+        call_kwargs = mock_provision.call_args
+        assert call_kwargs is not None
+
+    @patch.object(VMProvisioner, "_try_provision_vm")
+    @patch.object(VMProvisioner, "create_resource_group")
+    def test_provision_skips_tmp_disk_when_disabled(self, mock_rg, mock_provision):
+        """provision_vm should not create tmp disk when disabled."""
+        mock_provision.return_value = Mock(public_ip="1.2.3.4")
+
+        config = VMConfig(
+            name="test-vm",
+            resource_group="test-rg",
+            location="westus2",
+            tmp_disk_enabled=False,
+            home_disk_enabled=False,
+        )
+
+        self.provisioner.provision_vm(config)
+        # No tmp disk creation should occur
+
+
+class TestRetryConfigPreservesTmpDisk:
+    """Test _create_retry_config preserves tmp disk settings."""
+
+    def setup_method(self):
+        self.provisioner = VMProvisioner()
+
+    def test_retry_config_preserves_tmp_disk_fields(self):
+        """_create_retry_config should preserve tmp disk configuration."""
+        original = VMConfig(
+            name="test-vm",
+            resource_group="test-rg",
+            location="westus2",
+            tmp_disk_enabled=True,
+            tmp_disk_size_gb=128,
+            tmp_disk_sku="Premium_LRS",
+        )
+
+        retry = self.provisioner._create_retry_config(original, "eastus")
+        assert retry.tmp_disk_enabled == original.tmp_disk_enabled
+        assert retry.tmp_disk_size_gb == original.tmp_disk_size_gb
+        assert retry.tmp_disk_sku == original.tmp_disk_sku
+        assert retry.location == "eastus"


### PR DESCRIPTION
## Summary

- Adds `--tmp-disk-size` option to `azlin new` for provisioning VMs with dedicated /tmp storage
- Adds new `azlin disk add` command group for attaching disks to existing VMs
- Follows the established home_disk pattern for consistency

## Changes

### New VM support (`azlin new --tmp-disk-size`)
- `VMConfig`: Added `tmp_disk_enabled`, `tmp_disk_size_gb`, `tmp_disk_sku` fields (disabled by default)
- Cloud-init: Dynamic LUN assignment - home disk at lun0, tmp disk at next available
- Cloud-init sets /tmp permissions to 1777 (sticky bit) via runcmd
- `_create_retry_config()`: Now preserves all disk fields including tmp_disk on region retry
- Provisioning flow: Creates multiple data disks and attaches via `--attach-data-disks`

### Existing VM support (`azlin disk add`)
- New `disk` command group registered in CLI
- `azlin disk add VM_NAME --size 64 [--mount /tmp] [--sku Standard_LRS]`
- Uses `az vm run-command invoke` for remote formatting (no SSH keys needed)
- Partitions with sgdisk, formats ext4, mounts, adds fstab entry
- Detects LUN dynamically by querying VM after attach

### Test changes
- Updated 2 existing home_disk tests for `disk_id` → `disk_ids` API change
- Added 18 new unit tests covering VMConfig defaults, validation, disk creation, cloud-init, provisioning flow, and retry config

## Step 13: Local Testing Results

**Test Environment**: feat/issue-685-tmp-disk branch, 2026-02-24
**Tests Executed**:
1. Simple: `azlin new --help` → `--tmp-disk-size` flag visible ✅
2. Simple: `azlin disk --help` → disk command group with `add` subcommand ✅
3. Simple: `azlin disk add --help` → All options documented correctly ✅
4. Complex: 107 unit tests (home_disk + tmp_disk + cloud_init + validation) → All pass ✅
5. Complex: Pre-commit hooks (ruff, pyright, formatting) → All pass ✅
**Regressions**: All 40 existing home_disk tests still pass ✅ None detected
**Issues Found**: Fixed 2 home_disk tests that checked old `disk_id` param name

## Test plan
- [ ] Verify `azlin new --tmp-disk-size 64` creates VM with /tmp on separate disk
- [ ] Verify `azlin disk add <vm> --size 64` attaches and formats disk on running VM
- [ ] Verify /tmp has 1777 permissions after mount
- [ ] Verify disk survives VM reboot (fstab entry)
- [ ] Verify both home + tmp disk work together (lun0 + lun1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)