### PR TITLE
test: Add unit tests for execution layer (fixes #695)

### DIFF
--- a/tests/unit/test_batch_executor.py
+++ b/tests/unit/test_batch_executor.py
@@ -1,0 +1,458 @@
+"""Unit tests for batch_executor module.
+
+Tests the parallel execution engine for multi-VM operations with mocked
+dependencies. Covers TagFilter, BatchResult, BatchSelector, BatchExecutor,
+VMMetrics, MetricsCollector, and ConditionalExecutor.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from azlin.batch_executor import (
+    BatchExecutor,
+    BatchExecutorError,
+    BatchOperationResult,
+    BatchResult,
+    BatchSelector,
+    MetricsCollector,
+    TagFilter,
+    VMMetrics,
+)
+from azlin.modules.ssh_connector import SSHConfig
+from azlin.remote_exec import RemoteResult
+from azlin.vm_manager import VMInfo
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_vm(
+    name: str,
+    power_state: str = "VM running",
+    public_ip: str | None = "10.0.0.1",
+    tags: dict | None = None,
+) -> VMInfo:
+    """Helper to create VMInfo instances for testing."""
+    return VMInfo(
+        name=name,
+        resource_group="rg-test",
+        location="eastus",
+        power_state=power_state,
+        public_ip=public_ip,
+        tags=tags,
+    )
+
+
+@pytest.fixture
+def running_vms():
+    return [
+        _make_vm("vm1", public_ip="10.0.0.1", tags={"env": "dev", "team": "alpha"}),
+        _make_vm("vm2", public_ip="10.0.0.2", tags={"env": "prod", "team": "alpha"}),
+        _make_vm("vm3", public_ip="10.0.0.3", tags={"env": "dev", "team": "beta"}),
+    ]
+
+
+@pytest.fixture
+def ssh_config():
+    return SSHConfig(
+        host="10.0.0.1", user="azureuser", key_path=Path("/home/azureuser/.ssh/id_rsa")
+    )
+
+
+# ---------------------------------------------------------------------------
+# TagFilter
+# ---------------------------------------------------------------------------
+
+
+class TestTagFilter:
+    def test_parse_valid(self):
+        tag = TagFilter.parse("env=prod")
+        assert tag.key == "env"
+        assert tag.value == "prod"
+
+    def test_parse_value_with_equals(self):
+        """Value can contain '=' characters."""
+        tag = TagFilter.parse("config=key=value")
+        assert tag.key == "config"
+        assert tag.value == "key=value"
+
+    def test_parse_strips_whitespace(self):
+        tag = TagFilter.parse("  env  =  dev  ")
+        assert tag.key == "env"
+        assert tag.value == "dev"
+
+    def test_parse_no_equals_raises(self):
+        with pytest.raises(BatchExecutorError, match="Invalid tag format"):
+            TagFilter.parse("invalid")
+
+    def test_parse_empty_key_raises(self):
+        with pytest.raises(BatchExecutorError, match="Key cannot be empty"):
+            TagFilter.parse("=value")
+
+    def test_matches_vm_with_tag(self):
+        vm = _make_vm("vm1", tags={"env": "dev"})
+        tag = TagFilter(key="env", value="dev")
+        assert tag.matches(vm) is True
+
+    def test_no_match_wrong_value(self):
+        vm = _make_vm("vm1", tags={"env": "prod"})
+        tag = TagFilter(key="env", value="dev")
+        assert tag.matches(vm) is False
+
+    def test_no_match_no_tags(self):
+        vm = _make_vm("vm1", tags=None)
+        tag = TagFilter(key="env", value="dev")
+        assert tag.matches(vm) is False
+
+
+# ---------------------------------------------------------------------------
+# BatchResult
+# ---------------------------------------------------------------------------
+
+
+class TestBatchResult:
+    def test_properties(self):
+        results = [
+            BatchOperationResult(vm_name="vm1", success=True, message="ok"),
+            BatchOperationResult(vm_name="vm2", success=False, message="fail"),
+            BatchOperationResult(vm_name="vm3", success=True, message="ok"),
+        ]
+        batch = BatchResult(results)
+
+        assert batch.total == 3
+        assert batch.succeeded == 2
+        assert batch.failed == 1
+        assert batch.all_succeeded is False
+
+    def test_all_succeeded_true(self):
+        results = [BatchOperationResult(vm_name="vm1", success=True, message="ok")]
+        assert BatchResult(results).all_succeeded is True
+
+    def test_all_succeeded_empty(self):
+        assert BatchResult([]).all_succeeded is True
+
+    def test_get_failures_and_successes(self):
+        results = [
+            BatchOperationResult(vm_name="vm1", success=True, message="ok"),
+            BatchOperationResult(vm_name="vm2", success=False, message="fail"),
+        ]
+        batch = BatchResult(results)
+
+        assert len(batch.get_failures()) == 1
+        assert batch.get_failures()[0].vm_name == "vm2"
+        assert len(batch.get_successes()) == 1
+
+    def test_format_summary(self):
+        results = [
+            BatchOperationResult(vm_name="vm1", success=True, message="ok"),
+            BatchOperationResult(vm_name="vm2", success=False, message="fail"),
+        ]
+        summary = BatchResult(results).format_summary()
+        assert "Total: 2" in summary
+        assert "Succeeded: 1" in summary
+        assert "Failed: 1" in summary
+
+
+# ---------------------------------------------------------------------------
+# BatchSelector
+# ---------------------------------------------------------------------------
+
+
+class TestBatchSelector:
+    def test_select_by_tag(self, running_vms):
+        selected = BatchSelector.select_by_tag(running_vms, "env=dev")
+        assert len(selected) == 2
+        names = {vm.name for vm in selected}
+        assert names == {"vm1", "vm3"}
+
+    def test_select_by_pattern(self, running_vms):
+        selected = BatchSelector.select_by_pattern(running_vms, "vm[12]")
+        assert len(selected) == 2
+
+    def test_select_by_pattern_wildcard(self, running_vms):
+        selected = BatchSelector.select_by_pattern(running_vms, "vm*")
+        assert len(selected) == 3
+
+    def test_select_all(self, running_vms):
+        assert BatchSelector.select_all(running_vms) == running_vms
+
+    def test_select_running_only(self):
+        vms = [
+            _make_vm("vm1", power_state="VM running"),
+            _make_vm("vm2", power_state="VM deallocated"),
+            _make_vm("vm3", power_state="VM running"),
+        ]
+        selected = BatchSelector.select_running_only(vms)
+        assert len(selected) == 2
+
+
+# ---------------------------------------------------------------------------
+# BatchExecutor - stop / start / command / sync
+# ---------------------------------------------------------------------------
+
+
+class TestBatchExecutor:
+    def test_execute_stop_empty_list(self):
+        executor = BatchExecutor(max_workers=2)
+        results = executor.execute_stop([], resource_group="rg")
+        assert results == []
+
+    @patch("azlin.batch_executor.VMLifecycleController")
+    def test_execute_stop_success(self, mock_lifecycle, running_vms):
+        mock_lifecycle.stop_vm.return_value = MagicMock(success=True, message="Stopped")
+
+        executor = BatchExecutor(max_workers=2)
+        results = executor.execute_stop(running_vms, resource_group="rg")
+
+        assert len(results) == 3
+        assert all(r.success for r in results)
+
+    @patch("azlin.batch_executor.VMLifecycleController")
+    def test_execute_stop_one_failure(self, mock_lifecycle, running_vms):
+        """One VM stop failure should not prevent others from completing."""
+        call_count = 0
+
+        def side_effect(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if kwargs.get("vm_name") == "vm2":
+                raise Exception("Azure API error")
+            return MagicMock(success=True, message="Stopped")
+
+        mock_lifecycle.stop_vm.side_effect = side_effect
+
+        executor = BatchExecutor(max_workers=2)
+        results = executor.execute_stop(running_vms, resource_group="rg")
+
+        assert len(results) == 3
+        failures = [r for r in results if not r.success]
+        assert len(failures) == 1
+        assert "Azure API error" in failures[0].message
+
+    @patch("azlin.batch_executor.VMLifecycleController")
+    def test_execute_stop_with_progress_callback(self, mock_lifecycle, running_vms):
+        mock_lifecycle.stop_vm.return_value = MagicMock(success=True, message="Stopped")
+
+        messages = []
+        executor = BatchExecutor(max_workers=1)
+        executor.execute_stop(running_vms, resource_group="rg", progress_callback=messages.append)
+
+        # Should have at least one message per VM
+        assert len(messages) >= 3
+
+    @patch("azlin.batch_executor.VMLifecycleController")
+    def test_execute_start_success(self, mock_lifecycle, running_vms):
+        mock_lifecycle.start_vm.return_value = MagicMock(success=True, message="Started")
+
+        executor = BatchExecutor(max_workers=2)
+        results = executor.execute_start(running_vms, resource_group="rg")
+
+        assert len(results) == 3
+        assert all(r.success for r in results)
+
+    def test_execute_start_empty_list(self):
+        executor = BatchExecutor(max_workers=2)
+        assert executor.execute_start([], resource_group="rg") == []
+
+    @patch("azlin.batch_executor.SSHKeyManager")
+    @patch("azlin.batch_executor.RemoteExecutor")
+    def test_execute_command_success(self, mock_remote, mock_keys, running_vms):
+        mock_keys.ensure_key_exists.return_value = MagicMock(
+            private_path=Path("/home/azureuser/.ssh/id_rsa")
+        )
+        mock_remote.execute_command.return_value = RemoteResult(
+            vm_name="vm", success=True, stdout="hello\n", stderr="", exit_code=0
+        )
+
+        executor = BatchExecutor(max_workers=2)
+        results = executor.execute_command(running_vms, "echo hello", resource_group="rg")
+
+        assert len(results) == 3
+        assert all(r.success for r in results)
+        assert all("Exit code: 0" in r.message for r in results)
+
+    @patch("azlin.batch_executor.SSHKeyManager")
+    @patch("azlin.batch_executor.RemoteExecutor")
+    def test_execute_command_vm_no_ip(self, mock_remote, mock_keys):
+        """VM without public IP should fail gracefully."""
+        mock_keys.ensure_key_exists.return_value = MagicMock(
+            private_path=Path("/home/azureuser/.ssh/id_rsa")
+        )
+        vms = [_make_vm("vm-no-ip", public_ip=None)]
+
+        executor = BatchExecutor(max_workers=1)
+        results = executor.execute_command(vms, "echo hello", resource_group="rg")
+
+        assert len(results) == 1
+        assert results[0].success is False
+        assert "no public ip" in results[0].message.lower()
+
+    def test_execute_command_empty_list(self):
+        executor = BatchExecutor(max_workers=2)
+        assert executor.execute_command([], "echo", resource_group="rg") == []
+
+    def test_execute_sync_empty_list(self):
+        executor = BatchExecutor(max_workers=2)
+        assert executor.execute_sync([], resource_group="rg") == []
+
+
+# ---------------------------------------------------------------------------
+# VMMetrics
+# ---------------------------------------------------------------------------
+
+
+class TestVMMetrics:
+    def test_meets_condition_idle(self):
+        m = VMMetrics(
+            vm_name="vm1",
+            load_avg=(0.1, 0.2, 0.3),
+            cpu_percent=5.0,
+            memory_percent=30.0,
+            is_idle=True,
+            success=True,
+        )
+        assert m.meets_condition("idle") is True
+
+    def test_meets_condition_not_idle(self):
+        m = VMMetrics(
+            vm_name="vm1",
+            load_avg=(0.1, 0.2, 0.3),
+            cpu_percent=5.0,
+            memory_percent=30.0,
+            is_idle=False,
+            success=True,
+        )
+        assert m.meets_condition("idle") is False
+
+    def test_meets_condition_cpu_below(self):
+        m = VMMetrics(
+            vm_name="vm1",
+            load_avg=None,
+            cpu_percent=40.0,
+            memory_percent=None,
+            is_idle=False,
+            success=True,
+        )
+        assert m.meets_condition("cpu<50") is True
+        assert m.meets_condition("cpu<30") is False
+
+    def test_meets_condition_memory_below(self):
+        m = VMMetrics(
+            vm_name="vm1",
+            load_avg=None,
+            cpu_percent=None,
+            memory_percent=60.0,
+            is_idle=False,
+            success=True,
+        )
+        assert m.meets_condition("mem<80") is True
+        assert m.meets_condition("mem<50") is False
+
+    def test_meets_condition_failed_metrics(self):
+        m = VMMetrics(
+            vm_name="vm1",
+            load_avg=None,
+            cpu_percent=None,
+            memory_percent=None,
+            is_idle=False,
+            success=False,
+        )
+        assert m.meets_condition("idle") is False
+
+    def test_meets_condition_unknown_raises(self):
+        m = VMMetrics(
+            vm_name="vm1",
+            load_avg=None,
+            cpu_percent=None,
+            memory_percent=None,
+            is_idle=False,
+            success=True,
+        )
+        with pytest.raises(BatchExecutorError, match="Unknown condition"):
+            m.meets_condition("disk<90")
+
+    def test_meets_condition_invalid_cpu_format_raises(self):
+        m = VMMetrics(
+            vm_name="vm1",
+            load_avg=None,
+            cpu_percent=50.0,
+            memory_percent=None,
+            is_idle=False,
+            success=True,
+        )
+        with pytest.raises(BatchExecutorError, match="Invalid CPU condition"):
+            m.meets_condition("cpu>50")
+
+    def test_meets_condition_cpu_none(self):
+        m = VMMetrics(
+            vm_name="vm1",
+            load_avg=None,
+            cpu_percent=None,
+            memory_percent=None,
+            is_idle=False,
+            success=True,
+        )
+        assert m.meets_condition("cpu<50") is False
+
+
+# ---------------------------------------------------------------------------
+# MetricsCollector
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsCollector:
+    @patch("azlin.batch_executor.RemoteExecutor")
+    def test_collect_metrics_success(self, mock_remote, ssh_config):
+        mock_remote.execute_command.return_value = RemoteResult(
+            vm_name="vm1",
+            success=True,
+            stdout="0.10 0.20 0.30\n15.5\n42.3\nfalse\n",
+            stderr="",
+            exit_code=0,
+        )
+
+        vm = _make_vm("vm1")
+        metrics = MetricsCollector.collect_metrics(vm, ssh_config)
+
+        assert metrics.success is True
+        assert metrics.load_avg == (0.10, 0.20, 0.30)
+        assert metrics.cpu_percent == 15.5
+        assert metrics.memory_percent == 42.3
+        assert metrics.is_idle is False
+
+    @patch("azlin.batch_executor.RemoteExecutor")
+    def test_collect_metrics_ssh_failure(self, mock_remote, ssh_config):
+        mock_remote.execute_command.return_value = RemoteResult(
+            vm_name="vm1", success=False, stdout="", stderr="Connection refused", exit_code=255
+        )
+
+        vm = _make_vm("vm1")
+        metrics = MetricsCollector.collect_metrics(vm, ssh_config)
+
+        assert metrics.success is False
+        assert metrics.error is not None
+
+    @patch("azlin.batch_executor.RemoteExecutor")
+    def test_collect_metrics_incomplete_output(self, mock_remote, ssh_config):
+        mock_remote.execute_command.return_value = RemoteResult(
+            vm_name="vm1", success=True, stdout="0.10 0.20\n", stderr="", exit_code=0
+        )
+
+        vm = _make_vm("vm1")
+        metrics = MetricsCollector.collect_metrics(vm, ssh_config)
+
+        assert metrics.success is False
+        assert "Incomplete" in metrics.error
+
+    @patch("azlin.batch_executor.RemoteExecutor")
+    def test_collect_metrics_exception(self, mock_remote, ssh_config):
+        mock_remote.execute_command.side_effect = Exception("SSH broken")
+
+        vm = _make_vm("vm1")
+        metrics = MetricsCollector.collect_metrics(vm, ssh_config)
+
+        assert metrics.success is False
+        assert "SSH broken" in metrics.error

--- a/tests/unit/test_remote_exec.py
+++ b/tests/unit/test_remote_exec.py
@@ -1,0 +1,506 @@
+"""Unit tests for remote_exec module.
+
+Tests the SSH command execution backbone with mocked subprocess calls.
+Covers RemoteExecutor, TmuxSessionExecutor, PSCommandExecutor,
+WCommandExecutor, and OSUpdateExecutor.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from azlin.modules.ssh_connector import SSHConfig
+from azlin.remote_exec import (
+    OSUpdateExecutor,
+    PSCommandExecutor,
+    RemoteExecError,
+    RemoteExecutor,
+    RemoteResult,
+    TmuxSessionExecutor,
+    WCommandExecutor,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ssh_config():
+    """Standard SSH config for tests."""
+    return SSHConfig(
+        host="10.0.0.1",
+        user="azureuser",
+        key_path=Path("/home/azureuser/.ssh/id_rsa"),
+        port=22,
+    )
+
+
+@pytest.fixture
+def ssh_configs(ssh_config):
+    """Multiple SSH configs for parallel execution tests."""
+    return [
+        ssh_config,
+        SSHConfig(host="10.0.0.2", user="azureuser", key_path=Path("/home/azureuser/.ssh/id_rsa")),
+        SSHConfig(host="10.0.0.3", user="azureuser", key_path=Path("/home/azureuser/.ssh/id_rsa")),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# RemoteResult
+# ---------------------------------------------------------------------------
+
+
+class TestRemoteResult:
+    """Tests for the RemoteResult dataclass."""
+
+    def test_get_output_stdout_only(self):
+        r = RemoteResult(vm_name="vm1", success=True, stdout="hello", stderr="", exit_code=0)
+        assert r.get_output() == "hello"
+
+    def test_get_output_stderr_only(self):
+        r = RemoteResult(vm_name="vm1", success=False, stdout="", stderr="err", exit_code=1)
+        assert r.get_output() == "err"
+
+    def test_get_output_both(self):
+        r = RemoteResult(vm_name="vm1", success=True, stdout="out", stderr="warn", exit_code=0)
+        assert r.get_output() == "out\nwarn"
+
+    def test_get_output_empty(self):
+        r = RemoteResult(vm_name="vm1", success=True, stdout="", stderr="", exit_code=0)
+        assert r.get_output() == ""
+
+
+# ---------------------------------------------------------------------------
+# RemoteExecutor.execute_command
+# ---------------------------------------------------------------------------
+
+
+class TestRemoteExecutorCommand:
+    """Tests for single-VM command execution."""
+
+    @patch("azlin.remote_exec.subprocess.run")
+    def test_successful_command(self, mock_run, ssh_config):
+        mock_run.return_value = MagicMock(returncode=0, stdout="output line\n", stderr="")
+
+        result = RemoteExecutor.execute_command(ssh_config, "echo hello", timeout=10)
+
+        assert result.success is True
+        assert result.exit_code == 0
+        assert result.stdout == "output line\n"
+        assert result.vm_name == "10.0.0.1"
+        assert result.duration > 0
+
+        # Verify SSH command structure
+        args = mock_run.call_args[0][0]
+        assert args[0] == "ssh"
+        assert "-i" in args
+        assert "azureuser@10.0.0.1" in args
+        assert args[-1] == "echo hello"
+
+    @patch("azlin.remote_exec.subprocess.run")
+    def test_failed_command_nonzero_exit(self, mock_run, ssh_config):
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="command not found")
+
+        result = RemoteExecutor.execute_command(ssh_config, "bad_cmd")
+
+        assert result.success is False
+        assert result.exit_code == 1
+        assert "command not found" in result.stderr
+
+    @patch("azlin.remote_exec.subprocess.run")
+    def test_timeout_raises_remote_exec_error(self, mock_run, ssh_config):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="ssh", timeout=5)
+
+        with pytest.raises(RemoteExecError, match="timed out"):
+            RemoteExecutor.execute_command(ssh_config, "sleep 100", timeout=5)
+
+    @patch("azlin.remote_exec.subprocess.run")
+    def test_connection_error_raises_remote_exec_error(self, mock_run, ssh_config):
+        mock_run.side_effect = OSError("Connection refused")
+
+        with pytest.raises(RemoteExecError, match="Failed to execute"):
+            RemoteExecutor.execute_command(ssh_config, "echo hello")
+
+    @patch("azlin.remote_exec.subprocess.run")
+    def test_connect_timeout_capped_at_10(self, mock_run, ssh_config):
+        """ConnectTimeout should be min(timeout, 10)."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        RemoteExecutor.execute_command(ssh_config, "echo test", timeout=60)
+
+        args = mock_run.call_args[0][0]
+        assert "ConnectTimeout=10" in " ".join(args)
+
+    @patch("azlin.remote_exec.subprocess.run")
+    def test_connect_timeout_uses_smaller_value(self, mock_run, ssh_config):
+        """ConnectTimeout should be min(timeout, 10) when timeout < 10."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        RemoteExecutor.execute_command(ssh_config, "echo test", timeout=3)
+
+        args = mock_run.call_args[0][0]
+        assert "ConnectTimeout=3" in " ".join(args)
+
+
+# ---------------------------------------------------------------------------
+# RemoteExecutor.execute_parallel
+# ---------------------------------------------------------------------------
+
+
+class TestRemoteExecutorParallel:
+    """Tests for parallel command execution across multiple VMs."""
+
+    @patch.object(RemoteExecutor, "execute_command")
+    def test_parallel_all_succeed(self, mock_exec, ssh_configs):
+        mock_exec.side_effect = [
+            RemoteResult(vm_name=c.host, success=True, stdout="ok", stderr="", exit_code=0)
+            for c in ssh_configs
+        ]
+
+        results = RemoteExecutor.execute_parallel(ssh_configs, "echo test")
+
+        assert len(results) == 3
+        assert all(r.success for r in results)
+
+    @patch.object(RemoteExecutor, "execute_command")
+    def test_parallel_one_failure_others_continue(self, mock_exec, ssh_configs):
+        """If one VM fails, the others should still produce results."""
+        mock_exec.side_effect = [
+            RemoteResult(vm_name="10.0.0.1", success=True, stdout="ok", stderr="", exit_code=0),
+            RemoteExecError("Connection refused"),
+            RemoteResult(vm_name="10.0.0.3", success=True, stdout="ok", stderr="", exit_code=0),
+        ]
+
+        results = RemoteExecutor.execute_parallel(ssh_configs, "echo test")
+
+        assert len(results) == 3
+        successes = [r for r in results if r.success]
+        failures = [r for r in results if not r.success]
+        assert len(successes) == 2
+        assert len(failures) == 1
+        assert failures[0].exit_code == -1
+
+    def test_parallel_empty_list(self):
+        results = RemoteExecutor.execute_parallel([], "echo test")
+        assert results == []
+
+    @patch.object(RemoteExecutor, "execute_command")
+    def test_parallel_respects_max_workers(self, mock_exec, ssh_configs):
+        mock_exec.return_value = RemoteResult(
+            vm_name="vm", success=True, stdout="", stderr="", exit_code=0
+        )
+
+        # max_workers=1 should still work, just sequentially
+        results = RemoteExecutor.execute_parallel(ssh_configs, "echo test", max_workers=1)
+        assert len(results) == 3
+
+
+# ---------------------------------------------------------------------------
+# RemoteExecutor.format_parallel_output
+# ---------------------------------------------------------------------------
+
+
+class TestFormatParallelOutput:
+    def test_format_with_vm_names(self):
+        results = [
+            RemoteResult(
+                vm_name="vm1", success=True, stdout="line1\nline2", stderr="", exit_code=0
+            ),
+            RemoteResult(vm_name="vm2", success=False, stdout="", stderr="oops", exit_code=1),
+        ]
+
+        output = RemoteExecutor.format_parallel_output(results, show_vm_name=True)
+
+        assert "[vm1] line1" in output
+        assert "[vm1] line2" in output
+        assert "[vm2] ERROR: oops" in output
+
+    def test_format_without_vm_names(self):
+        results = [
+            RemoteResult(vm_name="vm1", success=True, stdout="hello", stderr="", exit_code=0),
+        ]
+
+        output = RemoteExecutor.format_parallel_output(results, show_vm_name=False)
+        assert "[vm1]" not in output
+        assert "hello" in output
+
+
+# ---------------------------------------------------------------------------
+# RemoteExecutor.parse_command_from_args / extract_command_slug
+# ---------------------------------------------------------------------------
+
+
+class TestCommandParsing:
+    def test_parse_command_from_args_with_delimiter(self):
+        args = ["azlin", "run", "--", "echo", "hello", "world"]
+        result = RemoteExecutor.parse_command_from_args(args)
+        assert result == "echo hello world"
+
+    def test_parse_command_from_args_no_delimiter(self):
+        args = ["azlin", "run", "echo"]
+        assert RemoteExecutor.parse_command_from_args(args) is None
+
+    def test_parse_command_from_args_empty_after_delimiter(self):
+        args = ["azlin", "--"]
+        assert RemoteExecutor.parse_command_from_args(args) is None
+
+    def test_extract_command_slug_basic(self):
+        slug = RemoteExecutor.extract_command_slug("python script.py --arg")
+        # Takes first 3 words, cleans special chars to dashes, strips leading/trailing dashes
+        assert slug == "python-script-py-arg"
+
+    def test_extract_command_slug_truncation(self):
+        slug = RemoteExecutor.extract_command_slug(
+            "a_very_long_command with many arguments", max_length=10
+        )
+        assert len(slug) <= 10
+
+    def test_extract_command_slug_empty(self):
+        slug = RemoteExecutor.extract_command_slug("")
+        assert slug == "cmd"
+
+
+# ---------------------------------------------------------------------------
+# TmuxSessionExecutor
+# ---------------------------------------------------------------------------
+
+
+class TestTmuxSessionExecutor:
+    @patch.object(RemoteExecutor, "execute_command")
+    def test_get_sessions_new_format(self, mock_exec, ssh_config):
+        """Parse new tmux format: name:attached:windows:created."""
+        mock_exec.return_value = RemoteResult(
+            vm_name="10.0.0.1",
+            success=True,
+            stdout="dev:1:3:1696932000\nwork:0:2:1696932100\n",
+            stderr="",
+            exit_code=0,
+        )
+
+        sessions = TmuxSessionExecutor.get_sessions_single_vm(ssh_config, vm_name="myvm")
+
+        assert len(sessions) == 2
+        assert sessions[0].session_name == "dev"
+        assert sessions[0].attached is True
+        assert sessions[0].windows == 3
+        assert sessions[1].session_name == "work"
+        assert sessions[1].attached is False
+
+    @patch.object(RemoteExecutor, "execute_command")
+    def test_get_sessions_old_format(self, mock_exec, ssh_config):
+        """Parse old tmux format: name: X windows (created date)."""
+        mock_exec.return_value = RemoteResult(
+            vm_name="10.0.0.1",
+            success=True,
+            stdout="dev: 3 windows (created Thu Oct 10 10:00:00 2024) (attached)\n",
+            stderr="",
+            exit_code=0,
+        )
+
+        sessions = TmuxSessionExecutor.get_sessions_single_vm(ssh_config, vm_name="myvm")
+
+        assert len(sessions) == 1
+        assert sessions[0].session_name == "dev"
+        assert sessions[0].windows == 3
+        assert sessions[0].attached is True
+
+    @patch.object(RemoteExecutor, "execute_command")
+    def test_get_sessions_no_sessions(self, mock_exec, ssh_config):
+        mock_exec.return_value = RemoteResult(
+            vm_name="10.0.0.1", success=True, stdout="No sessions\n", stderr="", exit_code=0
+        )
+
+        sessions = TmuxSessionExecutor.get_sessions_single_vm(ssh_config)
+        assert sessions == []
+
+    @patch.object(RemoteExecutor, "execute_command")
+    def test_get_sessions_ssh_failure(self, mock_exec, ssh_config):
+        mock_exec.return_value = RemoteResult(
+            vm_name="10.0.0.1", success=False, stdout="", stderr="Connection refused", exit_code=255
+        )
+
+        sessions = TmuxSessionExecutor.get_sessions_single_vm(ssh_config)
+        assert sessions == []
+
+    def test_format_sessions_display_empty(self):
+        assert TmuxSessionExecutor.format_sessions_display([]) == "No sessions"
+
+    @patch.object(RemoteExecutor, "execute_parallel")
+    def test_get_sessions_parallel(self, mock_parallel, ssh_configs):
+        mock_parallel.return_value = [
+            RemoteResult(
+                vm_name="vm1", success=True, stdout="s1:0:1:123\n", stderr="", exit_code=0
+            ),
+            RemoteResult(
+                vm_name="vm2", success=True, stdout="No sessions\n", stderr="", exit_code=0
+            ),
+            RemoteResult(vm_name="vm3", success=False, stdout="", stderr="err", exit_code=1),
+        ]
+
+        sessions = TmuxSessionExecutor.get_sessions_parallel(ssh_configs)
+
+        assert len(sessions) == 1
+        assert sessions[0].session_name == "s1"
+
+
+# ---------------------------------------------------------------------------
+# PSCommandExecutor
+# ---------------------------------------------------------------------------
+
+
+class TestPSCommandExecutor:
+    def test_is_ssh_process_sshd(self):
+        assert PSCommandExecutor._is_ssh_process("root 1234 0.0 sshd: azureuser@notty") is True
+
+    def test_is_ssh_process_regular(self):
+        assert PSCommandExecutor._is_ssh_process("azureuser 1234 0.0 python3 script.py") is False
+
+    def test_is_ssh_process_header(self):
+        assert PSCommandExecutor._is_ssh_process("USER PID %CPU") is False
+
+    def test_filter_user_processes_basic(self):
+        ps_output = (
+            "USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND\n"
+            "azureuser  1234  0.0  0.1  12345  6789 pts/0   S+   12:00   0:00 python3 script.py\n"
+            "azureuser  5678  0.0  0.2  23456  7890 pts/1   S+   12:01   0:00 node server.js\n"
+            "root       9012  0.0  0.0   1234   567 ?       Ss   11:00   0:00 [kworker/0:0]\n"
+            "azureuser  3456  0.0  0.0   1234   567 ?       Ss   11:00   0:00 sshd: azureuser@notty\n"
+        )
+
+        procs = PSCommandExecutor.filter_user_processes(ps_output)
+
+        assert "python3" in procs
+        assert "node" in procs
+        assert len(procs) == 2
+
+    def test_filter_user_processes_truncated_username(self):
+        """ps aux truncates usernames to 8 chars + '+' (azureus+)."""
+        ps_output = (
+            "USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND\n"
+            "azureus+ 1234  0.0  0.1  12345  6789 pts/0   S+   12:00   0:00 python3 app.py\n"
+        )
+
+        procs = PSCommandExecutor.filter_user_processes(ps_output)
+        assert "python3" in procs
+
+    def test_filter_user_processes_max_five(self):
+        lines = ["USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND\n"]
+        for i in range(10):
+            lines.append(
+                f"azureuser  {1000 + i}  0.0  0.1  12345  6789 pts/0   S+   12:00   0:00 proc{i} arg\n"
+            )
+        ps_output = "".join(lines)
+
+        procs = PSCommandExecutor.filter_user_processes(ps_output)
+        assert len(procs) == 5
+
+    def test_format_ps_output_filters_ssh(self):
+        results = [
+            RemoteResult(
+                vm_name="vm1",
+                success=True,
+                stdout="USER PID CMD\nazureuser 123 python3\nroot 456 sshd: azureuser@notty\n",
+                stderr="",
+                exit_code=0,
+            )
+        ]
+
+        output = PSCommandExecutor.format_ps_output(results, filter_ssh=True)
+        assert "python3" in output
+        assert "sshd:" not in output
+
+
+# ---------------------------------------------------------------------------
+# WCommandExecutor
+# ---------------------------------------------------------------------------
+
+
+class TestWCommandExecutor:
+    def test_format_w_output_with_session(self):
+        results = [
+            RemoteResult(
+                vm_name="vm1",
+                success=True,
+                stdout="12:00 up 1 day",
+                stderr="",
+                exit_code=0,
+                session_name="dev",
+            ),
+        ]
+
+        output = WCommandExecutor.format_w_output(results)
+        assert "vm1" in output
+        assert "Session: dev" in output
+        assert "12:00 up 1 day" in output
+
+    def test_format_w_output_error(self):
+        results = [
+            RemoteResult(
+                vm_name="vm2",
+                success=False,
+                stdout="",
+                stderr="Connection refused",
+                exit_code=255,
+            ),
+        ]
+
+        output = WCommandExecutor.format_w_output(results)
+        assert "ERROR: Connection refused" in output
+
+
+# ---------------------------------------------------------------------------
+# OSUpdateExecutor
+# ---------------------------------------------------------------------------
+
+
+class TestOSUpdateExecutor:
+    @patch.object(RemoteExecutor, "execute_command")
+    def test_execute_os_update_success(self, mock_exec, ssh_config):
+        mock_exec.return_value = RemoteResult(
+            vm_name="10.0.0.1",
+            success=True,
+            stdout="0 upgraded, 0 newly installed",
+            stderr="",
+            exit_code=0,
+            duration=45.0,
+        )
+
+        result = OSUpdateExecutor.execute_os_update(ssh_config, timeout=300)
+        assert result.success is True
+
+        # Verify the command used
+        mock_exec.assert_called_once_with(
+            ssh_config, "sudo apt update && sudo apt upgrade -y", timeout=300
+        )
+
+    def test_format_output_success(self):
+        r = RemoteResult(
+            vm_name="vm1",
+            success=True,
+            stdout="5 upgraded, 2 newly installed",
+            stderr="",
+            exit_code=0,
+            duration=120.5,
+        )
+
+        output = OSUpdateExecutor.format_output(r)
+        assert "SUCCESS" in output
+        assert "120.5s" in output
+        assert "Update completed successfully" in output
+
+    def test_format_output_failure(self):
+        r = RemoteResult(
+            vm_name="vm1",
+            success=False,
+            stdout="",
+            stderr="E: Unable to lock",
+            exit_code=100,
+            duration=5.0,
+        )
+
+        output = OSUpdateExecutor.format_output(r)
+        assert "FAILED" in output
+        assert "E: Unable to lock" in output


### PR DESCRIPTION
## Summary

- Add **80 unit tests** covering `remote_exec.py` (40 tests) and `batch_executor.py` (40 tests)
- All tests use mocked subprocess/SSH with zero external dependencies
- Full suite completes in **< 0.3 seconds**

## Test Coverage

### `test_remote_exec.py` (40 tests)
- `RemoteResult` - output merging (stdout, stderr, combined, empty)
- `RemoteExecutor.execute_command` - success, failure, timeout, connection error, ConnectTimeout capping
- `RemoteExecutor.execute_parallel` - all succeed, one failure (others continue), empty list, max_workers
- `RemoteExecutor.format_parallel_output` - with/without VM name prefix
- `RemoteExecutor.parse_command_from_args` - delimiter parsing, missing delimiter, empty after delimiter
- `RemoteExecutor.extract_command_slug` - basic, truncation, empty input
- `TmuxSessionExecutor` - new format parsing, old format parsing, no sessions, SSH failure, parallel, display formatting
- `PSCommandExecutor` - SSH process detection, user process filtering (incl. truncated username `azureus+`), max 5 limit, SSH filtering in output
- `WCommandExecutor` - output formatting with session name, error formatting
- `OSUpdateExecutor` - execute success, format success/failure output

### `test_batch_executor.py` (40 tests)
- `TagFilter` - parse valid/invalid, whitespace, equals in value, matching VMs, no tags
- `BatchResult` - total/succeeded/failed properties, all_succeeded, get_failures/successes, format_summary
- `BatchSelector` - select by tag, pattern, wildcard, all, running only
- `BatchExecutor` - stop/start/command with parallel execution, one-failure-others-continue isolation, progress callbacks, VM with no public IP, empty lists
- `VMMetrics` - idle/cpu/memory conditions, failed metrics, unknown condition, invalid format
- `MetricsCollector` - success parsing, SSH failure, incomplete output, exception handling

## Step 13: Local Testing Results

**Scenario 1 (simple):** Run both test files individually
```
$ uv run python -m pytest tests/unit/test_remote_exec.py -v --tb=short
40 passed in 0.13s

$ uv run python -m pytest tests/unit/test_batch_executor.py -v --tb=short
40 passed in 0.10s
```

**Scenario 2 (combined):** Run together to verify no import conflicts
```
$ uv run python -m pytest tests/unit/test_remote_exec.py tests/unit/test_batch_executor.py -v --tb=short
80 passed in 0.22s
```

**Regression check:** Ran alongside existing tests (auth_security, azure_cli_executor) -- no regressions.

Closes #695

---
Generated with [Claude Code](https://claude.com/claude-code)