### PR TITLE
Fix: Add missing --mount flag to disk add help text examples

### DIFF
--- a/src/azlin/commands/disk.py
+++ b/src/azlin/commands/disk.py
@@ -60,14 +60,15 @@ def add_disk(
 
     \b
     EXAMPLES:
-        # Add a 64GB /tmp disk
-        $ azlin disk add my-vm --size 64
-
-        # Add a 128GB disk mounted at /tmp with Premium storage
-        $ azlin disk add my-vm --size 128 --sku Premium_LRS
-
-        # Add a disk with custom mount point
-        $ azlin disk add my-vm --size 256 --mount /data
+    \b
+    # Add a 64GB /tmp disk
+    $ azlin disk add my-vm --size 64
+    \b
+    # Add a 128GB /tmp disk explicitly
+    $ azlin disk add my-vm --size 128 --mount /tmp
+    \b
+    # Add a disk with custom mount point
+    $ azlin disk add my-vm --size 256 --mount /data
     """
     try:
         # Resolve session name to VM name if applicable


### PR DESCRIPTION
## Summary

Fixes #705 - Improves help text formatting and accuracy for `azlin disk add` command.

### Changes Made

1. **Added explicit `--mount /tmp` flag to Example #2** - Previously, the example claimed the disk was "mounted at /tmp" but didn't show the flag, causing confusion about default behavior vs explicit specification.

2. **Updated example comment for clarity** - Changed from "with Premium storage" to "explicitly" since we're demonstrating explicit mount point specification.

3. **Added Click `\b` escape markers** - Attempted to improve text wrapping behavior (partial improvement).

4. **Shortened example text** - Reduced line length to minimize wrapping issues.

## Step 13: Local Testing Results

**Test Environment**: feat/issue-705-fix-disk-add-help-formatting branch, uvx installation

**Tests Executed**:
1. **Simple**: Display help text → ✅ `--mount /tmp` flag now visible in Example #2
2. **Complex**: Verify flag documentation matches behavior → ✅ Options section correctly shows `--mount TEXT` with default `/tmp`

**Regressions**: ✅ None detected
- No other commands affected
- All pre-commit hooks pass (ruff, pyright, formatting)
- No logic changes (docstring only)

## Before & After

**Before**:
```
# Add a 128GB disk mounted at /tmp with Premium storage
$ azlin disk add my-vm --size 128 --sku Premium_LRS
```
❌ Missing `--mount /tmp` flag despite comment claiming "/tmp" mount

**After**:
```
# Add a 128GB /tmp disk explicitly
$ azlin disk add my-vm --size 128 --mount /tmp
```
✅ Explicitly shows `--mount /tmp` flag

## Testing Instructions

```bash
# Install from this branch
uvx --from git+https://github.com/rysweet/azlin@feat/issue-705-fix-disk-add-help-formatting azlin disk add --help

# Verify:
# 1. Example #2 shows --mount /tmp flag
# 2. Help text is more accurate
# 3. No wrapping in short terminal widths (80 cols)
```

## Notes

- This is a documentation-only change (docstring text)
- No logic or behavior changes
- Click text wrapping partially improved with `\b` markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)