### PR TITLE
fix: Replace remaining datetime.utcnow() in lifecycle_manager.py (fixes #707)

### DIFF
--- a/src/azlin/lifecycle/lifecycle_manager.py
+++ b/src/azlin/lifecycle/lifecycle_manager.py
@@ -15,7 +15,7 @@ Public API (Studs):
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 try:
@@ -81,7 +81,7 @@ class MonitoringStatus:
     vm_name: str
     enabled: bool
     config: MonitoringConfig
-    last_updated: datetime = field(default_factory=datetime.utcnow)
+    last_updated: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 
 class LifecycleManager:


### PR DESCRIPTION
## Summary
- Replaced the last remaining `datetime.utcnow()` call in `lifecycle_manager.py` with `datetime.now(UTC)` to fix the Python 3.12+ deprecation warning
- Added `UTC` to the `datetime` module import
- The change is in the `MonitoringStatus` dataclass `default_factory` on line 84

## Test Results

**Lifecycle manager tests (11/11 passed):**
```
tests/lifecycle/test_lifecycle_manager.py ...........  [100%]
11 passed in 0.13s
```

**Pre-commit hooks:** All 10 checks passed (ruff, ruff format, pyright, etc.)

## Test plan
- [x] Run lifecycle manager unit tests -- 11/11 passed
- [x] Verify no other `utcnow()` calls remain in the file
- [x] All pre-commit hooks pass (including pyright type checking)

Closes #707

Generated with [Claude Code](https://claude.com/claude-code)