### PR TITLE
fix: Resolve 6 skipped tests by implementing missing features (fixes #709)

### DIFF
--- a/tests/unit/test_auth_security.py
+++ b/tests/unit/test_auth_security.py
@@ -411,7 +411,6 @@ certificate_path = "{cert_file}"
                         "****" in record.message
                     )
 
-    @pytest.mark.skip(reason="Requires _authenticate_with_secret method - future implementation")
     def test_log_sanitization_in_error_messages(self, tmp_path, monkeypatch):
         """Test that error messages don't leak secrets."""
         config_file = tmp_path / "config.toml"
@@ -698,7 +697,6 @@ auth_method = "client_secret"  # noqa: S105, S106
                 assert secret not in str(e)  # noqa: PT017
                 assert "****" in str(e) or "[REDACTED]" in str(e)  # noqa: PT017
 
-    @pytest.mark.skip(reason="Requires path masking in error messages - future implementation")
     def test_file_not_found_error_masks_sensitive_paths(self):
         """Test that file not found errors don't leak sensitive paths."""
         sensitive_path = "/home/user/.azlin/production-secrets/super-secret-key.pem"
@@ -726,9 +724,6 @@ auth_method = "client_secret"  # noqa: S105, S106
             # Error should not contain the secret
             assert "my-secret-password" not in str(e)  # noqa: PT017
 
-    @pytest.mark.skip(
-        reason="Requires custom __repr__ in ServicePrincipalError - future implementation"
-    )
     def test_exception_repr_masks_secrets(self):
         """Test that exception __repr__ masks secrets."""
         error = ServicePrincipalError("Authentication failed with secret: super-secret-123")


### PR DESCRIPTION
## Summary

- Resolved all 6 skipped tests across 2 test files by implementing the missing security features and fixing incorrect mock targets
- Added secret masking (`_mask_secrets`) and sensitive path masking (`_mask_sensitive_paths`) to `ServicePrincipalError.__init__` so all error messages are automatically sanitized
- Added `_authenticate_with_secret` method to `ServicePrincipalManager` and refactored `get_credentials` to delegate client_secret auth through it with error sanitization
- Rewrote 3 CLI error tests to target the actual auth error paths (`--auth-profile` + `AzureAuthenticator.get_credentials`) instead of nonexistent mock targets

## Changes

### `src/azlin/service_principal_auth.py`
- `ServicePrincipalError`: Added `__init__` with `_mask_secrets()` and `_mask_sensitive_paths()`, plus custom `__repr__` -- all error messages now automatically mask secret values and sensitive path components
- `ServicePrincipalManager._authenticate_with_secret()`: New method that retrieves client secret from env vars with error sanitization wrapping
- `ServicePrincipalManager.get_credentials()`: Refactored client_secret branch to delegate to `_authenticate_with_secret` with exception wrapping

### `tests/unit/test_cli_errors.py` (3 skips removed)
- `test_new_command_auth_failure`: Rewrote to mock `AzureAuthenticator` class and test `--auth-profile` error path
- `test_list_command_auth_failure`: Same approach for list command
- `test_missing_prerequisites`: Fixed mock path to `PrerequisiteChecker.check_all`, corrected field name to `all_available`

### `tests/unit/test_auth_security.py` (3 skips removed)
- `test_log_sanitization_in_error_messages`: Unskipped -- works with new `_authenticate_with_secret`
- `test_file_not_found_error_masks_sensitive_paths`: Unskipped -- works with new `_mask_sensitive_paths`
- `test_exception_repr_masks_secrets`: Unskipped -- works with new `__repr__`

## Test plan

- [x] Run target test files: 96 passed, 0 skipped, 0 failed
- [x] Run broader test suite (315 tests across service_principal, cli_errors, config, vm_provisioning): all pass
- [x] All pre-commit hooks pass (ruff, ruff-format, pyright)
- [x] Verified zero regressions in related test files

**Step 13: Local Testing Results**

```
$ .venv/bin/python -m pytest tests/unit/test_cli_errors.py tests/unit/test_auth_security.py -v -p no:warnings
96 passed in 0.80s

$ .venv/bin/python -m pytest tests/unit/test_auth_security.py tests/unit/test_cli_errors.py tests/unit/test_config*.py tests/unit/test_service_principal*.py tests/unit/test_vm_provisioning*.py -m "not tdd_red" --tb=no -q -p no:warnings
315 passed in 3.79s
```

Closes #709

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>