### PR TITLE
feat: Add --os option to specify Ubuntu version (fixes #714)

### DIFF
--- a/src/azlin/cli_helpers.py
+++ b/src/azlin/cli_helpers.py
@@ -1603,12 +1603,12 @@ def _generate_clone_configs(
 
     for i in range(1, num_replicas + 1):
         vm_name = f"azlin-vm-{timestamp}-{i}"
+        # Use VMConfig dataclass defaults (will use Ubuntu 25.10)
         config = VMConfig(
             name=vm_name,
             resource_group=source_vm.resource_group,
             location=clone_region,
             size=clone_size,
-            image="Ubuntu2204",
             ssh_public_key=None,  # Will use default SSH keys
             admin_username="azureuser",
             disable_password_auth=True,

--- a/src/azlin/image_mapper.py
+++ b/src/azlin/image_mapper.py
@@ -1,0 +1,129 @@
+"""OS image mapping for Azure VM provisioning.
+
+This module maps OS identifiers to Azure VM image URNs, supporting shorthand
+notation, URN aliases, and full URN passthroughs.
+
+Philosophy:
+- Ruthless simplicity: Dict-based O(1) lookup
+- Standard library only: No external dependencies
+- Self-contained and regeneratable: All mappings defined here
+
+Public API:
+    resolve_image: Map OS identifier to Azure URN
+    get_default_image: Return default OS URN
+    list_supported_os: List all supported OS mappings
+"""
+
+from __future__ import annotations
+
+__all__ = ["get_default_image", "list_supported_os", "resolve_image"]
+
+# Canonical OS image mappings (shorthand -> Azure URN)
+# Format: publisher:offer:sku:version
+_OS_IMAGE_MAP: dict[str, str] = {
+    # Ubuntu 25.10 (DEFAULT)
+    "25.10": "Canonical:ubuntu-25_10:server:latest",
+    "ubuntu2510": "Canonical:ubuntu-25_10:server:latest",
+    # Ubuntu 24.10
+    "24.10": "Canonical:ubuntu-24_10:server:latest",
+    "ubuntu2410": "Canonical:ubuntu-24_10:server:latest",
+    # Ubuntu 24.04 LTS
+    "24.04": "Canonical:ubuntu-24_04-lts:server:latest",
+    "24.04-lts": "Canonical:ubuntu-24_04-lts:server:latest",
+    "ubuntu2404": "Canonical:ubuntu-24_04-lts:server:latest",
+    # Ubuntu 22.04 LTS
+    "22.04": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest",
+    "22.04-lts": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest",
+    "ubuntu2204": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest",
+    # Ubuntu 20.04 LTS
+    "20.04": "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest",
+    "20.04-lts": "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest",
+    "ubuntu2004": "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest",
+}
+
+# Default OS image (Ubuntu 25.10)
+_DEFAULT_IMAGE = "Canonical:ubuntu-25_10:server:latest"
+
+
+def get_default_image() -> str:
+    """Return the default OS image URN.
+
+    Returns:
+        Azure URN for Ubuntu 25.10 (current default)
+
+    Example:
+        >>> get_default_image()
+        'Canonical:ubuntu-25_10:server:latest'
+    """
+    return _DEFAULT_IMAGE
+
+
+def resolve_image(os_identifier: str) -> str:
+    """Resolve OS identifier to Azure VM image URN.
+
+    Supports three formats:
+    1. Shorthand: "25.10", "24.04-lts", "22.04"
+    2. URN alias: "Ubuntu2510", "Ubuntu2404"
+    3. Full URN: "Canonical:ubuntu-25_10:server:latest" (passthrough)
+
+    Case-insensitive matching for all formats.
+
+    Args:
+        os_identifier: OS identifier in any supported format
+
+    Returns:
+        Azure URN string (publisher:offer:sku:version)
+
+    Raises:
+        ValueError: If OS identifier is not recognized
+
+    Examples:
+        >>> resolve_image("25.10")
+        'Canonical:ubuntu-25_10:server:latest'
+
+        >>> resolve_image("Ubuntu2510")
+        'Canonical:ubuntu-25_10:server:latest'
+
+        >>> resolve_image("24.04-lts")
+        'Canonical:ubuntu-24_04-lts:server:latest'
+
+        >>> resolve_image("Canonical:ubuntu-25_10:server:latest")
+        'Canonical:ubuntu-25_10:server:latest'
+    """
+    # Detect full URN format (contains colons)
+    if ":" in os_identifier:
+        # Passthrough full URN unchanged
+        return os_identifier
+
+    # Normalize to lowercase for case-insensitive lookup
+    normalized = os_identifier.lower()
+
+    # Lookup in mapping
+    if normalized in _OS_IMAGE_MAP:
+        return _OS_IMAGE_MAP[normalized]
+
+    # Not found - build helpful error message
+    supported = list_supported_os()
+    supported_list = "\n".join(f"  - {key}: {urn}" for key, urn in supported.items())
+
+    raise ValueError(
+        f"Unsupported OS identifier: '{os_identifier}'\n\n"
+        f"Supported OS options:\n{supported_list}\n\n"
+        f"Or provide full Azure URN (e.g., Canonical:ubuntu-25_10:server:latest)"
+    )
+
+
+def list_supported_os() -> dict[str, str]:
+    """List all supported OS identifiers and their URNs.
+
+    Returns:
+        Dictionary mapping OS identifier to Azure URN
+
+    Example:
+        >>> os_map = list_supported_os()
+        >>> "25.10" in os_map
+        True
+        >>> os_map["25.10"]
+        'Canonical:ubuntu-25_10:server:latest'
+    """
+    return _OS_IMAGE_MAP.copy()

--- a/src/azlin/modules/parallel_deployer.py
+++ b/src/azlin/modules/parallel_deployer.py
@@ -21,6 +21,8 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from azlin.image_mapper import get_default_image
+
 if TYPE_CHECKING:
     from azlin.config_manager import ConfigManager  # type: ignore[import]
     from azlin.models import VMConfig  # type: ignore[import]
@@ -254,7 +256,7 @@ class ParallelDeployer:
                     "--location",
                     region,
                     "--image",
-                    getattr(vm_config, "image", "Ubuntu2204"),
+                    getattr(vm_config, "image", get_default_image()),
                     "--size",
                     getattr(vm_config, "size", "Standard_D2s_v3"),
                     "--admin-username",

--- a/src/azlin/orchestrator.py
+++ b/src/azlin/orchestrator.py
@@ -112,6 +112,7 @@ class CLIOrchestrator:
         home_disk_size: int | None = None,
         no_home_disk: bool = False,
         tmp_disk_size: int | None = None,
+        os_image: str | None = None,
     ):
         """Initialize CLI orchestrator.
 
@@ -131,6 +132,7 @@ class CLIOrchestrator:
             home_disk_size: Size of separate /home disk in GB (optional, default: 100)
             no_home_disk: Disable separate /home disk (use OS disk only)
             tmp_disk_size: Size of separate /tmp disk in GB (optional, enables tmp disk)
+            os_image: OS image identifier (shorthand, alias, or URN; optional, defaults to Ubuntu 25.10)
 
         Note:
             SSH keys are automatically stored in Azure Key Vault (transparent operation)
@@ -150,6 +152,7 @@ class CLIOrchestrator:
         self.home_disk_size = home_disk_size
         self.no_home_disk = no_home_disk
         self.tmp_disk_size = tmp_disk_size
+        self.os_image = os_image
 
         # Initialize modules
         self.auth = AzureAuthenticator()
@@ -796,6 +799,7 @@ class CLIOrchestrator:
             tmp_disk_enabled=tmp_disk_enabled,
             tmp_disk_size_gb=tmp_disk_size,
             tmp_disk_sku="Standard_LRS",
+            image=self.os_image,
         )
 
         # Progress callback


### PR DESCRIPTION
## Summary

Adds `--os` CLI option to `azlin new` command and changes default OS from Ubuntu 22.04 to Ubuntu 25.10 (latest).

Fixes #714

## Changes

### New Module
- **`src/azlin/image_mapper.py`** - OS identifier to Azure URN mapping
  - Supports shorthand (25.10, 24.04-lts)
  - Supports URN aliases (Ubuntu2510, Ubuntu2404)
  - Supports full URNs (pass-through)
  - Case-insensitive matching
  - Helpful error messages

### Modified Files
- **`src/azlin/vm_provisioning.py`** - Changed VMConfig default to use `get_default_image()`
- **`src/azlin/commands/provisioning.py`** - Added `--os` option to `new` command
- **`src/azlin/orchestrator.py`** - Added `os_image` parameter
- **`src/azlin/cli_helpers.py`** - Removed hardcoded Ubuntu2204
- **`src/azlin/modules/parallel_deployer.py`** - Use `get_default_image()`

## Supported OS Versions

- Ubuntu 25.10 (DEFAULT)
- Ubuntu 24.10
- Ubuntu 24.04 LTS
- Ubuntu 22.04 LTS
- Ubuntu 20.04 LTS

## Usage Examples

```bash
# Use default (Ubuntu 25.10)
azlin new --name my-vm

# Use latest LTS
azlin new --name my-vm --os 24.04-lts

# Use old default
azlin new --name my-vm --os 22.04

# Use URN alias
azlin new --name my-vm --os Ubuntu2510

# Use full URN
azlin new --name my-vm --os "Canonical:ubuntu-25_10:server:latest"
```

## Step 13: Local Testing Results (Outside-In)

Tested with `uvx --from git+https://github.com/rysweet/azlin@feat/issue-714-os-selection`:

### Test 1: Help Text ✅
```bash
$ uvx --from git+...@feat/issue-714-os-selection azlin new --help | grep "os"
  --os TEXT    OS image (e.g., 25.10, 24.04-lts, Ubuntu2510, or full URN; default: Ubuntu 25.10)
```
**Result**: ✅ --os option appears in help with correct description

### Test 2: Default Behavior ✅
```python
from azlin.image_mapper import get_default_image
print(get_default_image())
# Output: Canonical:ubuntu-25_10:server:latest
```
**Result**: ✅ Default OS is Ubuntu 25.10 when --os not specified

### Test 3: Invalid OS Error Handling ✅
```bash
$ uvx --from git+...@feat/issue-714-os-selection azlin new --name test --os ubuntu-23.04
Error: Unsupported OS identifier: 'ubuntu-23.04'

Supported OS options:
  - 25.10: Canonical:ubuntu-25_10:server:latest
  - ubuntu2510: Canonical:ubuntu-25_10:server:latest
  - 24.10: Canonical:ubuntu-24_10:server:latest
  ...
  - 22.04: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
  ...
```
**Result**: ✅ Invalid OS shows helpful error with all supported options

### Test 4: VM Provisioning Start ✅
```bash
$ uvx --from git+...@feat/issue-714-os-selection azlin new --name test --os 25.10 --yes
► Starting: Prerequisites Check
✓ All prerequisites available
► Starting: Azure Authentication
✓ Authenticated with subscription
► Starting: Provisioning VM: test
... Region: westus2, Size: Standard_E16as_v5
```
**Result**: ✅ VM provisioning accepts --os 25.10 and starts correctly

### Test 5: Shorthand Formats ✅
Tested in isolation:
- `25.10` → `Canonical:ubuntu-25_10:server:latest` ✅
- `24.04-lts` → `Canonical:ubuntu-24_04-lts:server:latest` ✅
- `22.04` → `Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest` ✅
- `Ubuntu2510` → `Canonical:ubuntu-25_10:server:latest` ✅
- Case insensitive: `UBUNTU2510` works ✅

**Overall**: ✅ All outside-in tests passed

## Unit Testing

- ✅ Default image returns Ubuntu 25.10
- ✅ All shorthand formats resolve correctly
- ✅ URN aliases work
- ✅ Full URNs pass through unchanged
- ✅ Case-insensitive matching
- ✅ Error handling with helpful suggestions
- ✅ Pre-commit hooks pass

## Breaking Changes

⚠️ Default OS changes from Ubuntu 22.04 → 25.10. Users who need 22.04 can specify `--os 22.04`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)