### PR TITLE
feat: Add version logging for npm and rg (#716)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ azlin storage mount local --mount-point ~/azure/
 ### Python 3.13 & Ripgrep
 - All new VMs get Python 3.13+
 - ripgrep (rg) pre-installed for fast search
+- Tool versions logged to cloud-init output for verification
 
 ## Development Tools Installed
 
@@ -169,6 +170,23 @@ Node.js is configured for user-local global package installations, which means:
 - Packages are installed to `~/.npm-packages`
 - Automatic PATH and MANPATH configuration
 - Clean separation from system Node.js packages
+
+### Verifying Installed Tool Versions
+
+All VMs automatically log installed versions of npm and ripgrep during provisioning:
+
+```bash
+# View all tool versions logged during provisioning
+grep '[AZLIN_VERSION]' /var/log/cloud-init-output.log
+
+# Example output (actual versions may vary):
+# [AZLIN_VERSION] npm: 10.2.4
+# [AZLIN_VERSION] rg: 14.1.0
+```
+
+**Note**: The versions shown are examples. Actual versions depend on Ubuntu repository state at provision time. npm is bundled with Node.js 20.x LTS (installed via apt), not installed separately.
+
+This provides an audit trail of exactly which tool versions were installed, useful for troubleshooting and compliance.
 
 ## Prerequisites
 

--- a/src/azlin/vm_provisioning.py
+++ b/src/azlin/vm_provisioning.py
@@ -1145,6 +1145,12 @@ runcmd:
     EOF
   - chown azureuser:azureuser /home/azureuser/.npmrc /home/azureuser/.npm-packages
 
+  # Version verification logging
+  - echo "[AZLIN_VERSION_CHECK] Starting version verification"
+  - echo "[AZLIN_VERSION] npm: $(npm --version)"
+  - echo "[AZLIN_VERSION] rg: $(rg --version | head -1 | awk '{{print $2}}')"
+  - echo "[AZLIN_VERSION_CHECK] Version verification complete"
+
   # Tmux configuration for session name display
   - |
     cat > /home/azureuser/.tmux.conf << 'EOF'

--- a/tests/unit/test_vm_provisioning_cloud_init.py
+++ b/tests/unit/test_vm_provisioning_cloud_init.py
@@ -221,3 +221,26 @@ class TestCloudInitPackageOrder:
         assert "  - pipx" in cloud_init
         assert "  - ripgrep" in cloud_init
         assert "  - docker.io" in cloud_init
+
+
+class TestVersionLogging:
+    """Test version logging commands in cloud-init."""
+
+    def test_version_logging_commands_present(self):
+        """Test that npm and rg version logging exists in runcmd section with correct format."""
+        provisioner = VMProvisioner()
+        cloud_init = provisioner._generate_cloud_init()
+
+        # Verify both version commands exist in runcmd section with correct format
+        assert "runcmd:" in cloud_init, "runcmd section not found"
+        runcmd_pos = cloud_init.find("runcmd:")
+
+        # Check npm version logging
+        npm_pos = cloud_init.find("[AZLIN_VERSION] npm:")
+        assert npm_pos > runcmd_pos, "npm version logging not in runcmd section"
+        assert "npm --version" in cloud_init, "npm --version command not found"
+
+        # Check rg version logging
+        rg_pos = cloud_init.find("[AZLIN_VERSION] rg:")
+        assert rg_pos > runcmd_pos, "rg version logging not in runcmd section"
+        assert "rg --version" in cloud_init, "rg --version command not found"


### PR DESCRIPTION
## Summary

Adds version logging to verify npm and ripgrep (rg) are installed during VM provisioning.

Closes #716

## Background

Investigation revealed that both npm and rg are already automatically installed:
- **npm**: Bundled with Node.js 20.x LTS (NodeSource)
- **rg**: Installed via apt packages (line 1091 in vm_provisioning.py)

This PR adds logging to verify versions are installed correctly.

## Changes

- Added version logging commands to cloud-init (lines 1149-1152 in vm_provisioning.py)
- Format: `[AZLIN_VERSION] npm: X.Y.Z` and `[AZLIN_VERSION] rg: X.Y.Z`
- Output logged to `/var/log/cloud-init-output.log`
- Updated README with version verification instructions
- Added test to verify commands present in cloud-init

## Step 13: Local Testing Results

**Test Environment**: feat/issue-716-verify-latest-npm-rg, 2025-02-26

**Tests Executed**:
1. Simple: Local command validation
   - npm: `[AZLIN_VERSION] npm: 10.8.2` ✅
   - rg: `[AZLIN_VERSION] rg: 13.0.0` ✅
2. Complex: Cloud-init YAML verification
   - Commands at lines 1149-1152 ✅
   - Located in runcmd section ✅
   - Proper echo + command substitution format ✅

**Regressions**: ✅ None detected (all tests pass)

## Usage

After VM provisioning completes:

```bash
# View logged versions
grep '[AZLIN_VERSION]' /var/log/cloud-init-output.log
# Output:
# [AZLIN_VERSION] npm: 10.2.4
# [AZLIN_VERSION] rg: 14.1.0
```

**Note**: Versions depend on Ubuntu repository state at provision time.

## Testing

- ✅ Unit test passes (`test_version_logging_commands_present`)
- ✅ All pre-commit hooks pass
- ✅ Local command validation successful
- ✅ Cloud-init YAML structure verified

## Checklist

- [x] Tests added and passing
- [x] Pre-commit hooks pass
- [x] Local testing completed
- [x] Documentation updated
- [x] Issue #716 addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)