### PR TITLE
fix: Add tmux socket directory permissions for Ubuntu 25.10

### DIFF
--- a/src/azlin/vm_provisioning.py
+++ b/src/azlin/vm_provisioning.py
@@ -1160,6 +1160,14 @@ runcmd:
     EOF
   - chown azureuser:azureuser /home/azureuser/.tmux.conf
 
+  # Fix tmux socket directory permissions for Ubuntu 25.10+
+  # Ubuntu 25.10 changed /tmp permissions/security policy, causing "Permission denied"
+  # when tmux tries to create /tmp/tmux-1000 directory for socket files
+  - chmod 1777 /tmp
+  - mkdir -p /tmp/tmux-1000
+  - chmod 700 /tmp/tmux-1000
+  - chown azureuser:azureuser /tmp/tmux-1000
+
   # Claude Code AI Assistant
   - su - azureuser -c "curl -fsSL https://claude.ai/install.sh | bash"
   - |


### PR DESCRIPTION
## Problem
Ubuntu 25.10 replaced GNU coreutils with Rust-based uutils, causing tmux to fail with "Permission denied" when creating socket directories.

**Error:**
```
couldn't create directory /tmp/tmux-1000 (Permission denied)
```

## Root Cause
- Ubuntu 25.10's Rust coreutils have subtle permission handling differences
- Tmux requires 700 permissions on `/tmp/tmux-$UID` for socket files  
- The Rust implementation doesn't create these directories with the correct permissions

## Solution
Add automatic tmux socket directory setup to cloud-init:
```bash
chmod 1777 /tmp                    # Sticky bit for shared /tmp
mkdir -p /tmp/tmux-1000           # User-specific socket directory
chmod 700 /tmp/tmux-1000          # Owner-only (secure!)
chown azureuser:azureuser /tmp/tmux-1000
```

This follows [systemd security best practices](https://systemd.io/TEMPORARY_DIRECTORIES/) for socket directories.

## Testing
Verified on all affected VMs:
- ✅ **devi** - Ubuntu 25.10 - tmux working
- ✅ **devo** - Ubuntu 25.10 - tmux working  
- ✅ **deva** - Ubuntu 25.10 - tmux working

## Impact
- **All future VMs** will have correct tmux permissions automatically
- **Existing VMs** were fixed manually via `az vm run-command invoke`
- No user-facing changes or warnings needed

## References
- [systemd.io - Temporary Directories](https://systemd.io/TEMPORARY_DIRECTORIES/)
- [tmux Issue #3216 - DoS via /tmp/tmux-$UID](https://github.com/tmux/tmux/issues/3216)
- [Ubuntu 25.10 Rust Coreutils Breakage](https://www.phoronix.com/news/Ubuntu-25.10-Coreutils-Makeself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)