### PR TITLE
feat: Add full system upgrade and fix gh CLI install in cloud-init

### DIFF
--- a/src/azlin/vm_provisioning.py
+++ b/src/azlin/vm_provisioning.py
@@ -1093,27 +1093,28 @@ packages:
   - pipx
 
 runcmd:
-{tmp_disk_runcmd}  # Python 3.13+ from deadsnakes PPA
+{tmp_disk_runcmd}  # Full system upgrade to latest packages
+  - apt update && apt full-upgrade -y && apt autoremove -y && apt autoclean -y
+
+  # Python 3.13+ from deadsnakes PPA
   - add-apt-repository -y ppa:deadsnakes/ppa
 
-  # GitHub CLI repository setup
-  - curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-  - chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-  - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+  # GitHub CLI - official install method (https://github.com/cli/cli/blob/trunk/docs/install_linux.md)
+  - mkdir -p -m 755 /etc/apt/keyrings
+  - wget -nv -O /tmp/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg
+  - tee /etc/apt/keyrings/githubcli-archive-keyring.gpg < /tmp/githubcli-archive-keyring.gpg > /dev/null
+  - chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  - mkdir -p -m 755 /etc/apt/sources.list.d
+  - echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 
-  # OPTIMIZATION: Single apt update for both deadsnakes and GitHub CLI
+  # Single apt update for deadsnakes + GitHub CLI repos
   - apt update
 
   # Install Python 3.13 packages
   - apt install -y python3.13 python3.13-venv python3.13-dev python3.13-distutils
 
-  # Install GitHub CLI (separate command for explicit error handling)
-  - |
-    if apt install -y gh; then
-      echo "GitHub CLI (gh) installed successfully"
-    else
-      echo "WARNING: GitHub CLI (gh) installation failed - check repository setup"
-    fi
+  # Install GitHub CLI
+  - apt install -y gh
 
   - update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 1
   - update-alternatives --set python3 /usr/bin/python3.13

--- a/tests/unit/test_vm_provisioning_cloud_init.py
+++ b/tests/unit/test_vm_provisioning_cloud_init.py
@@ -223,6 +223,38 @@ class TestCloudInitPackageOrder:
         assert "  - docker.io" in cloud_init
 
 
+class TestSystemUpgrade:
+    """Test full system upgrade in cloud-init."""
+
+    def test_full_upgrade_present(self):
+        """Test that cloud-init includes full system upgrade.
+
+        Given: A VMProvisioner instance
+        When: _generate_cloud_init is called
+        Then: Returns cloud-init containing apt full-upgrade commands
+        """
+        provisioner = VMProvisioner()
+        cloud_init = provisioner._generate_cloud_init()
+
+        assert "apt full-upgrade -y" in cloud_init
+        assert "apt autoremove -y" in cloud_init
+        assert "apt autoclean -y" in cloud_init
+
+    def test_full_upgrade_runs_early(self):
+        """Test that full system upgrade runs before package installs.
+
+        Given: A VMProvisioner instance
+        When: _generate_cloud_init is called
+        Then: full-upgrade appears before Python/gh install commands
+        """
+        provisioner = VMProvisioner()
+        cloud_init = provisioner._generate_cloud_init()
+
+        upgrade_pos = cloud_init.find("apt full-upgrade")
+        python_pos = cloud_init.find("python3.13")
+        assert upgrade_pos < python_pos, "full-upgrade should run before Python install"
+
+
 class TestVersionLogging:
     """Test version logging commands in cloud-init."""
 


### PR DESCRIPTION
## Summary
- Add `apt full-upgrade` to bring VMs fully up to date at startup
- Fix GitHub CLI (`gh`) installation broken on Ubuntu 25.10

## Changes

### 1. Full System Upgrade
Runs before any package installs:
```bash
apt update && apt full-upgrade -y && apt autoremove -y && apt autoclean -y
```
This ensures all security patches and bug fixes are applied before installing tools.

### 2. Fix gh CLI Installation
**Problem:** `gh` was silently failing to install on Ubuntu 25.10 because the old method used `curl | dd` for GPG keyring setup, and Ubuntu 25.10's Rust-based `dd` produced invalid output.

**Fix:** Updated to the [official install method](https://github.com/cli/cli/blob/trunk/docs/install_linux.md):
- Uses `wget` instead of `curl | dd`
- Uses `/etc/apt/keyrings/` (current recommended location) instead of `/usr/share/keyrings/`
- Removed soft-failure handling: install now fails hard if broken

## Test Plan
- [x] All 16 cloud-init unit tests pass (including 2 new tests for full-upgrade)
- [x] Verified `gh` was NOT installed on existing Ubuntu 25.10 VMs (confirming the bug)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)