### PR TITLE
fix: Always measure SSH latency when --with-latency requested

### DIFF
--- a/src/azlin/commands/_list_helpers.py
+++ b/src/azlin/commands/_list_helpers.py
@@ -329,8 +329,8 @@ def enrich_vm_data(
             if resource_group:
                 _cache_tmux_sessions_fn(tmux_by_vm, resource_group, cache)
 
-    # Measure SSH latency if enabled (skip if cached)
-    if with_latency and not was_cached:
+    # Measure SSH latency if enabled (always fresh — latency is ephemeral)
+    if with_latency:
         try:
             # Use default SSH key path
             ssh_key_path = "~/.ssh/id_rsa"


### PR DESCRIPTION
## Summary

- Fixes `azlin list --with-latency` silently skipping latency measurement on cache hits
- Removes incorrect `not was_cached` guard from latency measurement condition
- Latency is ephemeral (like processes) and should always be measured fresh when requested

Fixes #720

## Root Cause

In `enrich_vm_data()`, the latency measurement was guarded by:
```python
if with_latency and not was_cached:
```

This meant latency was only measured on the first run (cache miss). On all subsequent runs, the measurement was silently skipped. The `show_procs` code immediately below already handled this correctly with the comment "always fresh — processes are ephemeral".

## Change

One-line fix: `if with_latency and not was_cached:` → `if with_latency:`

## Step 13: Local Testing Results

**Test 1 (simple) - Unit tests pass:**
```
uv run python -m pytest tests/unit/test_ssh_latency.py tests/unit/test_list_helpers_quota.py -v
→ 37 passed
```

**Test 2 (complex) - End-to-end live verification:**

Run 1 (cache miss):
```
$ uv run azlin list --with-latency
[FULL REFRESH] Fetching from Azure (cached: 0, refresh needed: 6)
Measuring SSH latency for running VMs...  ← Latency measured ✅
```

Run 2 (cache hit - this was the bug):
```
$ uv run azlin list --with-latency -w
[CACHE HIT] Using 4 cached VMs (60min TTL)
Measuring SSH latency for running VMs...  ← Latency now measured on cache hit ✅
```

Before the fix, Run 2 would silently skip "Measuring SSH latency" entirely.

## Test plan

- [x] Unit tests pass (37/37)
- [x] Pre-commit hooks pass (ruff, pyright, etc.)
- [x] Live test: latency measured on first run (cache miss)
- [x] Live test: latency measured on second run (cache hit) — this was the bug
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)