### PR TITLE
fix: Fix cloud-init runcmd failure from YAML colon-space in version logging

### DIFF
--- a/src/azlin/vm_provisioning.py
+++ b/src/azlin/vm_provisioning.py
@@ -1147,10 +1147,11 @@ runcmd:
   - chown azureuser:azureuser /home/azureuser/.npmrc /home/azureuser/.npm-packages
 
   # Version verification logging
-  - echo "[AZLIN_VERSION_CHECK] Starting version verification"
-  - echo "[AZLIN_VERSION] npm: $(npm --version)"
-  - echo "[AZLIN_VERSION] rg: $(rg --version | head -1 | awk '{{print $2}}')"
-  - echo "[AZLIN_VERSION_CHECK] Version verification complete"
+  - |
+    echo "[AZLIN_VERSION_CHECK] Starting version verification"
+    echo "[AZLIN_VERSION] npm=$(npm --version)"
+    echo "[AZLIN_VERSION] rg=$(rg --version | head -1 | awk '{{print $2}}')"
+    echo "[AZLIN_VERSION_CHECK] Version verification complete"
 
   # Tmux configuration for session name display
   - |


### PR DESCRIPTION
## Summary

- Fixes cloud-init `runcmd` completely failing on all newly provisioned VMs since PR #717
- Root cause: YAML colon-space (`: `) in version logging strings parsed as key-value mappings
- Fix: use YAML block scalar (`|`) and change `: ` to `=` in echo format
- Adds regression test to prevent this class of bug

Fixes #724

## Root Cause

PR #717 added:
```yaml
- echo "[AZLIN_VERSION] npm: $(npm --version)"
```

YAML interprets `npm: $(npm` as a mapping key-value, creating a dict. Cloud-init's `shellify()` expects strings, throws `TypeError`, and **the entire runcmd section fails** -- nothing executes. This is why devo (created after PR #718's tmux fix) still had broken tmux: the tmux fix was in runcmd but never ran.

Cloud-init log evidence from devo:
```
cloud-init status: error
TypeError: Failed to shellify [..., {'echo "[AZLIN_VERSION] npm': '$(npm --version)"'}, ...] into file .../scripts/runcmd
```

## Change

```yaml
# Before (broken - YAML parses colon-space as mapping)
- echo "[AZLIN_VERSION] npm: $(npm --version)"
- echo "[AZLIN_VERSION] rg: $(rg --version | head -1 | awk '{print $2}')"

# After (fixed - block scalar avoids YAML parsing issues)
- |
  echo "[AZLIN_VERSION_CHECK] Starting version verification"
  echo "[AZLIN_VERSION] npm=$(npm --version)"
  echo "[AZLIN_VERSION] rg=$(rg --version | head -1 | awk '{print $2}')"
  echo "[AZLIN_VERSION_CHECK] Version verification complete"
```

## Step 13: Local Testing Results

**Test 1 (unit tests):**
```
pytest tests/unit/test_vm_provisioning_cloud_init.py → 17 passed (16 existing + 1 new regression guard)
```

**Test 2 (YAML validation):**
```python
# Validated generated cloud-init parses as valid YAML with no dict entries
data = yaml.safe_load(cloud_init)
runcmd = data["runcmd"]  # 43 entries, all strings or lists, zero dicts
```

**Test 3 (live VM investigation):**
Verified on devo that `cloud-init status: error` with the exact `TypeError: Failed to shellify` message from the broken YAML.

## Test plan

- [x] Cloud-init unit tests pass (17/17)
- [x] Pre-commit hooks pass
- [x] YAML validation: no dict entries in runcmd
- [x] New regression test: `test_cloud_init_runcmd_entries_are_valid_yaml_strings`
- [x] Live evidence: confirmed on devo that cloud-init failed due to this bug
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)