### PR TITLE
fix: Remove OS icon from Session column

### DIFF
--- a/src/azlin/commands/_list_helpers.py
+++ b/src/azlin/commands/_list_helpers.py
@@ -643,12 +643,10 @@ def build_vm_table(
 
     # Add rows
     for vm in vms:
-        # Get OS info for icon and name
-        os_icon, os_name = get_os_display_info(vm.os_offer, vm.os_type)
+        # Get OS name for the OS column
+        _os_icon, os_name = get_os_display_info(vm.os_offer, vm.os_type)
 
-        # Prepend OS icon to session name
-        session_text = escape(vm.session_name) if vm.session_name else "-"
-        session_display = f"{os_icon} {session_text}" if os_icon else session_text
+        session_display = escape(vm.session_name) if vm.session_name else "-"
 
         status = vm.get_status_display()
 


### PR DESCRIPTION
## Summary
Remove emoji icon prefix from Session column in `azlin list`. The OS is already identified in its own dedicated OS column - the icon was redundant.

## Test plan
- [x] Verified `azlin list --all --no-tmux` shows clean session names without icons
- [x] OS column still shows distro name/version correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)