### PR TITLE
fix: Fix WSL SSH config sync for azlin code

### DIFF
--- a/src/azlin/modules/vscode_launcher.py
+++ b/src/azlin/modules/vscode_launcher.py
@@ -224,17 +224,19 @@ class VSCodeLauncher:
             ssh_host = f"azlin-{config.vm_name}"
             windows_key_path_str = f"C:\\Users\\{username}\\.ssh\\{wsl_key_path.name}"
 
-            config_entry = "\n".join([
-                f"Host {ssh_host}",
-                f"    HostName {config.host}",
-                f"    Port {config.port}",
-                f"    User {config.user}",
-                f"    IdentityFile {windows_key_path_str}",
-                "    StrictHostKeyChecking no",
-                "    UserKnownHostsFile NUL",
-                "    ServerAliveInterval 60",
-                "    ServerAliveCountMax 3",
-            ])
+            config_entry = "\n".join(
+                [
+                    f"Host {ssh_host}",
+                    f"    HostName {config.host}",
+                    f"    Port {config.port}",
+                    f"    User {config.user}",
+                    f"    IdentityFile {windows_key_path_str}",
+                    "    StrictHostKeyChecking no",
+                    "    UserKnownHostsFile NUL",
+                    "    ServerAliveInterval 60",
+                    "    ServerAliveCountMax 3",
+                ]
+            )
 
             # Append to Windows SSH config (don't overwrite existing entries)
             windows_config_path = windows_ssh_dir / "config"


### PR DESCRIPTION
## Summary
Fixes `azlin code` not working under WSL. Three bugs in the Windows SSH config sync:

1. **Config overwrite** - `write_text()` destroyed existing Windows SSH config entries on every run. Now appends with duplicate checking (matching the WSL-side logic).
2. **Username detection** - Added `cmd.exe /c echo %USERNAME%` as primary detection method. The previous `/mnt/c/Users` directory scan could match the wrong user.
3. **Silent errors** - Sync failures were only logged at WARNING level. Now prints visible messages so users know what failed and how to fix manually.

## Test plan
- [x] 15 existing vscode_launcher tests pass
- [x] Syntax verified
- [ ] Manual WSL testing (user to verify on their WSL setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)