### PR TITLE
feat: measure SSH latency through existing Bastion tunnels

### DIFF
--- a/tests/unit/test_list_helpers_quota.py
+++ b/tests/unit/test_list_helpers_quota.py
@@ -69,7 +69,7 @@ def test_quota_collected_when_cached_true(mock_quota_manager, mock_vms, mock_quo
         resource_group="test-rg",
         verbose=False,
         console=MagicMock(),
-        _collect_tmux_sessions_fn=lambda vms: {},
+        _collect_tmux_sessions_fn=lambda vms, with_latency=False: ({}, {}),
         _cache_tmux_sessions_fn=lambda *args: None,
     )
 
@@ -103,7 +103,7 @@ def test_quota_collected_when_cached_false(mock_quota_manager, mock_vms, mock_qu
         resource_group="test-rg",
         verbose=False,
         console=MagicMock(),
-        _collect_tmux_sessions_fn=lambda vms: {},
+        _collect_tmux_sessions_fn=lambda vms, with_latency=False: ({}, {}),
         _cache_tmux_sessions_fn=lambda *args: None,
     )
 
@@ -127,7 +127,7 @@ def test_quota_not_collected_when_flag_false(mock_quota_manager, mock_vms):
         resource_group="test-rg",
         verbose=False,
         console=MagicMock(),
-        _collect_tmux_sessions_fn=lambda vms: {},
+        _collect_tmux_sessions_fn=lambda vms, with_latency=False: ({}, {}),
         _cache_tmux_sessions_fn=lambda *args: None,
     )
 


### PR DESCRIPTION
Closes #738

## Summary

When `--with-latency` is used and tmux collection runs (the default), Bastion tunnels are already being created to collect tmux sessions. This PR piggybacks on those open tunnels to measure SSH latency for Bastion-only VMs — at **zero extra tunnel creation cost**.

Before: Bastion-only VMs always show `bastion` in the Latency column.
After: Bastion-only VMs show actual ms latency when tmux collection is active.

## How It Works

1. `_collect_tmux_sessions(vms, with_latency=False)` — after establishing each Bastion tunnel for tmux, immediately calls `measurer.measure_at_port("127.0.0.1", tunnel.local_port)` while the tunnel is still open
2. Returns `(tmux_by_vm, bastion_latency_by_vm)` tuple
3. `enrich_vm_data` merges `bastion_latency_by_vm` into `latency_by_vm` via `.update()`, overriding the "bastion" placeholder values

When `--no-tmux` is active: no tunnels are created, Bastion VMs continue to show `bastion`. This is honest — without tunnels we can't measure them.

## New API

```python
SSHLatencyMeasurer.measure_at_port(vm_name, host, port, ssh_user, ssh_key_path)
```

Measures SSH latency at an explicit host:port — designed for local tunnel endpoints.

## Step 13: Local Testing Results

Tested via `uvx --from git+https://github.com/rysweet/azlin@feature/bastion-latency azlin ...`

**Test 1 — `--with-latency --no-tmux` (no tunnels → "bastion" as expected):**
```
│ - │ Ubuntu 22.04 LTS │ Run… │ 10.0.0.4 (Bast) │ ... │ bast… │
```
✓ Correct — no tunnels, no measurement.

**Test 2 — `--with-latency` with default tmux (test environment caveat):**
The test VM's resource group reports "No Bastion host found" — meaning the test environment has a Bastion-only VM but no Azure Bastion host resource deployed. The tunnel creation code path is not triggered. This is an environment limitation, not a code defect.

**Test 3 — Unit tests for `measure_at_port` (4 new tests):**
```
test_measure_at_port_success         PASSED  — measures 45ms through port 12345
test_measure_at_port_timeout         PASSED  — returns timeout error
test_measure_at_port_connection_failed PASSED — returns connection error
test_measure_at_port_invalid_host    PASSED  — rejects non-IP host
58 passed total
```

**Test 4 — Pre-commit all green:**
```
ruff: Passed | ruff-format: Passed | pyright: Passed
```