### PR TITLE
feat: auto-sync SSH keys when azlin list detects auth failure

### DIFF
--- a/src/azlin/commands/monitoring_list.py
+++ b/src/azlin/commands/monitoring_list.py
@@ -265,9 +265,7 @@ def _sync_key_if_auth_failed(
     if "permission denied" not in stderr_lower and "publickey" not in stderr_lower:
         return False
 
-    logger.info(
-        f"SSH auth failed for {vm.name} - syncing key via Azure Run Command API"
-    )
+    logger.info(f"SSH auth failed for {vm.name} - syncing key via Azure Run Command API")
 
     try:
         public_key = _SSHKeyManager.get_public_key(ssh_key_path)
@@ -282,10 +280,10 @@ def _sync_key_if_auth_failed(
         if sync_result.synced:
             logger.info(f"SSH key synced to {vm.name} in {sync_result.duration_ms}ms")
             return True
-        elif sync_result.already_present:
+        if sync_result.already_present:
             logger.debug(f"SSH key already present on {vm.name} (auth issue may be elsewhere)")
             return False
-        elif sync_result.error:
+        if sync_result.error:
             logger.warning(f"Key sync failed for {vm.name}: {sync_result.error}")
             return False
     except Exception as e:
@@ -432,13 +430,9 @@ def _collect_tmux_sessions(
                             # Auto-sync SSH key if auth fails (Issue #740)
                             # Tests SSH first; if "Permission denied", syncs key
                             # via Azure Run Command API and signals caller to retry.
-                            key_was_synced = _sync_key_if_auth_failed(
-                                ssh_config, vm, ssh_key_path
-                            )
+                            key_was_synced = _sync_key_if_auth_failed(ssh_config, vm, ssh_key_path)
                             if key_was_synced:
-                                logger.info(
-                                    f"Key synced for {vm.name}, retrying tmux query"
-                                )
+                                logger.info(f"Key synced for {vm.name}, retrying tmux query")
 
                             logger.debug(
                                 f"Querying VM {vm.name} via tunnel port {pooled_tunnel.tunnel.local_port}"


### PR DESCRIPTION
## Summary

- When `azlin list` collects tmux sessions via Bastion tunnels, SSH auth can fail if the local key doesn't match the VM's `authorized_keys` (e.g., after `az login` refresh, VM reprovisioning, or key rotation)
- Previously this silently showed empty tmux sessions with no indication of the problem
- Now, before querying tmux on each Bastion VM, we test SSH connectivity first. If it fails with "Permission denied" (exit code 255), we auto-sync the public key via Azure Run Command API and retry

## How it works

1. `_sync_key_if_auth_failed()` runs `ssh true` as a quick connectivity test through the Bastion tunnel
2. If SSH returns exit code 255 with "Permission denied" in stderr, it triggers key sync via `VMKeySync.ensure_key_authorized()` (Azure Run Command API - doesn't need SSH)
3. If sync succeeds, the tmux query retries and succeeds
4. If SSH works fine (most common case), the test adds negligible overhead

## Test plan

- [x] Verified fix works in production: `seldon-dev` had stale key, auto-synced in 63s, tmux sessions displayed correctly after retry
- [x] All other VMs (devo, devi, deva, amplihack-dev) with valid keys had no impact - SSH test passed immediately
- [x] Unit tests pass: `pytest tests/unit -k "monitoring_list or tmux"` - all green
- [x] Import verification: `_sync_key_if_auth_failed` and modified `_collect_tmux_sessions` import cleanly

### Step 13: Local Testing Results

**Test 1 (simple)**: `uv run azlin list -v` with valid keys on 4/5 VMs
- Result: All 4 VMs connected immediately, tmux sessions displayed

**Test 2 (complex)**: `uv run azlin list -v` with stale key on seldon-dev
- Result: SSH auth failure detected, key synced via Run Command API in 63s, retry succeeded, tmux session `wikigr` displayed

Generated with [Claude Code](https://claude.com/claude-code)