### PR TITLE
feat: merge user's local .tmux.conf into cloud-init provisioning

### DIFF
--- a/src/azlin/vm_provisioning.py
+++ b/src/azlin/vm_provisioning.py
@@ -18,6 +18,7 @@ import threading
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, ClassVar
 
 from azlin.azure_cli_visibility import AzureCLIExecutor
@@ -963,6 +964,82 @@ class VMProvisioner:
         logger.info(f"Disk attached successfully at LUN {lun}")
         return lun
 
+    # Size threshold for user tmux.conf warning (cloud-init custom-data limit is 64KB)
+    _TMUX_CONF_SIZE_WARN_BYTES = 8192
+
+    def _get_user_tmux_conf(self) -> str | None:
+        """Read user's local .tmux.conf for merging into cloud-init.
+
+        Checks two locations in priority order:
+        1. ~/.azlin/home/.tmux.conf (azlin sync convention)
+        2. ~/.tmux.conf (standard location)
+
+        Security: Rejects symlinks pointing outside the home directory to prevent
+        leaking sensitive files into cloud-init metadata.
+
+        Returns:
+            File content as string, or None if no user config found.
+        """
+        home = Path.home()
+        candidates = [
+            home / ".azlin" / "home" / ".tmux.conf",
+            home / ".tmux.conf",
+        ]
+        for path in candidates:
+            if not path.is_file():
+                continue
+            # Reject symlinks that escape the home directory
+            resolved = path.resolve()
+            if not resolved.is_relative_to(home):
+                logger.warning(f"Skipping {path}: symlink points outside home directory")
+                continue
+            try:
+                content = path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError) as exc:
+                logger.warning(f"Failed to read {path}: {exc}. Skipping user tmux config.")
+                continue
+            if len(content.encode()) > self._TMUX_CONF_SIZE_WARN_BYTES:
+                logger.warning(
+                    f"User .tmux.conf is large ({len(content.encode())} bytes); "
+                    "cloud-init custom-data has a 64KB total limit"
+                )
+            logger.info(f"Found user tmux.conf at {path}")
+            return content
+        return None
+
+    def _build_tmux_conf_content(self, user_conf: str | None = None) -> str:
+        """Build merged tmux.conf content from azlin defaults and user config.
+
+        Azlin defaults are placed first. User settings are appended after,
+        so tmux's last-wins semantics let user settings override defaults.
+
+        Args:
+            user_conf: Optional user tmux.conf content to append.
+
+        Returns:
+            Merged tmux.conf content string.
+        """
+        azlin_defaults = (
+            "# === AZLIN DEFAULTS ===\n"
+            "# Display hostname and session name in status bar\n"
+            "set -g status-left-length 50\n"
+            'set -g status-left "#[fg=cyan][#h]#[fg=green] #S #[fg=yellow]| "\n'
+            'set -g status-right "#[fg=cyan]%Y-%m-%d %H:%M"\n'
+            "\n"
+            "# Additional useful settings\n"
+            "set -g status-interval 60\n"
+            "set -g status-bg black\n"
+            "set -g status-fg white"
+        )
+        if not user_conf or not user_conf.strip():
+            return azlin_defaults
+
+        return (
+            f"{azlin_defaults}\n\n"
+            "# === USER SETTINGS (merged from local .tmux.conf) ===\n"
+            f"{user_conf.rstrip()}"
+        )
+
     def _generate_cloud_init(
         self,
         ssh_public_key: str | None = None,
@@ -1076,6 +1153,14 @@ cloud_final_modules:
         if has_tmp_disk:
             tmp_disk_runcmd = "  # Set /tmp permissions (sticky bit) after separate disk mount\n  - chmod 1777 /tmp\n\n"
 
+        # Build merged tmux.conf (azlin defaults + user settings)
+        user_tmux_conf = self._get_user_tmux_conf()
+        tmux_conf_content = self._build_tmux_conf_content(user_tmux_conf)
+        # Indent each line with 4 spaces for YAML block scalar embedding
+        tmux_conf_indented = "\n".join(
+            f"    {line}" if line else "" for line in tmux_conf_content.splitlines()
+        )
+
         return f"""#cloud-config
 {ssh_keys_section}{disk_setup_section}package_update: true
 package_upgrade: true
@@ -1162,18 +1247,10 @@ runcmd:
     echo "[AZLIN_VERSION] rg=$(rg --version | head -1 | awk '{{print $2}}')"
     echo "[AZLIN_VERSION_CHECK] Version verification complete"
 
-  # Tmux configuration for session name display
+  # Tmux configuration (azlin defaults + user settings if found)
   - |
     cat > /home/azureuser/.tmux.conf << 'EOF'
-    # Display hostname and session name in status bar
-    set -g status-left-length 50
-    set -g status-left "#[fg=cyan][#h]#[fg=green] #S #[fg=yellow]| "
-    set -g status-right "#[fg=cyan]%Y-%m-%d %H:%M"
-
-    # Additional useful settings
-    set -g status-interval 60
-    set -g status-bg black
-    set -g status-fg white
+{tmux_conf_indented}
     EOF
   - chown azureuser:azureuser /home/azureuser/.tmux.conf
 

--- a/tests/unit/test_vm_provisioning_cloud_init.py
+++ b/tests/unit/test_vm_provisioning_cloud_init.py
@@ -328,3 +328,273 @@ class TestVersionLogging:
             assert not isinstance(entry, dict), (
                 f"runcmd[{i}] is a dict (YAML colon-space in unquoted string?): {entry}"
             )
+
+
+class TestTmuxConfMerge:
+    """Test tmux.conf merge behavior during cloud-init generation."""
+
+    def test_cloud_init_includes_azlin_tmux_defaults(self):
+        """Cloud-init includes azlin tmux defaults when no user config exists.
+
+        Given: No user .tmux.conf on the local machine
+        When: _generate_cloud_init is called
+        Then: Cloud-init contains azlin default status bar settings
+        """
+        provisioner = VMProvisioner()
+        cloud_init = provisioner._generate_cloud_init()
+
+        assert "AZLIN DEFAULTS" in cloud_init
+        assert "set -g status-left-length 50" in cloud_init
+        assert "set -g status-bg black" in cloud_init
+
+    def test_cloud_init_without_user_tmux_conf(self, tmp_path, monkeypatch):
+        """Cloud-init has no USER SETTINGS section when no user config exists.
+
+        Given: No user .tmux.conf files
+        When: _generate_cloud_init is called
+        Then: Cloud-init does NOT contain the user settings marker
+        """
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        provisioner = VMProvisioner()
+        cloud_init = provisioner._generate_cloud_init()
+
+        assert "USER SETTINGS" not in cloud_init
+
+    def test_build_tmux_conf_defaults_only(self):
+        """_build_tmux_conf_content returns only defaults when no user config provided.
+
+        Given: No user config (None)
+        When: _build_tmux_conf_content is called
+        Then: Returns azlin defaults without user section
+        """
+        provisioner = VMProvisioner()
+        result = provisioner._build_tmux_conf_content(None)
+
+        assert "AZLIN DEFAULTS" in result
+        assert "set -g status-left-length 50" in result
+        assert "USER SETTINGS" not in result
+
+    def test_build_tmux_conf_with_user_settings(self):
+        """_build_tmux_conf_content merges user settings after azlin defaults.
+
+        Given: User tmux.conf content
+        When: _build_tmux_conf_content is called
+        Then: Returns azlin defaults followed by user settings
+        """
+        provisioner = VMProvisioner()
+        user_conf = "set -g mouse on\nset -g history-limit 50000"
+        result = provisioner._build_tmux_conf_content(user_conf)
+
+        assert "AZLIN DEFAULTS" in result
+        assert "USER SETTINGS" in result
+        assert "set -g mouse on" in result
+        assert "set -g history-limit 50000" in result
+
+        # Azlin defaults come before user settings
+        defaults_pos = result.find("AZLIN DEFAULTS")
+        user_pos = result.find("USER SETTINGS")
+        assert defaults_pos < user_pos
+
+    def test_build_tmux_conf_user_overrides_take_effect(self):
+        """User settings placed after defaults so tmux last-wins applies.
+
+        Given: User config that overrides a default setting
+        When: _build_tmux_conf_content is called
+        Then: User's override appears after the default
+        """
+        provisioner = VMProvisioner()
+        user_conf = "set -g status-bg red"
+        result = provisioner._build_tmux_conf_content(user_conf)
+
+        default_bg_pos = result.find("set -g status-bg black")
+        user_bg_pos = result.find("set -g status-bg red")
+        assert default_bg_pos < user_bg_pos
+
+    def test_build_tmux_conf_strips_trailing_whitespace(self):
+        """Trailing whitespace in user config is stripped.
+
+        Given: User config with trailing newlines
+        When: _build_tmux_conf_content is called
+        Then: Trailing whitespace is removed
+        """
+        provisioner = VMProvisioner()
+        user_conf = "set -g mouse on\n\n\n"
+        result = provisioner._build_tmux_conf_content(user_conf)
+
+        assert result.endswith("set -g mouse on")
+
+    def test_get_user_tmux_conf_returns_none_when_no_files(self, tmp_path, monkeypatch):
+        """_get_user_tmux_conf returns None when no user tmux.conf exists.
+
+        Given: Neither ~/.azlin/home/.tmux.conf nor ~/.tmux.conf exist
+        When: _get_user_tmux_conf is called
+        Then: Returns None
+        """
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        provisioner = VMProvisioner()
+
+        assert provisioner._get_user_tmux_conf() is None
+
+    def test_get_user_tmux_conf_prefers_azlin_home(self, tmp_path, monkeypatch):
+        """_get_user_tmux_conf prefers ~/.azlin/home/.tmux.conf over ~/.tmux.conf.
+
+        Given: Both ~/.azlin/home/.tmux.conf and ~/.tmux.conf exist
+        When: _get_user_tmux_conf is called
+        Then: Returns content from ~/.azlin/home/.tmux.conf
+        """
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+        # Create both files with different content
+        azlin_dir = tmp_path / ".azlin" / "home"
+        azlin_dir.mkdir(parents=True)
+        (azlin_dir / ".tmux.conf").write_text("# azlin home version")
+        (tmp_path / ".tmux.conf").write_text("# home version")
+
+        provisioner = VMProvisioner()
+        result = provisioner._get_user_tmux_conf()
+
+        assert result == "# azlin home version"
+
+    def test_get_user_tmux_conf_falls_back_to_home(self, tmp_path, monkeypatch):
+        """_get_user_tmux_conf falls back to ~/.tmux.conf when azlin dir absent.
+
+        Given: Only ~/.tmux.conf exists (no ~/.azlin/home/.tmux.conf)
+        When: _get_user_tmux_conf is called
+        Then: Returns content from ~/.tmux.conf
+        """
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        (tmp_path / ".tmux.conf").write_text("# home version")
+
+        provisioner = VMProvisioner()
+        result = provisioner._get_user_tmux_conf()
+
+        assert result == "# home version"
+
+    def test_get_user_tmux_conf_warns_on_large_file(self, tmp_path, monkeypatch, caplog):
+        """_get_user_tmux_conf logs warning for large files.
+
+        Given: A .tmux.conf larger than 8KB
+        When: _get_user_tmux_conf is called
+        Then: Warning is logged about cloud-init size limit
+        """
+        import logging
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        (tmp_path / ".tmux.conf").write_text("x" * 9000)
+
+        provisioner = VMProvisioner()
+        with caplog.at_level(logging.WARNING):
+            result = provisioner._get_user_tmux_conf()
+
+        assert result is not None
+        assert "large" in caplog.text.lower() or "9000" in caplog.text
+
+    def test_cloud_init_with_user_tmux_is_valid_yaml(self, tmp_path, monkeypatch):
+        """Cloud-init with merged tmux.conf is still valid YAML.
+
+        Given: A user .tmux.conf with various settings
+        When: _generate_cloud_init is called
+        Then: The output is valid YAML with proper runcmd entries
+        """
+        import yaml
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        (tmp_path / ".tmux.conf").write_text(
+            "set -g mouse on\nset -g history-limit 50000\nbind r source-file ~/.tmux.conf"
+        )
+
+        provisioner = VMProvisioner()
+        cloud_init = provisioner._generate_cloud_init()
+
+        data = yaml.safe_load(cloud_init)
+        runcmd = data.get("runcmd", [])
+        assert len(runcmd) > 0
+        for i, entry in enumerate(runcmd):
+            assert not isinstance(entry, dict), f"runcmd[{i}] is a dict (YAML mapping bug): {entry}"
+
+    def test_cloud_init_merged_tmux_contains_both_sections(self, tmp_path, monkeypatch):
+        """Cloud-init with user config has both AZLIN DEFAULTS and USER SETTINGS.
+
+        Given: A user .tmux.conf exists
+        When: _generate_cloud_init is called
+        Then: Cloud-init contains both section markers and user content
+        """
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        (tmp_path / ".tmux.conf").write_text("set -g mouse on")
+
+        provisioner = VMProvisioner()
+        cloud_init = provisioner._generate_cloud_init()
+
+        assert "AZLIN DEFAULTS" in cloud_init
+        assert "USER SETTINGS" in cloud_init
+        assert "set -g mouse on" in cloud_init
+
+    def test_get_user_tmux_conf_rejects_symlink_outside_home(self, tmp_path, monkeypatch, caplog):
+        """Symlinks pointing outside home directory are rejected.
+
+        Given: .tmux.conf is a symlink to /etc/passwd
+        When: _get_user_tmux_conf is called
+        Then: Returns None and logs a warning
+        """
+        import logging
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        tmux_link = tmp_path / ".tmux.conf"
+        tmux_link.symlink_to("/etc/passwd")
+
+        provisioner = VMProvisioner()
+        with caplog.at_level(logging.WARNING):
+            result = provisioner._get_user_tmux_conf()
+
+        assert result is None
+        assert "symlink" in caplog.text.lower()
+
+    def test_get_user_tmux_conf_handles_non_utf8(self, tmp_path, monkeypatch, caplog):
+        """Non-UTF8 files are skipped gracefully.
+
+        Given: .tmux.conf contains binary data
+        When: _get_user_tmux_conf is called
+        Then: Returns None and logs a warning
+        """
+        import logging
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        (tmp_path / ".tmux.conf").write_bytes(b"\xff\xfe binary content")
+
+        provisioner = VMProvisioner()
+        with caplog.at_level(logging.WARNING):
+            result = provisioner._get_user_tmux_conf()
+
+        assert result is None
+        assert "failed to read" in caplog.text.lower()
+
+    def test_build_tmux_conf_ignores_whitespace_only_user_conf(self):
+        """Whitespace-only user config is treated as no config.
+
+        Given: User config with only whitespace
+        When: _build_tmux_conf_content is called
+        Then: Returns azlin defaults without user section
+        """
+        provisioner = VMProvisioner()
+        result = provisioner._build_tmux_conf_content("   \n\n  ")
+
+        assert "AZLIN DEFAULTS" in result
+        assert "USER SETTINGS" not in result
+
+    def test_get_user_tmux_conf_allows_symlink_within_home(self, tmp_path, monkeypatch):
+        """Symlinks within home directory are allowed.
+
+        Given: .tmux.conf is a symlink to another file under ~/
+        When: _get_user_tmux_conf is called
+        Then: Returns the file content
+        """
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        real_conf = tmp_path / "dotfiles" / "tmux.conf"
+        real_conf.parent.mkdir()
+        real_conf.write_text("set -g mouse on")
+        (tmp_path / ".tmux.conf").symlink_to(real_conf)
+
+        provisioner = VMProvisioner()
+        result = provisioner._get_user_tmux_conf()
+
+        assert result == "set -g mouse on"


### PR DESCRIPTION
## Problem

When provisioning a VM, cloud-init writes a hardcoded `.tmux.conf` that **clobbers** any user config synced by home sync — cloud-init runcmd (`cat >`) runs ~4 minutes after rsync finishes, so the user's file is always overwritten.

Unlike `.bashrc` (which uses `cat >>`), `.tmux.conf` uses destructive `cat >`.

## Solution

At `azlin new` time, read the user's local `.tmux.conf` and embed merged content in cloud-init:

- **Azlin defaults first** (status bar hostname/session display, colors)
- **User settings appended after** — tmux last-wins semantics mean user prefs naturally override conflicting defaults
- Checks `~/.azlin/home/.tmux.conf` first, falls back to `~/.tmux.conf`

### Security hardening
- Rejects symlinks pointing outside home directory (prevents leaking sensitive files into cloud-init metadata)
- Handles non-UTF8 files gracefully (skip with warning instead of crashing provisioning)
- Warns on files >8KB (cloud-init custom-data has a 64KB limit)

## Changes

| File | Change |
|------|--------|
| `src/azlin/vm_provisioning.py` | Added `_get_user_tmux_conf()`, `_build_tmux_conf_content()`, modified cloud-init tmux block |
| `tests/unit/test_vm_provisioning_cloud_init.py` | 16 new tests covering merge logic, security (symlinks, non-UTF8), YAML validity |

## Testing

- All 35 cloud-init unit tests pass (19 existing + 16 new)
- Lint clean (ruff check + format)
- No changes to home sync, orchestrator, or any other module
