### PR TITLE
fix(rust): rewrite create_vm, clone bastion routing, stop --no-deallocate (#787)

### DIFF
--- a/rust/crates/azlin-azure/src/vm.rs
+++ b/rust/crates/azlin-azure/src/vm.rs
@@ -372,11 +372,18 @@ impl VmManager {
     /// Provision a new VM with all required networking resources.
     ///
     /// Creates: resource group -> NSG -> VNet/subnet -> public IP -> NIC -> VM.
+    /// Create a new VM, letting `az vm create` handle networking automatically.
+    ///
+    /// This matches the Python reference implementation:
+    /// - No manual NSG/VNet/subnet/PIP/NIC creation
+    /// - `az vm create` creates all networking resources
+    /// - `--public-ip-address ""` disables public IP for bastion VMs
+    /// - `--subnet` + `--vnet-name` routes bastion VMs to the correct VNet
+    /// - `--attach-data-disks` attaches disks during creation for cloud-init
     pub fn create_vm(&self, params: &CreateVmParams) -> Result<VmInfo> {
         let rg = &params.resource_group;
         let location = &params.region;
         let vm_name = &params.name;
-        let names = build_vm_resource_names(vm_name);
         let timeout = self.az_cli_timeout;
 
         let az = |args: &[&str]| -> Result<String> { az_cli_with_timeout(args, timeout) };
@@ -401,135 +408,7 @@ impl VmManager {
                 .context(format!("Failed to create resource group '{rg}'"))?;
         }
 
-        // 2. Create NSG with SSH + HTTPS rules
-        debug!(nsg_name = %names.nsg, "Creating NSG");
-        az(&[
-            "network",
-            "nsg",
-            "create",
-            "--resource-group",
-            rg,
-            "--name",
-            &names.nsg,
-            "--location",
-            location,
-        ])
-        .context(format!("Failed to create NSG '{}'", names.nsg))?;
-
-        az(&[
-            "network",
-            "nsg",
-            "rule",
-            "create",
-            "--resource-group",
-            rg,
-            "--nsg-name",
-            &names.nsg,
-            "--name",
-            "AllowSSH",
-            "--priority",
-            "1000",
-            "--protocol",
-            "Tcp",
-            "--destination-port-ranges",
-            "22",
-            "--access",
-            "Allow",
-            "--direction",
-            "Inbound",
-        ])
-        .context("Failed to create SSH NSG rule")?;
-
-        az(&[
-            "network",
-            "nsg",
-            "rule",
-            "create",
-            "--resource-group",
-            rg,
-            "--nsg-name",
-            &names.nsg,
-            "--name",
-            "AllowHTTPS",
-            "--priority",
-            "1001",
-            "--protocol",
-            "Tcp",
-            "--destination-port-ranges",
-            "443",
-            "--access",
-            "Allow",
-            "--direction",
-            "Inbound",
-        ])
-        .context("Failed to create HTTPS NSG rule")?;
-
-        // 3. Create VNet + subnet
-        debug!(vnet_name = %names.vnet, subnet_name = %names.subnet, "Creating VNet and subnet");
-        az(&[
-            "network",
-            "vnet",
-            "create",
-            "--resource-group",
-            rg,
-            "--name",
-            &names.vnet,
-            "--address-prefix",
-            "10.0.0.0/16",
-            "--subnet-name",
-            &names.subnet,
-            "--subnet-prefix",
-            "10.0.0.0/24",
-            "--location",
-            location,
-            "--network-security-group",
-            &names.nsg,
-        ])
-        .context(format!("Failed to create VNet '{}'", names.vnet))?;
-
-        // 4. Create public IP
-        debug!(pip_name = %names.pip, "Creating public IP");
-        az(&[
-            "network",
-            "public-ip",
-            "create",
-            "--resource-group",
-            rg,
-            "--name",
-            &names.pip,
-            "--sku",
-            "Standard",
-            "--allocation-method",
-            "Static",
-            "--location",
-            location,
-        ])
-        .context(format!("Failed to create public IP '{}'", names.pip))?;
-
-        // 5. Create NIC
-        debug!(nic_name = %names.nic, "Creating NIC");
-        az(&[
-            "network",
-            "nic",
-            "create",
-            "--resource-group",
-            rg,
-            "--name",
-            &names.nic,
-            "--vnet-name",
-            &names.vnet,
-            "--subnet",
-            &names.subnet,
-            "--public-ip-address",
-            &names.pip,
-            "--network-security-group",
-            &names.nsg,
-            "--location",
-            location,
-        ])
-        .context(format!("Failed to create NIC '{}'", names.nic))?;
-
-        // 6. Create the VM
+        // 2. Build az vm create command — let Azure handle networking
         debug!(%vm_name, "Creating VM");
         let image_urn = params.image.to_string();
 
@@ -542,8 +421,8 @@ impl VmManager {
             rg,
             "--name",
             vm_name,
-            "--nics",
-            &names.nic,
+            "--location",
+            location,
             "--image",
             &image_urn,
             "--size",
@@ -558,6 +437,36 @@ impl VmManager {
             &cloud_init_path,
         ];
 
+        // Public IP handling — matches Python: --public-ip-address "" disables PIP
+        if params.public_ip_enabled {
+            az_args.push("--public-ip-sku");
+            az_args.push("Standard");
+        } else {
+            az_args.push("--public-ip-address");
+            az_args.push("");
+        }
+
+        // For bastion VMs, specify the bastion VNet and default subnet so Azure
+        // doesn't pick the AzureBastionSubnet by mistake.
+        let vnet_name;
+        if !params.public_ip_enabled {
+            vnet_name = format!("azlin-bastion-{location}-vnet");
+            az_args.push("--subnet");
+            az_args.push("default");
+            az_args.push("--vnet-name");
+            az_args.push(&vnet_name);
+        }
+
+        // Attach data disks during VM creation (not after!) so cloud-init can find them.
+        // Order matters: first disk = lun0, second = lun1, etc.
+        let disk_id_refs: Vec<&str> = params.disk_ids.iter().map(|s| s.as_str()).collect();
+        if !disk_id_refs.is_empty() {
+            az_args.push("--attach-data-disks");
+            for d in &disk_id_refs {
+                az_args.push(d);
+            }
+        }
+
         let tag_strs = format_tag_cli_args(&params.tags);
         if !tag_strs.is_empty() {
             az_args.push("--tags");
@@ -570,7 +479,7 @@ impl VmManager {
 
         // cloud_init_file is dropped here, which auto-deletes the temp file
 
-        // 7. Fetch and return VM info
+        // 3. Fetch and return VM info
         debug!(%vm_name, "Fetching created VM details");
         let vm_info = self.get_vm(rg, vm_name)?;
         Ok(vm_info)
@@ -781,28 +690,7 @@ echo "cloud-init provisioning complete"
     )
 }
 
-// ── Resource naming helpers ────────────────────────────────────────────
-
-/// Struct holding derived resource names for VM provisioning.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct VmResourceNames {
-    nsg: String,
-    vnet: String,
-    subnet: String,
-    pip: String,
-    nic: String,
-}
-
-/// Build the conventional resource names for a VM (NSG, VNet, subnet, PIP, NIC).
-fn build_vm_resource_names(vm_name: &str) -> VmResourceNames {
-    VmResourceNames {
-        nsg: format!("{vm_name}-nsg"),
-        vnet: format!("{vm_name}-vnet"),
-        subnet: format!("{vm_name}-subnet"),
-        pip: format!("{vm_name}-pip"),
-        nic: format!("{vm_name}-nic"),
-    }
-}
+// ── Tag helpers ───────────────────────────────────────────────────────
 
 /// Format a tag map into CLI args suitable for `az ... --tags key=value`.
 ///
@@ -1188,46 +1076,6 @@ mod tests {
         match result {
             Ok(_) | Err(_) => {}
         }
-    }
-
-    // ── build_vm_resource_names tests ───────────────────────────────
-
-    #[test]
-    fn test_build_vm_resource_names_basic() {
-        let names = build_vm_resource_names("my-vm");
-        assert_eq!(names.nsg, "my-vm-nsg");
-        assert_eq!(names.vnet, "my-vm-vnet");
-        assert_eq!(names.subnet, "my-vm-subnet");
-        assert_eq!(names.pip, "my-vm-pip");
-        assert_eq!(names.nic, "my-vm-nic");
-    }
-
-    #[test]
-    fn test_build_vm_resource_names_with_hyphens() {
-        let names = build_vm_resource_names("dev-vm-01");
-        assert_eq!(names.nsg, "dev-vm-01-nsg");
-        assert_eq!(names.nic, "dev-vm-01-nic");
-    }
-
-    #[test]
-    fn test_build_vm_resource_names_equality() {
-        let n1 = build_vm_resource_names("vm");
-        let n2 = build_vm_resource_names("vm");
-        assert_eq!(n1, n2);
-    }
-
-    #[test]
-    fn test_build_vm_resource_names_inequality() {
-        let n1 = build_vm_resource_names("vm1");
-        let n2 = build_vm_resource_names("vm2");
-        assert_ne!(n1, n2);
-    }
-
-    #[test]
-    fn test_build_vm_resource_names_debug() {
-        let names = build_vm_resource_names("vm");
-        let debug = format!("{names:?}");
-        assert!(debug.contains("vm-nsg"));
     }
 
     // ── format_tag_cli_args tests ───────────────────────────────────

--- a/rust/crates/azlin-cli/src/lib.rs
+++ b/rust/crates/azlin-cli/src/lib.rs
@@ -354,9 +354,9 @@ pub enum Commands {
         #[arg(long)]
         config: Option<PathBuf>,
 
-        /// Deallocate to save costs (default: yes)
-        #[arg(long, default_value = "true")]
-        deallocate: bool,
+        /// Power off without deallocating (keeps reserved IP and avoids reboot delay)
+        #[arg(long)]
+        no_deallocate: bool,
     },
 
     /// Connect to existing VM via SSH
@@ -2156,12 +2156,28 @@ mod tests {
         let cli = Cli::parse_from(["azlin", "stop", "my-vm"]);
         if let Commands::Stop {
             vm_name,
-            deallocate,
+            no_deallocate,
             ..
         } = cli.command
         {
             assert_eq!(vm_name, "my-vm");
-            assert!(deallocate);
+            assert!(!no_deallocate); // default: deallocate (no_deallocate = false)
+        } else {
+            panic!("Expected Stop command");
+        }
+    }
+
+    #[test]
+    fn test_stop_no_deallocate_flag() {
+        let cli = Cli::parse_from(["azlin", "stop", "my-vm", "--no-deallocate"]);
+        if let Commands::Stop {
+            vm_name,
+            no_deallocate,
+            ..
+        } = cli.command
+        {
+            assert_eq!(vm_name, "my-vm");
+            assert!(no_deallocate);
         } else {
             panic!("Expected Stop command");
         }

--- a/rust/crates/azlin-core/src/models.rs
+++ b/rust/crates/azlin-core/src/models.rs
@@ -165,6 +165,10 @@ pub struct CreateVmParams {
     pub ssh_key_path: PathBuf,
     pub image: VmImage,
     pub tags: HashMap<String, String>,
+    /// Whether to create a public IP (false for bastion-only VMs).
+    pub public_ip_enabled: bool,
+    /// Optional list of disk resource IDs to attach during VM creation.
+    pub disk_ids: Vec<String>,
 }
 
 impl CreateVmParams {
@@ -446,6 +450,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/tmp/nonexistent.pub"),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         assert!(params.validate().is_err());
         assert!(params.validate().unwrap_err().contains("name"));
@@ -462,6 +468,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/tmp/nonexistent.pub"),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         assert!(params.validate().is_err());
         assert!(params.validate().unwrap_err().contains("64 characters"));
@@ -478,6 +486,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/home/user/.ssh/id_rsa.pub"),
             image: VmImage::default(),
             tags: HashMap::from([("env".into(), "dev".into())]),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         let json = serde_json::to_string(&params).unwrap();
         let deserialized: CreateVmParams = serde_json::from_str(&json).unwrap();
@@ -498,6 +508,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/tmp/nonexistent_key_abc123.pub"),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         let err = params.validate().unwrap_err();
         assert!(err.contains("SSH public key not found"));
@@ -618,6 +630,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/tmp/nonexistent.pub"),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         let err = params.validate().unwrap_err();
         assert!(err.contains("Resource group"));
@@ -634,6 +648,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/tmp/nonexistent.pub"),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         let err = params.validate().unwrap_err();
         assert!(err.contains("Region"));
@@ -650,6 +666,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/tmp/nonexistent.pub"),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         let err = params.validate().unwrap_err();
         assert!(err.contains("VM size"));
@@ -666,6 +684,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/tmp/nonexistent.pub"),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         let err = params.validate().unwrap_err();
         assert!(err.contains("username"));
@@ -684,6 +704,8 @@ mod tests {
             ssh_key_path: keyfile.path().to_path_buf(),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         assert!(params.validate().is_ok());
     }
@@ -701,6 +723,8 @@ mod tests {
             ssh_key_path: keyfile.path().to_path_buf(),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         assert!(params.validate().is_ok());
     }

--- a/rust/crates/azlin/src/cmd_lifecycle.rs
+++ b/rust/crates/azlin/src/cmd_lifecycle.rs
@@ -34,13 +34,14 @@ pub(crate) async fn dispatch(
         azlin_cli::Commands::Stop {
             vm_name,
             resource_group,
-            deallocate,
+            no_deallocate,
             ..
         } => {
             let auth = create_auth()?;
             let vm_manager = azlin_azure::VmManager::new(&auth);
             let rg = resolve_resource_group(resource_group)?;
 
+            let deallocate = !no_deallocate;
             let (action, _done) = crate::stop_helpers::stop_action_labels(deallocate);
             let pb = ProgressBar::new_spinner();
             pb.set_style(fleet_spinner_style());
@@ -209,12 +210,7 @@ pub(crate) async fn dispatch(
             let pb = indicatif::ProgressBar::new_spinner();
             pb.set_message(format!("Looking up {}...", vm_identifier));
             pb.enable_steady_tick(std::time::Duration::from_millis(100));
-            let target = resolve_vm_ssh_target(
-                &vm_identifier,
-                None,
-                Some(rg.clone()),
-            )
-            .await?;
+            let target = resolve_vm_ssh_target(&vm_identifier, None, Some(rg.clone())).await?;
             pb.finish_and_clear();
 
             println!("Running OS updates on '{}'...", vm_identifier);

--- a/rust/crates/azlin/src/cmd_vm.rs
+++ b/rust/crates/azlin/src/cmd_vm.rs
@@ -19,6 +19,7 @@ pub(crate) async fn dispatch(
             pool,
             no_auto_connect,
             template,
+            private,
             ..
         } => {
             crate::cmd_vm_ops::handle_vm_new(
@@ -30,6 +31,7 @@ pub(crate) async fn dispatch(
                 pool,
                 no_auto_connect,
                 template,
+                private,
             )
             .await?;
         }

--- a/rust/crates/azlin/src/cmd_vm_ops.rs
+++ b/rust/crates/azlin/src/cmd_vm_ops.rs
@@ -12,6 +12,7 @@ pub(crate) async fn handle_vm_new(
     pool: Option<u32>,
     no_auto_connect: bool,
     template: Option<String>,
+    force_private: bool,
 ) -> Result<()> {
     let auth = create_auth()?;
     let vm_manager = azlin_azure::VmManager::new(&auth);
@@ -83,6 +84,23 @@ pub(crate) async fn handle_vm_new(
         loc
     };
 
+    // Auto-detect bastion in resource group to determine public IP behaviour.
+    // Matches Python: if bastion exists or --private is set, disable public IP.
+    let bastion_detected = match crate::list_helpers::detect_bastion_hosts(&rg) {
+        Ok(bastions) => !bastions.is_empty(),
+        Err(_) => false,
+    };
+    let use_bastion = force_private || bastion_detected;
+    let public_ip_enabled = !use_bastion;
+    if use_bastion {
+        let reason = if force_private {
+            "--private flag"
+        } else {
+            "bastion detected"
+        };
+        eprintln!("{reason} — creating VM without public IP in '{rg}'");
+    }
+
     for i in 0..vm_count {
         let vm_name = if let Some(ref n) = name {
             if vm_count > 1 {
@@ -91,7 +109,11 @@ pub(crate) async fn handle_vm_new(
                 n.clone()
             }
         } else {
-            format!("azlin-vm-{}", chrono::Utc::now().format("%Y%m%d-%H%M%S"))
+            // Use microsecond timestamps to avoid pool name collisions
+            format!(
+                "azlin-vm-{}",
+                chrono::Utc::now().format("%Y%m%d-%H%M%S-%6f")
+            )
         };
 
         azlin_core::models::validate_vm_name(&vm_name).map_err(|e| anyhow::anyhow!(e))?;
@@ -105,6 +127,8 @@ pub(crate) async fn handle_vm_new(
             ssh_key_path: ssh_key_path.clone(),
             image: azlin_core::models::VmImage::default(),
             tags: std::collections::HashMap::new(),
+            public_ip_enabled,
+            disk_ids: vec![],
         };
 
         if let Err(e) = params.validate() {

--- a/rust/crates/azlin/src/cmd_vm_ops2.rs
+++ b/rust/crates/azlin/src/cmd_vm_ops2.rs
@@ -9,8 +9,7 @@ pub(crate) async fn handle_vm_update(
     let pb = indicatif::ProgressBar::new_spinner();
     pb.set_message(format!("Looking up {}...", vm_identifier));
     pb.enable_steady_tick(std::time::Duration::from_millis(100));
-    let target =
-        resolve_vm_ssh_target(vm_identifier, None, resource_group).await?;
+    let target = resolve_vm_ssh_target(vm_identifier, None, resource_group).await?;
     pb.finish_and_clear();
 
     println!("Updating development tools on '{}'...", vm_identifier);
@@ -101,6 +100,8 @@ pub(crate) fn handle_vm_clone(
                 &disk_name,
                 "--source",
                 &snapshot_name,
+                "--location",
+                &location,
                 "--output",
                 "json",
             ])
@@ -112,23 +113,44 @@ pub(crate) fn handle_vm_clone(
             pb.set_message(format!("Creating VM '{}'...", clone_name));
             pb.enable_steady_tick(std::time::Duration::from_millis(100));
 
+            // Build clone VM command with location and bastion routing
+            let mut clone_args = vec![
+                "vm".to_string(),
+                "create".to_string(),
+                "--resource-group".to_string(),
+                rg.clone(),
+                "--name".to_string(),
+                clone_name.clone(),
+                "--attach-os-disk".to_string(),
+                disk_name.clone(),
+                "--os-type".to_string(),
+                "Linux".to_string(),
+                "--location".to_string(),
+                location.clone(),
+            ];
+
+            // Detect bastion and route accordingly (match new command behaviour)
+            let use_bastion = match crate::list_helpers::detect_bastion_hosts(&rg) {
+                Ok(bastions) => !bastions.is_empty(),
+                Err(_) => false,
+            };
+            if use_bastion {
+                // No public IP, use bastion VNet
+                clone_args.extend([
+                    "--public-ip-address".to_string(),
+                    "".to_string(),
+                    "--subnet".to_string(),
+                    "default".to_string(),
+                    "--vnet-name".to_string(),
+                    format!("azlin-bastion-{}-vnet", location),
+                ]);
+            }
+
+            clone_args.extend(["--output".to_string(), "json".to_string()]);
+
+            let clone_arg_refs: Vec<&str> = clone_args.iter().map(|s| s.as_str()).collect();
             let vm_out = std::process::Command::new("az")
-                .args([
-                    "vm",
-                    "create",
-                    "--resource-group",
-                    &rg,
-                    "--name",
-                    &clone_name,
-                    "--attach-os-disk",
-                    &disk_name,
-                    "--os-type",
-                    "Linux",
-                    "--nsg",
-                    "",
-                    "--output",
-                    "json",
-                ])
+                .args(&clone_arg_refs)
                 .output()?;
             pb.finish_and_clear();
 

--- a/rust/crates/azlin/src/handlers/tests/test_group_03.rs
+++ b/rust/crates/azlin/src/handlers/tests/test_group_03.rs
@@ -167,6 +167,8 @@ fn test_create_vm_via_mock() {
         admin_username: "azureuser".to_string(),
         ssh_key_path: PathBuf::from("/tmp/fake-key.pub"),
         tags: HashMap::new(),
+        public_ip_enabled: true,
+        disk_ids: vec![],
     };
     let vm = mock.create_vm(&params).unwrap();
     assert_eq!(vm.name, "new-vm");

--- a/rust/crates/azlin/src/main.rs
+++ b/rust/crates/azlin/src/main.rs
@@ -586,9 +586,7 @@ fn run_health_tui(metrics: &[HealthMetrics]) -> Result<()> {
 
 /// Get running VMs with their IPs from Azure for SSH-based commands.
 /// Returns Vec of (vm_name, ip, admin_user).
-async fn get_running_vm_targets(
-    resource_group: Option<String>,
-) -> Result<Vec<VmSshTarget>> {
+async fn get_running_vm_targets(resource_group: Option<String>) -> Result<Vec<VmSshTarget>> {
     resolve_vm_targets(None, None, resource_group).await
 }
 


### PR DESCRIPTION
## Summary

Fixes #787 — Rust command parity for `new`, `clone`, and `stop`.

### Bug 1: `new` command (CRITICAL)
- **Root cause**: `create_vm()` manually created NSG/VNet/subnet/PIP/NIC before the VM. This caused resource name clashes, wrong VNet for bastion, and unconditional public IP creation.
- **Fix**: Rewrote `create_vm()` to let `az vm create` handle networking automatically, matching the Python reference (`VMProvisioner._try_provision_vm()`).
- Added `public_ip_enabled` and `disk_ids` fields to `CreateVmParams`.
- Auto-detect bastion in resource group → disable public IP → route to `azlin-bastion-{region}-vnet`.
- New `--private` flag for explicit no-public-IP mode.
- Microsecond timestamps prevent pool name collisions.

### Bug 2: `clone` command
- Added `--location` flag to both `az disk create` and `az vm create`.
- Bastion routing: clones get no public IP when bastion detected, routed to bastion VNet.

### Bug 3: `stop --no-deallocate`
- Changed from `--deallocate` (always true default) to `--no-deallocate` flag.
- Default: deallocate (matches Python `--deallocate/--no-deallocate`).
- New test: `test_stop_no_deallocate_flag`.

### Bug 4: Untested commands verified
- `logs --lines 5` via bastion: works
- `disk add --size 10`: works

## Step 13: Local Testing Results

**Test Environment**: fix/issue-787-vm-new-parity, live Azure, 2026-03-09
**Tests Executed**:
1. Simple: `azlin new --name test-e2e-787 --region westus2 --no-auto-connect` → VM created on bastion VNet (10.0.0.13, no public IP) ✅
2. Complex: `azlin clone devo` → clone on bastion VNet (10.0.0.8, no public IP) ✅
3. `azlin stop test-e2e-787 --no-deallocate` → "VM stopped" (not deallocated) ✅
4. `azlin stop test-e2e-787` → "VM deallocated" ✅
5. `azlin logs devo --lines 5` → cloud-init output via bastion ✅
6. `azlin disk add devo --size 10` → attached successfully ✅
7. VNet verification: `az network nic show` confirmed VM on `azlin-bastion-westus2-vnet/subnets/default` ✅
**Regressions**: `cargo test --workspace` → 2,531 tests pass, 0 failures ✅
**CI checks**: `cargo clippy --workspace -- -D warnings` clean, `cargo fmt --check` clean

## Files Changed
- `rust/crates/azlin-azure/src/vm.rs` — Rewrote `create_vm()`, removed dead `VmResourceNames`
- `rust/crates/azlin-core/src/models.rs` — Added `public_ip_enabled`, `disk_ids` to `CreateVmParams`
- `rust/crates/azlin-cli/src/lib.rs` — `stop --no-deallocate` flag, new test
- `rust/crates/azlin/src/cmd_vm_ops.rs` — Bastion detection, `--private` flag, microsecond timestamps
- `rust/crates/azlin/src/cmd_vm_ops2.rs` — Clone bastion routing, `--location` flag
- `rust/crates/azlin/src/cmd_lifecycle.rs` — Updated stop dispatch for `no_deallocate`
- `rust/crates/azlin/src/cmd_vm.rs` — Pass `private` flag to handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)