### PR TITLE
fix(rust): 3 bugs found verifying commands against live Azure

### DIFF
--- a/rust/crates/azlin-azure/src/vm.rs
+++ b/rust/crates/azlin-azure/src/vm.rs
@@ -389,8 +389,11 @@ impl VmManager {
 
         // 1. Create or verify resource group
         debug!(rg, location, "Creating/verifying resource group");
-        az(&["group", "create", "--name", rg, "--location", location])
-            .context(format!("Failed to create resource group '{rg}'"))?;
+        let rg_exists = az(&["group", "show", "--name", rg, "--output", "json"]).is_ok();
+        if !rg_exists {
+            az(&["group", "create", "--name", rg, "--location", location])
+                .context(format!("Failed to create resource group '{rg}'"))?;
+        }
 
         // 2. Create NSG with SSH + HTTPS rules
         debug!(nsg_name = %names.nsg, "Creating NSG");
@@ -533,6 +536,8 @@ impl VmManager {
             rg,
             "--name",
             vm_name,
+            "--location",
+            location,
             "--nics",
             &names.nic,
             "--image",

--- a/rust/crates/azlin-cli/src/lib.rs
+++ b/rust/crates/azlin-cli/src/lib.rs
@@ -354,9 +354,9 @@ pub enum Commands {
         #[arg(long)]
         config: Option<PathBuf>,
 
-        /// Deallocate to save costs (default: yes)
-        #[arg(long, default_value = "true")]
-        deallocate: bool,
+        /// Skip deallocation (just stop, don't deallocate)
+        #[arg(long)]
+        no_deallocate: bool,
     },
 
     /// Connect to existing VM via SSH
@@ -2156,12 +2156,12 @@ mod tests {
         let cli = Cli::parse_from(["azlin", "stop", "my-vm"]);
         if let Commands::Stop {
             vm_name,
-            deallocate,
+            no_deallocate,
             ..
         } = cli.command
         {
             assert_eq!(vm_name, "my-vm");
-            assert!(deallocate);
+            assert!(!no_deallocate);
         } else {
             panic!("Expected Stop command");
         }

--- a/rust/crates/azlin/src/cmd_lifecycle.rs
+++ b/rust/crates/azlin/src/cmd_lifecycle.rs
@@ -34,12 +34,13 @@ pub(crate) async fn dispatch(
         azlin_cli::Commands::Stop {
             vm_name,
             resource_group,
-            deallocate,
+            no_deallocate,
             ..
         } => {
             let auth = create_auth()?;
             let vm_manager = azlin_azure::VmManager::new(&auth);
             let rg = resolve_resource_group(resource_group)?;
+            let deallocate = !no_deallocate;
 
             let (action, _done) = crate::stop_helpers::stop_action_labels(deallocate);
             let pb = ProgressBar::new_spinner();

--- a/rust/crates/azlin/src/cmd_self_update.rs
+++ b/rust/crates/azlin/src/cmd_self_update.rs
@@ -115,7 +115,7 @@ fn download_and_replace(url: &str, version: &str) -> Result<()> {
             "xzf",
             archive_path.to_str().unwrap(),
             "-C",
-            &tmp_dir.to_str().unwrap(),
+            tmp_dir.to_str().unwrap(),
         ])
         .status()
         .context("Failed to extract archive")?;

--- a/rust/crates/azlin/src/cmd_vm_ops.rs
+++ b/rust/crates/azlin/src/cmd_vm_ops.rs
@@ -2,6 +2,7 @@
 use super::*;
 use anyhow::Result;
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn handle_vm_new(
     repo: Option<String>,
     vm_size: Option<String>,

--- a/rust/crates/azlin/src/cmd_vm_ops2.rs
+++ b/rust/crates/azlin/src/cmd_vm_ops2.rs
@@ -109,6 +109,8 @@ pub(crate) fn handle_vm_clone(
                 &disk_name,
                 "--source",
                 &snapshot_name,
+                "--location",
+                &location,
                 "--output",
                 "json",
             ])
@@ -132,6 +134,8 @@ pub(crate) fn handle_vm_clone(
                     &disk_name,
                     "--os-type",
                     "Linux",
+                    "--location",
+                    &location,
                     "--nsg",
                     "",
                     "--output",

--- a/rust/crates/azlin/src/lifecycle_helpers.rs
+++ b/rust/crates/azlin/src/lifecycle_helpers.rs
@@ -1,6 +1,5 @@
 /// Pure helper functions for lifecycle commands (start/stop/delete/kill/destroy/killall/os-update).
 /// Extracted from cmd_lifecycle.rs for testability.
-
 /// Build the confirmation prompt for deleting a single VM.
 pub fn delete_confirm_prompt(vm_name: &str) -> String {
     format!("Delete VM '{}'? This cannot be undone.", vm_name)


### PR DESCRIPTION
## Summary

Fixes #789 — verified all 10 untested commands against live Azure, found and fixed 3 bugs.

### Bugs Fixed

- **clone**: `az disk create` and `az vm create` missing `--location` flag, causing resources to land in wrong region when RG location differs from source VM
- **stop**: `--no-deallocate` was unusable — bool field with `default_value = "true"` had no way to be set false. Changed to `--no-deallocate` flag matching Python
- **new**: `az group create` fails when RG already exists in different region. Now checks if RG exists before attempting creation. Added `--location` to `az vm create` so VM deploys in requested region

### All 10 Commands Verified Against Live Azure

| # | Command | Result |
|---|---------|--------|
| 1 | `azlin clone devo` | PASS (after fix) |
| 2 | `azlin stop devo-clone-1 --no-deallocate` + `azlin start` | PASS (after fix) |
| 3 | `azlin disk add devo --size 10` | PASS |
| 4 | `azlin new --name test-pub --region westus2 --no-auto-connect` | PASS (after fix) |
| 5 | `azlin code devo` | PASS (correct cmd string) |
| 6 | `azlin logs devo --follow` | PASS |
| 7 | `azlin compose --help` | PASS |
| 8 | `azlin github-runner --help` | PASS |
| 9 | `azlin fleet workflow --help` | PASS |
| 10 | `azlin sync` with test file | PASS |

### Cleanup

- All test VMs deleted (test-pub, devo-clone-1)
- All test disks removed (devo_datadisk_0)
- All test snapshots deleted
- Clippy warnings fixed (empty doc line, needless borrow, too-many-args)

## Step 13: Local Testing Results

**Test Environment**: fix/issue-789-verify-commands, live Azure, 2026-03-09
**Tests Executed**:
1. Simple: clone devo, verify clone exists in list, kill clone -> PASS
2. Complex: new --name test-pub --region westus2 (cross-region into existing RG) -> PASS
3. stop --no-deallocate + start cycle on clone -> PASS
4. disk add 10GB to devo, verify attached, detach+delete -> PASS
5. logs, sync, code, compose/github-runner/fleet help -> all PASS
**Regressions**: 2,536 tests pass, 0 failures
**Issues Found**: 3 bugs fixed (see above)

## Test plan

- [x] All 10 commands run against live Azure
- [x] Python equivalents compared where applicable
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `RUST_MIN_STACK=8388608 cargo test --workspace` — 2,536 pass, 0 fail
- [x] All test VMs/disks/snapshots cleaned up


Generated with [Claude Code](https://claude.com/claude-code)