### PR TITLE
fix(rust): quality audit — eliminate exit(), error swallowing, silent fallbacks

### DIFF
--- a/rust/crates/azlin/src/azdoit.rs
+++ b/rust/crates/azlin/src/azdoit.rs
@@ -88,9 +88,7 @@ async fn main() -> Result<()> {
 
     let request = args.request.join(" ");
     if request.is_empty() {
-        eprintln!("Error: No request provided.");
-        eprintln!("Usage: azdoit \"create a VM called dev-box\"");
-        std::process::exit(1);
+        anyhow::bail!("No request provided. Usage: azdoit \"create a VM called dev-box\"");
     }
 
     let client = azlin_ai::AnthropicClient::new()

--- a/rust/crates/azlin/src/cmd_autopilot.rs
+++ b/rust/crates/azlin/src/cmd_autopilot.rs
@@ -150,10 +150,28 @@ pub(crate) async fn dispatch(
                             if out.status.success() {
                                 let text = String::from_utf8_lossy(&out.stdout);
                                 let lines: Vec<&str> = text.trim().lines().collect();
-                                let cpu_pct: f64 =
-                                    lines.first().and_then(|s| s.parse().ok()).unwrap_or(100.0);
+                                let cpu_pct: f64 = match lines.first().and_then(|s| s.parse().ok())
+                                {
+                                    Some(v) => v,
+                                    None => {
+                                        eprintln!(
+                                            "  Warning: {} — failed to parse CPU stats, skipping",
+                                            vm.name
+                                        );
+                                        continue;
+                                    }
+                                };
                                 let uptime_secs: f64 =
-                                    lines.get(1).and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                                    match lines.get(1).and_then(|s| s.parse().ok()) {
+                                        Some(v) => v,
+                                        None => {
+                                            eprintln!(
+                                                "  Warning: {} — failed to parse uptime, skipping",
+                                                vm.name
+                                            );
+                                            continue;
+                                        }
+                                    };
                                 if let Some(action_name) = crate::handlers::classify_autopilot_vm(
                                     cpu_pct,
                                     uptime_secs,

--- a/rust/crates/azlin/src/cmd_connect.rs
+++ b/rust/crates/azlin/src/cmd_connect.rs
@@ -162,8 +162,11 @@ pub(crate) async fn dispatch(
                     std::process::Command::new("ssh").args(&ssh_args).status()?
                 };
                 attempt += 1;
-                if status.success() || attempt >= max {
-                    std::process::exit(status.code().unwrap_or(1));
+                if status.success() {
+                    return Ok(());
+                }
+                if attempt >= max {
+                    anyhow::bail!("SSH exited with code {}", status.code().unwrap_or(1));
                 }
                 if !yes {
                     eprint!(
@@ -174,7 +177,7 @@ pub(crate) async fn dispatch(
                     let mut input = String::new();
                     std::io::stdin().read_line(&mut input)?;
                     if input.trim().eq_ignore_ascii_case("n") {
-                        std::process::exit(status.code().unwrap_or(1));
+                        anyhow::bail!("SSH exited with code {}", status.code().unwrap_or(1));
                     }
                 } else {
                     eprintln!(

--- a/rust/crates/azlin/src/cmd_list.rs
+++ b/rust/crates/azlin/src/cmd_list.rs
@@ -266,7 +266,10 @@ pub(crate) async fn dispatch(
                 };
                 println!("\nvCPU Quota:");
                 // Use the configured default region instead of hardcoding "westus"
-                let config_for_quota = azlin_core::AzlinConfig::load().unwrap_or_default();
+                let config_for_quota = azlin_core::AzlinConfig::load().unwrap_or_else(|e| {
+                    eprintln!("Warning: failed to load config, using defaults: {e}");
+                    azlin_core::AzlinConfig::default()
+                });
                 let quota_location = config_for_quota.default_region.clone();
                 let output = std::process::Command::new("az")
                     .args([

--- a/rust/crates/azlin/src/cmd_list_data.rs
+++ b/rust/crates/azlin/src/cmd_list_data.rs
@@ -1,5 +1,4 @@
 //! Data collection helpers for the list command (tmux, latency, health, procs).
-#![allow(dead_code)]
 
 use super::*;
 use azlin_core::models::VmInfo;

--- a/rust/crates/azlin/src/cmd_network_ops.rs
+++ b/rust/crates/azlin/src/cmd_network_ops.rs
@@ -140,7 +140,10 @@ pub(crate) fn handle_web_start(port: u32, host: &str) -> Result<()> {
     let status = child.wait()?;
     let _ = std::fs::remove_file(&pid_path);
     if !status.success() {
-        std::process::exit(status.code().unwrap_or(1));
+        anyhow::bail!(
+            "Web dev server exited with code {}",
+            status.code().unwrap_or(1)
+        );
     }
     Ok(())
 }

--- a/rust/crates/azlin/src/cmd_self_update.rs
+++ b/rust/crates/azlin/src/cmd_self_update.rs
@@ -140,9 +140,13 @@ fn download_and_replace(url: &str, version: &str) -> Result<()> {
     fs::copy(&new_bin, &current_exe).context("Failed to install new binary")?;
     fs::set_permissions(&current_exe, fs::Permissions::from_mode(0o755))?;
 
-    // Clean up backup and temp dir
-    fs::remove_file(&backup).ok();
-    fs::remove_dir_all(&tmp_dir).ok();
+    // Clean up backup and temp dir (warn but don't fail on cleanup errors)
+    if let Err(e) = fs::remove_file(&backup) {
+        eprintln!("Warning: failed to remove backup file: {e}");
+    }
+    if let Err(e) = fs::remove_dir_all(&tmp_dir) {
+        eprintln!("Warning: failed to remove temp dir: {e}");
+    }
 
     pb.finish_and_clear();
     println!("Updated azlin: {} → {}", CURRENT_VERSION, version);

--- a/rust/crates/azlin/src/cmd_sync_ops.rs
+++ b/rust/crates/azlin/src/cmd_sync_ops.rs
@@ -236,7 +236,7 @@ pub(crate) async fn handle_logs(
             args.push(format!("sudo tail -f {}", log_path));
             let status = std::process::Command::new("az").args(&args).status()?;
             if !status.success() {
-                std::process::exit(status.code().unwrap_or(1));
+                anyhow::bail!("Log follow exited with code {}", status.code().unwrap_or(1));
             }
         } else {
             let follow_args =
@@ -245,7 +245,7 @@ pub(crate) async fn handle_logs(
                 .args(&follow_args)
                 .status()?;
             if !status.success() {
-                std::process::exit(status.code().unwrap_or(1));
+                anyhow::bail!("Log follow exited with code {}", status.code().unwrap_or(1));
             }
         }
     } else {

--- a/rust/crates/azlin/src/cmd_vm_ops.rs
+++ b/rust/crates/azlin/src/cmd_vm_ops.rs
@@ -18,7 +18,10 @@ pub(crate) async fn handle_vm_new(
     let rg = resolve_resource_group(resource_group)?;
 
     let vm_count = pool.unwrap_or(1);
-    let config_defaults = azlin_core::AzlinConfig::load().unwrap_or_default();
+    let config_defaults = azlin_core::AzlinConfig::load().unwrap_or_else(|e| {
+        eprintln!("Warning: failed to load config, using defaults: {e}");
+        azlin_core::AzlinConfig::default()
+    });
     let user_specified_size = vm_size.is_some();
     let user_specified_region = region.is_some();
     let size = vm_size.unwrap_or_else(|| config_defaults.default_vm_size.clone());

--- a/rust/crates/azlin/src/main.rs
+++ b/rust/crates/azlin/src/main.rs
@@ -655,7 +655,9 @@ fn run_on_fleet(vms: &[(String, String, String)], command: &str, show_output: bo
 }
 
 fn main() {
-    color_eyre::install().ok();
+    if let Err(e) = color_eyre::install() {
+        eprintln!("Warning: failed to install error reporter: {e}");
+    }
 
     let result = tokio::runtime::Runtime::new()
         .expect("Failed to create tokio runtime")


### PR DESCRIPTION
## Summary

Fixes #798. Comprehensive quality audit of all 6 Rust crates (`rust/crates/`) with targeted fixes for high and medium severity findings.

### Changes (10 files, +52/-19 lines)

**High severity fixes:**
- **Eliminate `process::exit()` from handlers** (4 files) — replaced with proper `Result`/`anyhow::bail!()` returns so Drop runs and cleanup happens. Affected: `cmd_connect.rs`, `cmd_network_ops.rs`, `cmd_sync_ops.rs`, `azdoit.rs`
- **Warn on config load failure** — `cmd_vm_ops.rs` and `cmd_list.rs` now print a warning instead of silently falling back to empty defaults via `unwrap_or_default()`
- **Fix `cargo fmt` drift** — formatting corrected in `cmd_cleanup_costs.rs`

**Medium severity fixes:**
- **`color_eyre::install()` failure** — `main.rs` now warns instead of swallowing with `.ok()`
- **Self-update cleanup errors** — `cmd_self_update.rs` now logs warnings instead of silently ignoring backup/temp cleanup failures
- **Autopilot parse failures** — `cmd_autopilot.rs` now skips VMs with unparseable CPU/uptime data with a warning, instead of defaulting to misleading values (100% CPU, 0s uptime)
- **Blanket dead_code suppression** — removed `#![allow(dead_code)]` from `cmd_list_data.rs`

### What was NOT changed (and why)
- `main.rs:665` `process::exit(1)` — kept as the single top-level error handler (previous audit decision)
- `subprocess.rs` `.ok()` on pipe reads — acceptable in drain threads (best-effort)
- Large file sizes (4,467 LOC in `azlin-cli/src/lib.rs`) — structural, needs separate refactoring PR
- 5 pre-existing test failures in `test_group_55`/`test_group_56` — caused by corrupt config file on disk, not related to these changes

## Step 13: Local Testing Results

**Test Environment**: `fix/quality-audit-2026-03-09`, 2026-03-09
**Tests Executed**:
1. Simple: `cargo clippy --workspace -- -D warnings` -> 0 warnings, 0 errors
2. Simple: `cargo fmt --check` -> clean
3. Complex: `RUST_MIN_STACK=8388608 cargo test --workspace` -> 1,860 passed, 5 failed (pre-existing), 52 ignored
4. Verification: confirmed 5 failing tests fail identically on base branch `rust-rewrite-scaffold`

**Regressions**: None detected
**Issues Found**: 5 pre-existing test failures due to corrupt config file on disk (not related)

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `RUST_MIN_STACK=8388608 cargo test --workspace` — no new failures
- [ ] Manual verification of SSH connect behavior (interactive, needs live Azure VMs)
- [ ] Manual verification of autopilot scan with live VMs