### PR TITLE
fix(rust): harden config set against TOML corruption

### DIFF
--- a/rust/crates/azlin-core/src/config.rs
+++ b/rust/crates/azlin-core/src/config.rs
@@ -126,8 +126,13 @@ impl Default for AzlinConfig {
 }
 
 impl AzlinConfig {
-    /// Returns the config directory path (~/.azlin/)
+    /// Returns the config directory path.
+    ///
+    /// Checks `AZLIN_CONFIG_DIR` env var first, falls back to `~/.azlin/`.
     pub fn config_dir() -> crate::Result<PathBuf> {
+        if let Ok(dir) = std::env::var("AZLIN_CONFIG_DIR") {
+            return Ok(PathBuf::from(dir));
+        }
         Ok(dirs::home_dir()
             .ok_or_else(|| crate::AzlinError::Config("Home directory not found".into()))?
             .join(".azlin"))
@@ -206,6 +211,15 @@ impl AzlinConfig {
                 },
             )?;
         }
+
+        // Verify the serialized TOML is valid before committing the write.
+        // This prevents corrupt data from reaching config.toml.
+        let _: AzlinConfig = toml::from_str(&contents).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            crate::AzlinError::Config(format!(
+                "BUG: save() produced invalid TOML — not writing: {e}"
+            ))
+        })?;
 
         // Atomic rename (on same filesystem, this is atomic on Unix)
         std::fs::rename(&tmp_path, &path).map_err(|e| {


### PR DESCRIPTION
## Summary

Fixes #800 — `azlin config set key value` could corrupt `config.toml`.

- **Add `AZLIN_CONFIG_DIR` env var support** to `config_dir()` — integration tests that set this variable now actually use isolated temp directories instead of `~/.azlin/`
- **Add TOML verification in `save()`** — re-parses serialized output before the atomic rename, preventing corrupt data from ever reaching `config.toml`
- The config set handler already used the correct load-parse-update-serialize-write flow via serde_json + toml; these changes add defense-in-depth against future regressions

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `RUST_MIN_STACK=8388608 cargo test --workspace` — all 2,537 tests pass, 0 failures
- [x] Manual: `azlin config set az_cli_timeout 300` then `azlin config show` shows 300
- [x] Manual: `azlin config set default_region westus3` then `azlin config show` shows westus3
- [x] Manual: verified config.toml is valid TOML after set (parsed with Python tomllib)
- [x] Manual: `AZLIN_CONFIG_DIR=/tmp/test azlin config set az_cli_timeout 300` writes to `/tmp/test/config.toml`

## Step 13: Local Testing Results

**Test Environment**: fix/issue-800-config-set, dev build, 2026-03-09
**Tests Executed**:
1. Simple: `azlin config set az_cli_timeout 300` → `azlin config show` shows 300 ✅
2. Complex: Multiple set operations + TOML validation with Python tomllib ✅
3. AZLIN_CONFIG_DIR isolation: temp dir receives config.toml ✅
**Regressions**: Full workspace test suite passes ✅ None detected
**Issues Found**: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)