### PR TITLE
refactor: rename self-update→update, update→dev-update

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -47,11 +47,13 @@ pip install azlin-rs
 cd rust && cargo install --path crates/azlin
 ```
 
-### Self-update
+### Update
 
 The Rust binary can update itself from GitHub Releases:
 
 ```bash
+azlin update
+# Backward-compatible alias still works:
 azlin self-update
 ```
 
@@ -66,7 +68,7 @@ alias azlin="uvx --from git+https://github.com/rysweet/azlin azlin"
 
 When you run any command, the Python bridge:
 1. Checks for a Rust binary at `~/.azlin/bin/azlin`, `~/.cargo/bin/azlin`, or `/usr/local/bin/azlin`
-2. If found with `self-update` support → execs Rust binary (zero Python overhead)
+2. If found with `update` command support → execs Rust binary (zero Python overhead)
 3. If not found → downloads from GitHub Releases (or builds with `cargo` if available)
 4. Falls back to Python CLI only if nothing else works
 

--- a/rust/crates/azlin-cli/src/lib.rs
+++ b/rust/crates/azlin-cli/src/lib.rs
@@ -410,7 +410,8 @@ pub enum Commands {
     },
 
     /// Update all development tools on a VM
-    Update {
+    #[command(name = "dev-update")]
+    DevUpdate {
         /// VM name or session name
         vm_identifier: String,
 
@@ -971,8 +972,8 @@ pub enum Commands {
     Version,
 
     /// Update azlin to the latest version from GitHub Releases
-    #[command(name = "self-update")]
-    SelfUpdate,
+    #[command(name = "update", alias = "self-update")]
+    Update,
 
     /// Generate shell completions
     Completions {
@@ -2803,13 +2804,25 @@ mod tests {
     }
 
     #[test]
-    fn test_update_command() {
-        let cli = Cli::parse_from(["azlin", "update", "my-vm"]);
-        if let Commands::Update { vm_identifier, .. } = cli.command {
+    fn test_dev_update_command() {
+        let cli = Cli::parse_from(["azlin", "dev-update", "my-vm"]);
+        if let Commands::DevUpdate { vm_identifier, .. } = cli.command {
             assert_eq!(vm_identifier, "my-vm");
         } else {
-            panic!("Expected Update command");
+            panic!("Expected DevUpdate command");
         }
+    }
+
+    #[test]
+    fn test_update_is_self_update() {
+        let cli = Cli::parse_from(["azlin", "update"]);
+        assert!(matches!(cli.command, Commands::Update));
+    }
+
+    #[test]
+    fn test_self_update_alias() {
+        let cli = Cli::parse_from(["azlin", "self-update"]);
+        assert!(matches!(cli.command, Commands::Update));
     }
 
     #[test]

--- a/rust/crates/azlin/src/cmd_self_update.rs
+++ b/rust/crates/azlin/src/cmd_self_update.rs
@@ -178,7 +178,7 @@ fn find_binary_in_dir(dir: &std::path::Path) -> Result<PathBuf> {
 
 /// Run the self-update flow.
 pub fn handle_self_update() -> Result<()> {
-    println!("azlin self-update (current: v{})", CURRENT_VERSION);
+    println!("azlin update (current: v{})", CURRENT_VERSION);
 
     let (url, version) = find_latest_release()?;
 

--- a/rust/crates/azlin/src/cmd_vm.rs
+++ b/rust/crates/azlin/src/cmd_vm.rs
@@ -33,7 +33,7 @@ pub(crate) async fn dispatch(
             )
             .await?;
         }
-        azlin_cli::Commands::Update {
+        azlin_cli::Commands::DevUpdate {
             vm_identifier,
             resource_group,
             timeout: _,

--- a/rust/crates/azlin/src/dispatch.rs
+++ b/rust/crates/azlin/src/dispatch.rs
@@ -74,7 +74,7 @@ pub(crate) async fn dispatch_command(cli: azlin_cli::Cli) -> Result<()> {
             crate::cmd_ai::dispatch(cmd, cli.verbose, &cli.output).await?;
         }
         cmd @ azlin_cli::Commands::New { .. }
-        | cmd @ azlin_cli::Commands::Update { .. }
+        | cmd @ azlin_cli::Commands::DevUpdate { .. }
         | cmd @ azlin_cli::Commands::Clone { .. } => {
             crate::cmd_vm::dispatch(cmd, cli.verbose, &cli.output).await?;
         }
@@ -115,7 +115,7 @@ pub(crate) async fn dispatch_command(cli: azlin_cli::Cli) -> Result<()> {
         | cmd @ azlin_cli::Commands::Logs { .. } => {
             crate::cmd_sync::dispatch(cmd, cli.verbose, &cli.output).await?;
         }
-        azlin_cli::Commands::SelfUpdate => {
+        azlin_cli::Commands::Update => {
             crate::cmd_self_update::handle_self_update()?;
         }
         azlin_cli::Commands::Completions { shell } => {

--- a/rust/crates/azlin/src/tests/test_group_12.rs
+++ b/rust/crates/azlin/src/tests/test_group_12.rs
@@ -165,6 +165,24 @@ fn test_update_help() {
 }
 
 #[test]
+fn test_dev_update_help() {
+    assert_cmd::Command::cargo_bin("azlin")
+        .unwrap()
+        .args(["dev-update", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_self_update_alias_help() {
+    assert_cmd::Command::cargo_bin("azlin")
+        .unwrap()
+        .args(["self-update", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
 fn test_logs_help() {
     assert_cmd::Command::cargo_bin("azlin")
         .unwrap()

--- a/rust/crates/azlin/src/tests/test_group_19.rs
+++ b/rust/crates/azlin/src/tests/test_group_19.rs
@@ -200,8 +200,8 @@ fn test_show_graceful_error_no_auth() {
 }
 
 #[test]
-fn test_update_graceful_error_no_auth() {
-    assert_graceful_auth_error(&["update", "test-vm"]);
+fn test_dev_update_graceful_error_no_auth() {
+    assert_graceful_auth_error(&["dev-update", "test-vm"]);
 }
 
 #[test]

--- a/src/azlin/rust_bridge.py
+++ b/src/azlin/rust_bridge.py
@@ -49,15 +49,15 @@ def _platform_suffix() -> str | None:
 
 
 def _is_rust_binary(path: Path) -> bool:
-    """Check if a binary is the Rust azlin (has self-update command)."""
+    """Check if a binary is the Rust azlin (has update command)."""
     try:
         result = subprocess.run(
-            [str(path), "self-update", "--help"],
+            [str(path), "update", "--help"],
             capture_output=True,
             text=True,
             timeout=5,
         )
-        return result.returncode == 0 and "self-update" in result.stdout.lower()
+        return result.returncode == 0 and "update" in result.stdout.lower()
     except (subprocess.TimeoutExpired, OSError):
         return False
 


### PR DESCRIPTION
## Summary

Fixes #804

- `azlin update` now updates the azlin binary itself (was `azlin self-update`)
- `azlin self-update` still works as a backward-compatible alias
- `azlin dev-update <vm>` updates dev tools on a VM (was `azlin update <vm>`)
- Python migration bridge updated to probe `update --help` instead of `self-update --help`
- `azlin os-update <vm>` unchanged (OS package updates)

## Files Changed

- `rust/crates/azlin-cli/src/lib.rs` — CLI command definitions: `Update{}` → `DevUpdate{}` with `#[command(name = "dev-update")]`; `SelfUpdate` → `Update` with `#[command(name = "update", alias = "self-update")]`
- `rust/crates/azlin/src/dispatch.rs` — Updated match arms for renamed variants
- `rust/crates/azlin/src/cmd_vm.rs` — Updated match arm `Commands::Update` → `Commands::DevUpdate`
- `rust/crates/azlin/src/cmd_self_update.rs` — Updated status message text
- `rust/crates/azlin/src/tests/test_group_12.rs` — Added `test_dev_update_help` and `test_self_update_alias_help`
- `rust/crates/azlin/src/tests/test_group_19.rs` — Renamed `test_update_graceful_error_no_auth` → `test_dev_update_graceful_error_no_auth`
- `src/azlin/rust_bridge.py` — Bridge now probes `update --help` instead of `self-update --help`
- `rust/README.md` — Updated docs

## Step 13: Local Testing Results

**Test Environment**: fix/issue-804-rename-update-commands, cargo test, 2026-03-09
**Tests Executed**:
1. Simple: `cargo fmt --check` + `cargo clippy --workspace -- -D warnings` → passed ✅
2. Complex: `RUST_MIN_STACK=8388608 cargo test --workspace` → 1865 passed, 2 flaky (pre-existing config race), 52 ignored ✅
3. Specific: `test_dev_update_command`, `test_update_is_self_update`, `test_self_update_alias`, `test_dev_update_help`, `test_self_update_alias_help` all pass ✅
**Regressions**: None detected ✅
**Issues Found**: 2 flaky template-list tests (pre-existing, pass in isolation, fail under concurrent load due to shared config)

## Test plan

- [x] `azlin update --help` shows self-update help text
- [x] `azlin self-update --help` still works (alias)
- [x] `azlin dev-update --help` shows dev tools update help
- [x] All existing tests pass (1865/1865 non-flaky)
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)