### PR TITLE
refactor: rename self-update to update, move vm update-tools under azlin vm

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -47,12 +47,21 @@ pip install azlin-rs
 cd rust && cargo install --path crates/azlin
 ```
 
-### Self-update
+### Update
 
 The Rust binary can update itself from GitHub Releases:
 
 ```bash
-azlin self-update
+azlin update          # update the azlin binary itself
+azlin self-update     # backward-compatible alias
+```
+
+### VM tool updates
+
+Update development tools on a remote VM:
+
+```bash
+azlin vm update-tools <vm-name>
 ```
 
 ## Migration from Python
@@ -66,7 +75,7 @@ alias azlin="uvx --from git+https://github.com/rysweet/azlin azlin"
 
 When you run any command, the Python bridge:
 1. Checks for a Rust binary at `~/.azlin/bin/azlin`, `~/.cargo/bin/azlin`, or `/usr/local/bin/azlin`
-2. If found with `self-update` support → execs Rust binary (zero Python overhead)
+2. If found with `update` support → execs Rust binary (zero Python overhead)
 3. If not found → downloads from GitHub Releases (or builds with `cargo` if available)
 4. Falls back to Python CLI only if nothing else works
 

--- a/rust/crates/azlin-cli/src/lib.rs
+++ b/rust/crates/azlin-cli/src/lib.rs
@@ -123,7 +123,7 @@ pub enum Commands {
 
     // ── VM Lifecycle ───────────────────────────────────────────────────
     /// Provision a new VM
-    #[command(alias = "vm", alias = "create")]
+    #[command(alias = "create")]
     New {
         /// GitHub repository URL to clone
         #[arg(long)]
@@ -409,22 +409,10 @@ pub enum Commands {
         remote_command: Vec<String>,
     },
 
-    /// Update all development tools on a VM
-    Update {
-        /// VM name or session name
-        vm_identifier: String,
-
-        /// Resource group
-        #[arg(long, alias = "rg")]
-        resource_group: Option<String>,
-
-        /// Config file path
-        #[arg(long)]
-        config: Option<PathBuf>,
-
-        /// Timeout per update in seconds
-        #[arg(long, default_value = "300")]
-        timeout: u32,
+    /// VM management subcommands
+    Vm {
+        #[command(subcommand)]
+        action: VmAction,
     },
 
     /// Manage VM tags
@@ -971,8 +959,8 @@ pub enum Commands {
     Version,
 
     /// Update azlin to the latest version from GitHub Releases
-    #[command(name = "self-update")]
-    SelfUpdate,
+    #[command(name = "update", alias = "self-update")]
+    Update,
 
     /// Generate shell completions
     Completions {
@@ -985,6 +973,30 @@ pub enum Commands {
 // ---------------------------------------------------------------------------
 // Subcommand enums
 // ---------------------------------------------------------------------------
+
+// ── VM subcommands ────────────────────────────────────────────────────────
+
+#[derive(Subcommand, Debug)]
+pub enum VmAction {
+    /// Update development tools on a VM
+    #[command(name = "update-tools")]
+    UpdateTools {
+        /// VM name or session name
+        vm_identifier: String,
+
+        /// Resource group
+        #[arg(long, alias = "rg")]
+        resource_group: Option<String>,
+
+        /// Config file path
+        #[arg(long)]
+        config: Option<PathBuf>,
+
+        /// Timeout per update in seconds
+        #[arg(long, default_value = "300")]
+        timeout: u32,
+    },
+}
 
 #[derive(Subcommand, Debug)]
 pub enum BastionAction {
@@ -2803,12 +2815,55 @@ mod tests {
     }
 
     #[test]
-    fn test_update_command() {
-        let cli = Cli::parse_from(["azlin", "update", "my-vm"]);
-        if let Commands::Update { vm_identifier, .. } = cli.command {
+    fn test_update_self_update() {
+        // `azlin update` should trigger the binary self-update
+        let cli = Cli::parse_from(["azlin", "update"]);
+        assert!(matches!(cli.command, Commands::Update));
+    }
+
+    #[test]
+    fn test_self_update_alias() {
+        // `azlin self-update` should still work as a backward-compat alias
+        let cli = Cli::parse_from(["azlin", "self-update"]);
+        assert!(matches!(cli.command, Commands::Update));
+    }
+
+    #[test]
+    fn test_vm_update_tools() {
+        let cli = Cli::parse_from(["azlin", "vm", "update-tools", "my-vm"]);
+        if let Commands::Vm {
+            action: VmAction::UpdateTools { vm_identifier, .. },
+        } = cli.command
+        {
             assert_eq!(vm_identifier, "my-vm");
         } else {
-            panic!("Expected Update command");
+            panic!("Expected Vm UpdateTools command");
+        }
+    }
+
+    #[test]
+    fn test_vm_update_tools_with_rg() {
+        let cli = Cli::parse_from([
+            "azlin",
+            "vm",
+            "update-tools",
+            "my-vm",
+            "--resource-group",
+            "my-rg",
+        ]);
+        if let Commands::Vm {
+            action:
+                VmAction::UpdateTools {
+                    vm_identifier,
+                    resource_group,
+                    ..
+                },
+        } = cli.command
+        {
+            assert_eq!(vm_identifier, "my-vm");
+            assert_eq!(resource_group, Some("my-rg".to_string()));
+        } else {
+            panic!("Expected Vm UpdateTools command");
         }
     }
 

--- a/rust/crates/azlin/src/cmd_cleanup_costs.rs
+++ b/rust/crates/azlin/src/cmd_cleanup_costs.rs
@@ -60,9 +60,7 @@ pub(crate) fn dispatch_costs(action: azlin_cli::CostsAction) -> Result<()> {
                         "⚠ Cost history unavailable: {}",
                         azlin_core::sanitizer::sanitize(&e.to_string())
                     );
-                    eprintln!(
-                        "  Run 'az consumption usage list' for cost data via Azure CLI."
-                    );
+                    eprintln!("  Run 'az consumption usage list' for cost data via Azure CLI.");
                     return Ok(());
                 }
             };
@@ -94,21 +92,15 @@ pub(crate) fn dispatch_costs(action: azlin_cli::CostsAction) -> Result<()> {
             if date_costs.is_empty() {
                 println!("No cost data available for the last {} days.", days);
             } else {
-                let mut table = crate::table_render::SimpleTable::new(
-                    &["Date", "Cost (USD)"],
-                    &[12, 14],
-                );
+                let mut table =
+                    crate::table_render::SimpleTable::new(&["Date", "Cost (USD)"], &[12, 14]);
                 let mut total = 0.0;
                 for (date, cost) in &date_costs {
                     table.add_row(vec![date.clone(), format!("${:.2}", cost)]);
                     total += cost;
                 }
                 println!("{table}");
-                println!(
-                    "Total: ${:.2} ({} days with data)",
-                    total,
-                    date_costs.len()
-                );
+                println!("Total: ${:.2} ({} days with data)", total, date_costs.len());
             }
         }
         azlin_cli::CostsAction::Budget {

--- a/rust/crates/azlin/src/cmd_lifecycle.rs
+++ b/rust/crates/azlin/src/cmd_lifecycle.rs
@@ -209,12 +209,7 @@ pub(crate) async fn dispatch(
             let pb = indicatif::ProgressBar::new_spinner();
             pb.set_message(format!("Looking up {}...", vm_identifier));
             pb.enable_steady_tick(std::time::Duration::from_millis(100));
-            let target = resolve_vm_ssh_target(
-                &vm_identifier,
-                None,
-                Some(rg.clone()),
-            )
-            .await?;
+            let target = resolve_vm_ssh_target(&vm_identifier, None, Some(rg.clone())).await?;
             pb.finish_and_clear();
 
             println!("Running OS updates on '{}'...", vm_identifier);

--- a/rust/crates/azlin/src/cmd_vm.rs
+++ b/rust/crates/azlin/src/cmd_vm.rs
@@ -33,14 +33,16 @@ pub(crate) async fn dispatch(
             )
             .await?;
         }
-        azlin_cli::Commands::Update {
-            vm_identifier,
-            resource_group,
-            timeout: _,
-            ..
-        } => {
-            crate::cmd_vm_ops2::handle_vm_update(&vm_identifier, resource_group).await?;
-        }
+        azlin_cli::Commands::Vm { action } => match action {
+            azlin_cli::VmAction::UpdateTools {
+                vm_identifier,
+                resource_group,
+                timeout: _,
+                ..
+            } => {
+                crate::cmd_vm_ops2::handle_vm_update(&vm_identifier, resource_group).await?;
+            }
+        },
         azlin_cli::Commands::Clone {
             source_vm,
             num_replicas,

--- a/rust/crates/azlin/src/cmd_vm_ops2.rs
+++ b/rust/crates/azlin/src/cmd_vm_ops2.rs
@@ -9,8 +9,7 @@ pub(crate) async fn handle_vm_update(
     let pb = indicatif::ProgressBar::new_spinner();
     pb.set_message(format!("Looking up {}...", vm_identifier));
     pb.enable_steady_tick(std::time::Duration::from_millis(100));
-    let target =
-        resolve_vm_ssh_target(vm_identifier, None, resource_group).await?;
+    let target = resolve_vm_ssh_target(vm_identifier, None, resource_group).await?;
     pb.finish_and_clear();
 
     println!("Updating development tools on '{}'...", vm_identifier);

--- a/rust/crates/azlin/src/dispatch.rs
+++ b/rust/crates/azlin/src/dispatch.rs
@@ -74,7 +74,7 @@ pub(crate) async fn dispatch_command(cli: azlin_cli::Cli) -> Result<()> {
             crate::cmd_ai::dispatch(cmd, cli.verbose, &cli.output).await?;
         }
         cmd @ azlin_cli::Commands::New { .. }
-        | cmd @ azlin_cli::Commands::Update { .. }
+        | cmd @ azlin_cli::Commands::Vm { .. }
         | cmd @ azlin_cli::Commands::Clone { .. } => {
             crate::cmd_vm::dispatch(cmd, cli.verbose, &cli.output).await?;
         }
@@ -115,7 +115,7 @@ pub(crate) async fn dispatch_command(cli: azlin_cli::Cli) -> Result<()> {
         | cmd @ azlin_cli::Commands::Logs { .. } => {
             crate::cmd_sync::dispatch(cmd, cli.verbose, &cli.output).await?;
         }
-        azlin_cli::Commands::SelfUpdate => {
+        azlin_cli::Commands::Update => {
             crate::cmd_self_update::handle_self_update()?;
         }
         azlin_cli::Commands::Completions { shell } => {

--- a/rust/crates/azlin/src/main.rs
+++ b/rust/crates/azlin/src/main.rs
@@ -586,9 +586,7 @@ fn run_health_tui(metrics: &[HealthMetrics]) -> Result<()> {
 
 /// Get running VMs with their IPs from Azure for SSH-based commands.
 /// Returns Vec of (vm_name, ip, admin_user).
-async fn get_running_vm_targets(
-    resource_group: Option<String>,
-) -> Result<Vec<VmSshTarget>> {
+async fn get_running_vm_targets(resource_group: Option<String>) -> Result<Vec<VmSshTarget>> {
     resolve_vm_targets(None, None, resource_group).await
 }
 

--- a/rust/crates/azlin/src/tests/test_group_12.rs
+++ b/rust/crates/azlin/src/tests/test_group_12.rs
@@ -157,9 +157,28 @@ fn test_sync_help() {
 
 #[test]
 fn test_update_help() {
+    // `azlin update` is now the self-update command
     assert_cmd::Command::cargo_bin("azlin")
         .unwrap()
         .args(["update", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_vm_update_tools_help() {
+    assert_cmd::Command::cargo_bin("azlin")
+        .unwrap()
+        .args(["vm", "update-tools", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_self_update_alias_help() {
+    assert_cmd::Command::cargo_bin("azlin")
+        .unwrap()
+        .args(["self-update", "--help"])
         .assert()
         .success();
 }

--- a/rust/crates/azlin/src/tests/test_group_19.rs
+++ b/rust/crates/azlin/src/tests/test_group_19.rs
@@ -200,8 +200,8 @@ fn test_show_graceful_error_no_auth() {
 }
 
 #[test]
-fn test_update_graceful_error_no_auth() {
-    assert_graceful_auth_error(&["update", "test-vm"]);
+fn test_vm_update_tools_graceful_error_no_auth() {
+    assert_graceful_auth_error(&["vm", "update-tools", "test-vm"]);
 }
 
 #[test]

--- a/src/azlin/rust_bridge.py
+++ b/src/azlin/rust_bridge.py
@@ -49,15 +49,15 @@ def _platform_suffix() -> str | None:
 
 
 def _is_rust_binary(path: Path) -> bool:
-    """Check if a binary is the Rust azlin (has self-update command)."""
+    """Check if a binary is the Rust azlin (has update command)."""
     try:
         result = subprocess.run(
-            [str(path), "self-update", "--help"],
+            [str(path), "update", "--help"],
             capture_output=True,
             text=True,
             timeout=5,
         )
-        return result.returncode == 0 and "self-update" in result.stdout.lower()
+        return result.returncode == 0 and "update" in result.stdout.lower()
     except (subprocess.TimeoutExpired, OSError):
         return False
 


### PR DESCRIPTION
## Summary

Fixes #804. Corrects the command naming that PR #805 got wrong.

- `azlin update` — updates the azlin binary itself (was `self-update`)
- `azlin self-update` — kept as backward-compatible alias
- `azlin vm update-tools <vm>` — updates dev tools on a VM (was `update <vm>`)
- Creates `VmAction` enum following existing subcommand group patterns (`BastionAction`, `ConfigAction`, etc.)
- Removes `vm` alias from `new` command to avoid clash with the new `Vm` subcommand
- Updates `rust_bridge.py` to probe `update --help` instead of `self-update --help`
- Updates `rust/README.md` command references

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] 1,866 tests pass (1 pre-existing failure in `test_dispatch_config_set_and_restore` unrelated to this change)
- [x] `azlin update --help` shows self-update help
- [x] `azlin self-update --help` still works (alias)
- [x] `azlin vm --help` shows `update-tools` subcommand
- [x] `azlin vm update-tools --help` shows correct args

## Step 13: Local Testing Results

**Test Environment**: feat/issue-804-rename-update-commands, cargo build, 2026-03-09

**Tests Executed**:
1. Simple: `azlin update --help` → shows self-update help text ✅
2. Simple: `azlin self-update --help` → backward-compat alias works ✅
3. Complex: `azlin vm update-tools --help` → shows VM identifier arg + options ✅
4. Complex: `azlin vm --help` → lists `update-tools` subcommand ✅
5. Regression: Full test suite (1,866 pass, 0 new failures) ✅

**Regressions**: None detected
**Issues Found**: Removed `vm` alias from `new` command to avoid conflict with new `Vm` subcommand group

🤖 Generated with [Claude Code](https://claude.com/claude-code)