### PR TITLE
feat: auto version bump in release workflow + release docs

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -10,7 +10,88 @@ permissions:
   contents: write
 
 jobs:
+  # ── Auto-increment patch version ──────────────────────────────────────
+  version-bump:
+    runs-on: ubuntu-latest
+    # Skip if this push is already a version-bump commit (prevent loops)
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      sha: ${{ steps.bump.outputs.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump patch version
+        id: bump
+        run: |
+          set -euo pipefail
+
+          # Read current version from workspace Cargo.toml
+          CURRENT=$(grep '^version' rust/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "Current Cargo.toml version: ${CURRENT}"
+
+          # Parse major.minor.patch
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${CURRENT}"
+
+          # Find the latest release tag matching this major.minor
+          LATEST_TAG=$(gh release list --limit 100 --json tagName --jq '.[].tagName' \
+            | grep -E "^v${MAJOR}\.${MINOR}\.[0-9]+-rust\." \
+            | sort -t. -k3 -n -r \
+            | head -1 || true)
+
+          if [ -n "${LATEST_TAG}" ]; then
+            # Extract patch from tag: v2.6.3-rust.abc1234 → 3
+            LATEST_PATCH=$(echo "${LATEST_TAG}" | sed 's/^v[0-9]*\.[0-9]*\.\([0-9]*\)-.*/\1/')
+            NEW_PATCH=$((LATEST_PATCH + 1))
+            echo "Latest release tag: ${LATEST_TAG} (patch=${LATEST_PATCH})"
+          else
+            # No prior release for this major.minor — use current patch
+            NEW_PATCH="${PATCH}"
+            echo "No prior release found for v${MAJOR}.${MINOR}.x"
+          fi
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
+          echo "New version: ${NEW_VERSION}"
+
+          if [ "${NEW_VERSION}" = "${CURRENT}" ]; then
+            echo "Version unchanged — skipping commit"
+            echo "version=${CURRENT}" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # ── Update all version files ──────────────────────────────────
+          # 1. rust/Cargo.toml (workspace)
+          sed -i "s/^version = \"${CURRENT}\"/version = \"${NEW_VERSION}\"/" rust/Cargo.toml
+
+          # 2. pyproject.toml (root)
+          sed -i "s/^version = \"${CURRENT}\"/version = \"${NEW_VERSION}\"/" pyproject.toml
+
+          # 3. rust/pyproject.toml (maturin)
+          sed -i "s/^version = \"${CURRENT}\"/version = \"${NEW_VERSION}\"/" rust/pyproject.toml
+
+          # 4. src/azlin/__init__.py
+          sed -i "s/__version__ = \"${CURRENT}\"/__version__ = \"${NEW_VERSION}\"/" src/azlin/__init__.py
+
+          # ── Commit and push ───────────────────────────────────────────
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add rust/Cargo.toml pyproject.toml rust/pyproject.toml src/azlin/__init__.py
+          git commit -m "chore: bump version ${CURRENT} → ${NEW_VERSION} [skip ci]"
+          git push
+
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Build native binaries ─────────────────────────────────────────────
   build:
+    needs: [version-bump]
     strategy:
       matrix:
         include:
@@ -37,6 +118,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version-bump.outputs.sha }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -83,6 +166,7 @@ jobs:
 
   # Build Python wheels with maturin for uvx/pip install
   wheels:
+    needs: [version-bump]
     strategy:
       matrix:
         include:
@@ -101,6 +185,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version-bump.outputs.sha }}
 
       - uses: actions/setup-python@v5
         with:
@@ -121,20 +207,23 @@ jobs:
           name: wheel-${{ matrix.os }}-${{ matrix.target }}
           path: rust/dist/*.whl
 
+  # ── Create GitHub Release ─────────────────────────────────────────────
   release:
-    needs: [build]
+    needs: [version-bump, build]
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version-bump.outputs.sha }}
 
       - name: Get version
         id: version
         run: |
-          BASE=$(grep '^version' rust/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          echo "version=${BASE}" >> $GITHUB_OUTPUT
-          echo "tag=${BASE}-rust.${SHORT_SHA}" >> $GITHUB_OUTPUT
+          VERSION="${{ needs.version-bump.outputs.version }}"
+          SHORT_SHA=$(echo "${{ needs.version-bump.outputs.sha }}" | cut -c1-7)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=${VERSION}-rust.${SHORT_SHA}" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -152,7 +241,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.tag }}
-          name: "azlin v${{ steps.version.outputs.version }} (${{ github.sha }})"
+          name: "azlin v${{ steps.version.outputs.version }} (${{ needs.version-bump.outputs.sha }})"
           body: |
             ## Rust CLI Release
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,146 @@
+# Release Pipeline
+
+How azlin gets built, versioned, tagged, and distributed.
+
+## What triggers a release
+
+The GitHub Actions workflow `.github/workflows/rust-release.yml` runs when:
+
+1. **A push to `main` changes any file under `rust/`** — automatic release.
+2. **Manual dispatch** — click "Run workflow" in the Actions tab.
+
+The workflow skips entirely if the triggering commit message contains `[skip ci]`
+(this prevents the version-bump commit from re-triggering itself).
+
+## What gets built
+
+| Platform        | Target triple                  | Asset name              |
+| --------------- | ------------------------------ | ----------------------- |
+| Linux x86_64    | `x86_64-unknown-linux-gnu`     | `azlin-linux-x86_64`   |
+| Linux aarch64   | `aarch64-unknown-linux-gnu`    | `azlin-linux-aarch64`  |
+| macOS x86_64    | `x86_64-apple-darwin`          | `azlin-macos-x86_64`   |
+| macOS aarch64   | `aarch64-apple-darwin`         | `azlin-macos-aarch64`  |
+| Windows x86_64  | `x86_64-pc-windows-msvc`       | `azlin-windows-x86_64` |
+
+Each platform produces a `.tar.gz` archive containing both `azlin` and `azdoit`
+binaries. Python wheels (via maturin) are also built for all platforms.
+
+## Where artifacts go
+
+Every release creates a **GitHub Release** at
+`https://github.com/rysweet/azlin/releases` with:
+
+- Platform-specific `.tar.gz` archives (native binaries)
+- Python `.whl` files (for `pip install azlin-rs`)
+
+## Version scheme
+
+```
+<major>.<minor>.<patch>
+```
+
+- **Patch** is auto-incremented by the release workflow on every merge to main.
+- **Minor** and **major** bumps are manual (edit `rust/Cargo.toml`).
+
+### Auto-increment logic
+
+The `version-bump` job in the release workflow:
+
+1. Reads the current version from `rust/Cargo.toml` (e.g. `2.6.0`).
+2. Queries existing GitHub Release tags for the same `major.minor` prefix.
+3. Finds the highest patch number among those tags (e.g. `v2.6.3-rust.abc1234` has patch `3`).
+4. Sets the new version to `major.minor.(highest_patch + 1)` (e.g. `2.6.4`).
+5. Updates all version files: `rust/Cargo.toml`, `pyproject.toml`, `rust/pyproject.toml`, `src/azlin/__init__.py`.
+6. Commits with `[skip ci]` to prevent re-triggering the workflow.
+7. Pushes the commit. All subsequent build jobs check out this commit.
+
+If no prior release exists for the current `major.minor`, the patch number from
+`Cargo.toml` is used as-is.
+
+## Tag format
+
+```
+v<major>.<minor>.<patch>-rust.<short-sha>
+```
+
+Examples:
+- `v2.6.4-rust.abc1234`
+- `v2.7.0-rust.def5678`
+
+The `-rust` suffix distinguishes Rust releases from any legacy Python releases.
+The short SHA identifies the exact commit the binaries were built from.
+
+## How `azlin update` works
+
+The `azlin update` command (implemented in `rust/crates/azlin/src/cmd_self_update.rs`):
+
+1. Queries the GitHub Releases API for `rysweet/azlin`:
+   - First tries **`gh api`** (authenticated, no rate limits).
+   - Falls back to **`curl`** (unauthenticated, 60 req/hr limit).
+2. Finds the latest release whose tag contains `-rust`.
+3. Matches the platform-specific `.tar.gz` asset (e.g. `azlin-linux-x86_64.tar.gz`).
+4. Downloads the archive with `curl`, extracts it with `tar`.
+5. Replaces the running binary:
+   - Renames current binary to `.old` (backup).
+   - Copies new binary into place.
+   - Sets executable permissions.
+   - Removes backup and temp files.
+6. Prints `Updated azlin: <old_version> → <new_version>`.
+
+If the current version already matches the latest release, it prints
+"Already at the latest version" and exits.
+
+## How Python-to-Rust migration works
+
+The Python package (`pip install azlin`) ships a thin bridge at
+`src/azlin/rust_bridge.py` that **does not contain any CLI logic**. It only
+bootstraps the Rust binary:
+
+1. **Probe known locations** (in order):
+   - `~/.azlin/bin/azlin` (managed install from GitHub Releases)
+   - `~/.cargo/bin/azlin` (cargo install)
+   - `/usr/local/bin/azlin` (system package)
+2. **If not found, download from GitHub Releases** — same mechanism as
+   `azlin update`, using the Releases API to find the latest `-rust` tagged
+   release and downloading the platform-specific archive.
+3. **If download fails, build from source** — runs
+   `cargo install --git https://github.com/rysweet/azlin --bin azlin`.
+4. **If all methods fail, exit with error** — prints clear instructions for
+   manual installation. There is **no Python fallback**.
+5. **exec() the Rust binary** — replaces the Python process entirely.
+
+## How to do a manual version bump
+
+For minor or major bumps, edit the workspace version in `rust/Cargo.toml`:
+
+```toml
+[workspace.package]
+version = "2.7.0"  # ← change this
+```
+
+All crates inherit the workspace version (`version.workspace = true`), so only
+the root `Cargo.toml` needs changing. The release workflow will then update the
+remaining files (`pyproject.toml`, `rust/pyproject.toml`, `src/azlin/__init__.py`)
+automatically during the next release — or you can update them manually for
+consistency:
+
+```bash
+# Files that contain the version string:
+rust/Cargo.toml          # workspace version (source of truth)
+pyproject.toml           # Python package version
+rust/pyproject.toml      # maturin wheel version
+src/azlin/__init__.py    # __version__ string
+```
+
+After editing, commit and push to `main`. The release workflow picks up the new
+base version and auto-increments from there.
+
+## Platform support
+
+| Platform       | Binary         | Wheel        | Tested |
+| -------------- | -------------- | ------------ | ------ |
+| linux-x86_64   | yes            | yes          | CI     |
+| linux-aarch64  | yes (cross)    | yes (cross)  | CI     |
+| macos-x86_64   | yes            | yes          | CI     |
+| macos-aarch64  | yes            | yes          | CI     |
+| windows-x86_64 | yes            | yes          | CI     |


### PR DESCRIPTION
## Summary

- Add automated patch version bumping to the release workflow (`rust-release.yml`)
- Create `docs/RELEASE.md` documenting the full release pipeline

Closes #808

## Changes

### 1. Release workflow — auto version bump

Added a `version-bump` job that runs before `build` and `wheels`:

- Reads current version from `rust/Cargo.toml`
- Queries existing GitHub Release tags for the same `major.minor` prefix via `gh release list`
- Increments patch: e.g. if latest tag is `v2.6.3-rust.abc1234`, next release becomes `v2.6.4-rust.<sha>`
- Updates all version files: `rust/Cargo.toml`, `pyproject.toml`, `rust/pyproject.toml`, `src/azlin/__init__.py`
- Commits with `[skip ci]` to prevent infinite workflow loops
- Pushes the bump commit; `build`/`wheels`/`release` jobs all check out the bumped SHA

**Loop prevention**: The `version-bump` job has `if: "!contains(github.event.head_commit.message, '[skip ci]')"` so the bump commit never re-triggers the workflow.

**No-op when version unchanged**: If the computed version equals the current `Cargo.toml` version (e.g. first release of a new minor), no commit is created.

### 2. docs/RELEASE.md

Documents:
- What triggers a release (push to main changing `rust/**`, or manual dispatch)
- Build matrix (5 platforms: linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64)
- Version scheme (`major.minor.patch` — patch auto-incremented, minor/major manual)
- Tag format (`v<version>-rust.<short-sha>`)
- How `azlin update` works (GitHub Releases API via `gh`/`curl`, download, replace binary)
- How Python→Rust migration bridge works (`rust_bridge.py`: probe → download → build → fail)
- Manual version bump instructions
- Platform support matrix

## Step 13: Local Testing Results

**Test Environment**: feat/issue-808-auto-version-bump, 2026-03-10
**Tests Executed**:
1. Simple: YAML validation with `python3 -c "import yaml; yaml.safe_load(...)"` → valid YAML
2. Complex: Verified workflow logic — `[skip ci]` guard prevents loops, `version-bump` outputs feed into `build`/`wheels`/`release` jobs via `needs` + `outputs`, all checkout steps use `ref: ${{ needs.version-bump.outputs.sha }}`

**Regressions**: Existing build/wheels/release logic preserved — only added dependency on version-bump job
**Issues Found**: None


🤖 Generated with [Claude Code](https://claude.com/claude-code)