### PR TITLE
feat: penguin emoji progress spinner (#812)

### DIFF
--- a/rust/crates/azlin/src/cmd_ai_ops.rs
+++ b/rust/crates/azlin/src/cmd_ai_ops.rs
@@ -28,9 +28,7 @@ pub(crate) async fn handle_ask(
     };
 
     let context = format!("Resource group: {}", rg);
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message("Querying Claude...");
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner("Querying Claude...");
     let answer = client.ask(&query_text, &context).await?;
     pb.finish_and_clear();
     println!("{}", answer);
@@ -45,9 +43,7 @@ pub(crate) async fn handle_do(
 ) -> Result<()> {
     let client = azlin_ai::AnthropicClient::new()?;
 
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message("Generating commands...");
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner("Generating commands...");
     let commands = client.execute(request).await?;
     pb.finish_and_clear();
 
@@ -120,9 +116,7 @@ pub(crate) async fn handle_doit_deploy(request: &str, dry_run: bool, yes: bool) 
         Available operations: az vm list, az vm start, az vm stop, az vm create, \
         az vm delete, az group create, az network nsg create, etc.";
 
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message("Generating deployment plan...");
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner("Generating deployment plan...");
     let commands = client.ask(request, system_context).await?;
     pb.finish_and_clear();
 

--- a/rust/crates/azlin/src/cmd_ai_ops2.rs
+++ b/rust/crates/azlin/src/cmd_ai_ops2.rs
@@ -30,9 +30,7 @@ pub(crate) fn handle_doit_list(username: Option<String>) -> Result<()> {
     let auth = create_auth()?;
     let vm_manager = azlin_azure::VmManager::new(&auth);
     let rg = resolve_resource_group(None)?;
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message("Listing doit-created resources...");
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner("Listing doit-created resources...");
     let vms = vm_manager.list_vms(&rg)?;
     pb.finish_and_clear();
     let filtered: Vec<_> = vms
@@ -79,9 +77,7 @@ pub(crate) fn handle_doit_cleanup(
     let vm_manager = azlin_azure::VmManager::new(&auth);
     let rg = resolve_resource_group(None)?;
 
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message("Finding doit-created resources...");
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner("Finding doit-created resources...");
     let vms = vm_manager.list_vms(&rg)?;
     pb.finish_and_clear();
 

--- a/rust/crates/azlin/src/cmd_auth.rs
+++ b/rust/crates/azlin/src/cmd_auth.rs
@@ -74,12 +74,10 @@ pub(crate) async fn dispatch(
                     }
                 }
                 azlin_cli::AuthAction::Test { profile, .. } => {
-                    let pb = indicatif::ProgressBar::new_spinner();
-                    pb.set_message(format!(
+                    let pb = penguin_spinner(&format!(
                         "Testing authentication for profile '{}'...",
                         profile
                     ));
-                    pb.enable_steady_tick(std::time::Duration::from_millis(100));
 
                     let output = std::process::Command::new("az")
                         .args(["account", "show", "--output", "json"])

--- a/rust/crates/azlin/src/cmd_batch.rs
+++ b/rust/crates/azlin/src/cmd_batch.rs
@@ -98,9 +98,7 @@ pub(crate) async fn dispatch(
                 let _vm_manager = azlin_azure::VmManager::new(&auth);
                 let rg = resolve_resource_group(resource_group)?;
 
-                let pb = indicatif::ProgressBar::new_spinner();
-                pb.set_message(format!("Running '{}' on all VMs in '{}'...", command, rg));
-                pb.enable_steady_tick(std::time::Duration::from_millis(100));
+                let pb = penguin_spinner(&format!("Running '{}' on all VMs in '{}'...", command, rg));
 
                 let vms = get_running_vm_targets(Some(rg.clone())).await?;
                 pb.finish_and_clear();
@@ -195,9 +193,7 @@ pub(crate) async fn dispatch(
                     let auth = create_auth()?;
                     let _vm_manager = azlin_azure::VmManager::new(&auth);
 
-                    let pb = indicatif::ProgressBar::new_spinner();
-                    pb.set_message(format!("Gathering fleet VMs in '{}'...", rg));
-                    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+                    let pb = penguin_spinner(&format!("Gathering fleet VMs in '{}'...", rg));
 
                     let vms = get_running_vm_targets(Some(rg.clone())).await?;
                     pb.finish_and_clear();

--- a/rust/crates/azlin/src/cmd_connect.rs
+++ b/rust/crates/azlin/src/cmd_connect.rs
@@ -76,9 +76,7 @@ pub(crate) async fn dispatch(
                 running[idx].name.clone()
             };
 
-            let pb = indicatif::ProgressBar::new_spinner();
-            pb.set_message(format!("Looking up {}...", name));
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            let pb = penguin_spinner(&format!("Looking up {}...", name));
             let vm = vm_manager.get_vm(&rg, &name)?;
             pb.finish_and_clear();
 
@@ -217,9 +215,7 @@ pub(crate) async fn dispatch(
             let vm_manager = azlin_azure::VmManager::new(&auth);
             let rg = resolve_resource_group(resource_group)?;
 
-            let pb = indicatif::ProgressBar::new_spinner();
-            pb.set_message(format!("Fetching {}...", name));
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            let pb = penguin_spinner(&format!("Fetching {}...", name));
             let vm = crate::handlers::handle_show(&vm_manager, &rg, &name)?;
             pb.finish_and_clear();
 

--- a/rust/crates/azlin/src/cmd_infra_ops.rs
+++ b/rust/crates/azlin/src/cmd_infra_ops.rs
@@ -48,9 +48,7 @@ pub(crate) async fn handle_runner_enable(
 
     for i in 0..count {
         let vm_name = format!("azlin-runner-{}-{}", pool, i + 1);
-        let pb = indicatif::ProgressBar::new_spinner();
-        pb.set_message(format!("Provisioning {}...", vm_name));
-        pb.enable_steady_tick(std::time::Duration::from_millis(100));
+        let pb = penguin_spinner(&format!("Provisioning {}...", vm_name));
         let out = std::process::Command::new("az")
             .args([
                 "vm",

--- a/rust/crates/azlin/src/cmd_lifecycle.rs
+++ b/rust/crates/azlin/src/cmd_lifecycle.rs
@@ -27,7 +27,7 @@ pub(crate) async fn dispatch(
             pb.set_message(crate::lifecycle_helpers::progress_message(
                 "Starting", &vm_name,
             ));
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            pb.enable_steady_tick(std::time::Duration::from_millis(120));
             let msg = crate::handlers::handle_start(&vm_manager, &rg, &vm_name)?;
             pb.finish_with_message(crate::lifecycle_helpers::finished_ok(&msg));
         }
@@ -46,7 +46,7 @@ pub(crate) async fn dispatch(
             pb.set_style(fleet_spinner_style());
             pb.set_prefix(format!("{:>20}", vm_name));
             pb.set_message(crate::lifecycle_helpers::progress_message(action, &vm_name));
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            pb.enable_steady_tick(std::time::Duration::from_millis(120));
             let msg = crate::handlers::handle_stop(&vm_manager, &rg, &vm_name, deallocate)?;
             pb.finish_with_message(crate::lifecycle_helpers::finished_ok(&msg));
         }
@@ -74,7 +74,7 @@ pub(crate) async fn dispatch(
             pb.set_message(crate::lifecycle_helpers::progress_message(
                 "Deleting", &vm_name,
             ));
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            pb.enable_steady_tick(std::time::Duration::from_millis(120));
             let msg = crate::handlers::handle_delete(&vm_manager, &rg, &vm_name)?;
             pb.finish_with_message(crate::lifecycle_helpers::finished_ok(&msg));
         }
@@ -93,7 +93,7 @@ pub(crate) async fn dispatch(
             pb.set_message(crate::lifecycle_helpers::progress_message(
                 "Killing", &vm_name,
             ));
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            pb.enable_steady_tick(std::time::Duration::from_millis(120));
             let _msg = crate::handlers::handle_delete(&vm_manager, &rg, &vm_name)?;
             pb.finish_with_message(crate::lifecycle_helpers::killed_message(&vm_name));
         }
@@ -129,7 +129,7 @@ pub(crate) async fn dispatch(
                 "Destroying",
                 &vm_name,
             ));
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            pb.enable_steady_tick(std::time::Duration::from_millis(120));
             crate::handlers::handle_delete(&vm_manager, &rg, &vm_name)?;
             pb.finish_with_message(crate::lifecycle_helpers::destroyed_message(&vm_name));
         }
@@ -148,12 +148,10 @@ pub(crate) async fn dispatch(
                 return Ok(());
             }
 
-            let pb = indicatif::ProgressBar::new_spinner();
-            pb.set_message(crate::lifecycle_helpers::progress_message(
+            let pb = penguin_spinner(&crate::lifecycle_helpers::progress_message(
                 "Deleting VMs with prefix",
                 &format!("'{}'", prefix),
             ));
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
 
             let query = crate::lifecycle_helpers::killall_jmespath_query(&prefix);
             let args = crate::lifecycle_helpers::killall_list_args(&rg, &query);
@@ -206,9 +204,7 @@ pub(crate) async fn dispatch(
         } => {
             let rg = resolve_resource_group(resource_group)?;
 
-            let pb = indicatif::ProgressBar::new_spinner();
-            pb.set_message(format!("Looking up {}...", vm_identifier));
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            let pb = penguin_spinner(&format!("Looking up {}...", vm_identifier));
             let target = resolve_vm_ssh_target(&vm_identifier, None, Some(rg.clone())).await?;
             pb.finish_and_clear();
 

--- a/rust/crates/azlin/src/cmd_monitoring.rs
+++ b/rust/crates/azlin/src/cmd_monitoring.rs
@@ -73,9 +73,7 @@ pub(crate) async fn dispatch(
             let vm_manager = azlin_azure::VmManager::new(&auth);
             let rg = resolve_resource_group(resource_group)?;
 
-            let pb = indicatif::ProgressBar::new_spinner();
-            pb.set_message("Collecting health metrics...");
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            let pb = penguin_spinner("Collecting health metrics...");
 
             // Detect bastion hosts for private-IP-only VMs
             let bastion_map: std::collections::HashMap<String, String> =

--- a/rust/crates/azlin/src/cmd_network_ops.rs
+++ b/rust/crates/azlin/src/cmd_network_ops.rs
@@ -12,9 +12,7 @@ pub(crate) fn handle_disk_add(
     let rg = resolve_resource_group(resource_group)?;
     let disk_name = format!("{}_datadisk_{}", vm_name, lun.unwrap_or(0));
 
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message(format!("Adding {} GB disk to {}...", size, vm_name));
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner(&format!("Adding {} GB disk to {}...", size, vm_name));
 
     let output = std::process::Command::new("az")
         .args([

--- a/rust/crates/azlin/src/cmd_self_update.rs
+++ b/rust/crates/azlin/src/cmd_self_update.rs
@@ -93,9 +93,7 @@ fn download_and_replace(url: &str, version: &str) -> Result<()> {
     let archive_path = tmp_dir.join("azlin.tar.gz");
 
     // Download
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message(format!("Downloading azlin v{}...", version));
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = crate::penguin_spinner(&format!("Downloading azlin v{}...", version));
 
     let dl_status = std::process::Command::new("curl")
         .args(["-sS", "-L", "-o", archive_path.to_str().unwrap(), url])

--- a/rust/crates/azlin/src/cmd_session.rs
+++ b/rust/crates/azlin/src/cmd_session.rs
@@ -138,9 +138,7 @@ pub(crate) async fn dispatch(
             let vm_manager = azlin_azure::VmManager::new(&auth);
             let rg = resolve_resource_group(resource_group)?;
 
-            let pb = indicatif::ProgressBar::new_spinner();
-            pb.set_message("Fetching VM status...");
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            let pb = penguin_spinner("Fetching VM status...");
 
             let vms = vm_manager.list_vms(&rg)?;
             pb.finish_and_clear();
@@ -185,9 +183,7 @@ pub(crate) async fn dispatch(
             let vm_manager = azlin_azure::VmManager::new(&auth);
             let rg = resolve_resource_group(resource_group)?;
 
-            let pb = indicatif::ProgressBar::new_spinner();
-            pb.set_message(format!("Looking up {}...", name));
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            let pb = penguin_spinner(&format!("Looking up {}...", name));
             let vm = vm_manager.get_vm(&rg, &name)?;
             pb.finish_and_clear();
 

--- a/rust/crates/azlin/src/cmd_snapshot_ops.rs
+++ b/rust/crates/azlin/src/cmd_snapshot_ops.rs
@@ -7,9 +7,7 @@ pub(crate) async fn handle_snapshot_create(vm_name: &str, rg: &str) -> Result<()
 
     let ts = chrono::Utc::now().format("%Y%m%d_%H%M%S").to_string();
     let snapshot_name = crate::snapshot_helpers::build_snapshot_name(vm_name, &ts);
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message(format!("Creating snapshot {}...", snapshot_name));
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner(&format!("Creating snapshot {}...", snapshot_name));
 
     let output = std::process::Command::new("az")
         .args([
@@ -98,9 +96,7 @@ pub(crate) async fn handle_snapshot_restore(
         return Ok(());
     }
 
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message(format!("Restoring {} from {}...", vm_name, snapshot_name));
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner(&format!("Restoring {} from {}...", vm_name, snapshot_name));
 
     let snap_output = std::process::Command::new("az")
         .args([
@@ -149,9 +145,7 @@ pub(crate) async fn handle_snapshot_restore(
             new_disk, snapshot_name
         );
         // Step 3: Deallocate the VM so we can swap the OS disk
-        let pb2 = indicatif::ProgressBar::new_spinner();
-        pb2.set_message(format!("Deallocating VM '{}'...", vm_name));
-        pb2.enable_steady_tick(std::time::Duration::from_millis(100));
+        let pb2 = penguin_spinner(&format!("Deallocating VM '{}'...", vm_name));
         let dealloc = std::process::Command::new("az")
             .args([
                 "vm",
@@ -176,9 +170,7 @@ pub(crate) async fn handle_snapshot_restore(
         }
 
         // Step 4: Swap the OS disk
-        let pb3 = indicatif::ProgressBar::new_spinner();
-        pb3.set_message("Swapping OS disk...");
-        pb3.enable_steady_tick(std::time::Duration::from_millis(100));
+        let pb3 = penguin_spinner("Swapping OS disk...");
         let swap = std::process::Command::new("az")
             .args([
                 "vm",
@@ -203,9 +195,7 @@ pub(crate) async fn handle_snapshot_restore(
         }
 
         // Step 5: Start the VM back up
-        let pb4 = indicatif::ProgressBar::new_spinner();
-        pb4.set_message(format!("Starting VM '{}'...", vm_name));
-        pb4.enable_steady_tick(std::time::Duration::from_millis(100));
+        let pb4 = penguin_spinner(&format!("Starting VM '{}'...", vm_name));
         let start = std::process::Command::new("az")
             .args(["vm", "start", "--resource-group", rg, "--name", vm_name])
             .output()?;

--- a/rust/crates/azlin/src/cmd_snapshot_ops2.rs
+++ b/rust/crates/azlin/src/cmd_snapshot_ops2.rs
@@ -18,9 +18,7 @@ pub(crate) async fn handle_snapshot_delete(
         return Ok(());
     }
 
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message(format!("Deleting snapshot {}...", snapshot_name));
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner(&format!("Deleting snapshot {}...", snapshot_name));
 
     let output = std::process::Command::new("az")
         .args([
@@ -139,9 +137,7 @@ pub(crate) async fn handle_snapshot_sync(vm: Option<&str>, _rg: &str) -> Result<
             let ts = chrono::Utc::now().format("%Y%m%d_%H%M%S").to_string();
             let snap_name = crate::snapshot_helpers::build_snapshot_name(&sched.vm_name, &ts);
 
-            let pb = indicatif::ProgressBar::new_spinner();
-            pb.set_message(format!("Creating snapshot {}...", snap_name));
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            let pb = penguin_spinner(&format!("Creating snapshot {}...", snap_name));
 
             let disk_info =
                 crate::dispatch_helpers::lookup_vm_disk_info(&sched.resource_group, &sched.vm_name);

--- a/rust/crates/azlin/src/cmd_storage_ops.rs
+++ b/rust/crates/azlin/src/cmd_storage_ops.rs
@@ -13,9 +13,7 @@ pub(crate) async fn handle_storage_create(
     let rg = resolve_resource_group(resource_group)?;
     let loc = region.unwrap_or_else(|| "westus2".to_string());
 
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message(format!("Creating storage account {}...", name));
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner(&format!("Creating storage account {}...", name));
 
     let sku = crate::storage_helpers::storage_sku_from_tier(tier);
 
@@ -142,9 +140,7 @@ pub(crate) fn handle_storage_mount(
     let auth = create_auth()?;
     let vm_manager = azlin_azure::VmManager::new(&auth);
 
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message(format!("Looking up VM {}...", vm));
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner(&format!("Looking up VM {}...", vm));
     let vm_info = vm_manager.get_vm(&rg, vm)?;
     pb.finish_and_clear();
 
@@ -189,9 +185,7 @@ pub(crate) fn handle_storage_unmount(vm: &str, resource_group: Option<String>) -
     let auth = create_auth()?;
     let vm_manager = azlin_azure::VmManager::new(&auth);
 
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message(format!("Looking up VM {}...", vm));
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner(&format!("Looking up VM {}...", vm));
     let vm_info = vm_manager.get_vm(&rg, vm)?;
     pb.finish_and_clear();
 

--- a/rust/crates/azlin/src/cmd_storage_ops2.rs
+++ b/rust/crates/azlin/src/cmd_storage_ops2.rs
@@ -17,9 +17,7 @@ pub(crate) fn handle_storage_delete(
         return Ok(());
     }
 
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message(format!("Deleting storage account {}...", name));
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner(&format!("Deleting storage account {}...", name));
 
     let output = std::process::Command::new("az")
         .args([

--- a/rust/crates/azlin/src/cmd_sync_ops.rs
+++ b/rust/crates/azlin/src/cmd_sync_ops.rs
@@ -249,12 +249,10 @@ pub(crate) async fn handle_logs(
             }
         }
     } else {
-        let pb = indicatif::ProgressBar::new_spinner();
-        pb.set_message(format!(
+        let pb = penguin_spinner(&format!(
             "Fetching {:?} logs for {}...",
             log_type, vm_identifier
         ));
-        pb.enable_steady_tick(std::time::Duration::from_millis(100));
 
         let tail_cmd = crate::sync_helpers::build_tail_command(lines, log_path);
         let result = target.exec(&tail_cmd);

--- a/rust/crates/azlin/src/cmd_vm_ops.rs
+++ b/rust/crates/azlin/src/cmd_vm_ops.rs
@@ -112,9 +112,7 @@ pub(crate) async fn handle_vm_new(
             anyhow::bail!("Invalid VM parameters: {}", e);
         }
 
-        let pb = indicatif::ProgressBar::new_spinner();
-        pb.set_message(format!("Creating VM '{}'...", vm_name));
-        pb.enable_steady_tick(std::time::Duration::from_millis(100));
+        let pb = penguin_spinner(&format!("Creating VM '{}'...", vm_name));
         let vm = vm_manager.create_vm(&params)?;
         pb.finish_and_clear();
 

--- a/rust/crates/azlin/src/cmd_vm_ops2.rs
+++ b/rust/crates/azlin/src/cmd_vm_ops2.rs
@@ -6,9 +6,7 @@ pub(crate) async fn handle_vm_update(
     vm_identifier: &str,
     resource_group: Option<String>,
 ) -> Result<()> {
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message(format!("Looking up {}...", vm_identifier));
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner(&format!("Looking up {}...", vm_identifier));
     let target = resolve_vm_ssh_target(vm_identifier, None, resource_group).await?;
     pb.finish_and_clear();
 
@@ -54,9 +52,7 @@ pub(crate) fn handle_vm_clone(
 
     let (disk_id, location) = crate::dispatch_helpers::lookup_vm_disk_info(&rg, source_vm)?;
 
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message(format!("Snapshotting {}...", source_vm));
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner(&format!("Snapshotting {}...", source_vm));
 
     let snap_out = std::process::Command::new("az")
         .args([
@@ -107,9 +103,7 @@ pub(crate) fn handle_vm_clone(
 
         if disk_out.status.success() {
             println!("  Created disk '{}' from snapshot", disk_name);
-            let pb = indicatif::ProgressBar::new_spinner();
-            pb.set_message(format!("Creating VM '{}'...", clone_name));
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            let pb = penguin_spinner(&format!("Creating VM '{}'...", clone_name));
 
             let vm_out = std::process::Command::new("az")
                 .args([

--- a/rust/crates/azlin/src/dispatch.rs
+++ b/rust/crates/azlin/src/dispatch.rs
@@ -195,9 +195,7 @@ fn handle_cost(
         .map(|c| c.az_cli_timeout)
         .unwrap_or(120);
 
-    let pb = indicatif::ProgressBar::new_spinner();
-    pb.set_message("Fetching cost data...");
-    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    let pb = penguin_spinner("Fetching cost data...");
     match azlin_azure::get_cost_summary(&auth, &rg, cost_timeout) {
         Ok(summary) => {
             pb.finish_and_clear();

--- a/rust/crates/azlin/src/main.rs
+++ b/rust/crates/azlin/src/main.rs
@@ -591,9 +591,38 @@ async fn get_running_vm_targets(resource_group: Option<String>) -> Result<Vec<Vm
     resolve_vm_targets(None, None, resource_group).await
 }
 
-/// Create a consistent spinner style used across all operations.
+/// Penguin tick frames — the penguin waddles back and forth across dots.
+const PENGUIN_TICKS: &[&str] = &[
+    "🐧·····",
+    "·🐧····",
+    "··🐧···",
+    "···🐧··",
+    "····🐧·",
+    "·····🐧",
+    "····🐧·",
+    "···🐧··",
+    "··🐧···",
+    "·🐧····",
+];
+
+/// Create a penguin-themed spinner for slow operations.
+pub(crate) fn penguin_spinner(msg: &str) -> indicatif::ProgressBar {
+    let pb = indicatif::ProgressBar::new_spinner();
+    pb.set_style(
+        indicatif::ProgressStyle::default_spinner()
+            .tick_strings(PENGUIN_TICKS)
+            .template("{spinner} {msg}")
+            .expect("valid spinner template"),
+    );
+    pb.set_message(msg.to_string());
+    pb.enable_steady_tick(std::time::Duration::from_millis(120));
+    pb
+}
+
+/// Create a consistent spinner style used across fleet operations.
 fn fleet_spinner_style() -> ProgressStyle {
     ProgressStyle::default_spinner()
+        .tick_strings(PENGUIN_TICKS)
         .template("{prefix:.bold} {spinner} {msg}")
         .expect("valid spinner template")
 }
@@ -612,7 +641,7 @@ fn run_on_fleet(targets: &[VmSshTarget], command: &str, show_output: bool) {
             pb.set_style(style.clone());
             pb.set_prefix(format!("{:>20}", t.vm_name));
             pb.set_message("connecting...");
-            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            pb.enable_steady_tick(std::time::Duration::from_millis(120));
             pb
         })
         .collect();


### PR DESCRIPTION
## Summary

- Add waddling penguin (🐧) animation to ALL progress spinners across the CLI
- New `penguin_spinner()` helper function replaces boilerplate 3-line spinner creation
- Updated `fleet_spinner_style()` to use penguin tick frames
- Tick interval standardized to 120ms everywhere (was 100ms)

## Changes

- **main.rs**: Added `PENGUIN_TICKS` constant, `penguin_spinner()` helper, updated `fleet_spinner_style()` and `run_on_fleet()` tick interval
- **20 source files**: Replaced all `ProgressBar::new_spinner()` + `set_message()` + `enable_steady_tick()` patterns with single `penguin_spinner()` call
- Fleet-style spinners (cmd_lifecycle.rs with prefix/style) kept their structure but now use `PENGUIN_TICKS` via `fleet_spinner_style()`

## Test plan

- [x] `cargo build --workspace` passes
- [x] `RUST_MIN_STACK=8388608 cargo test --workspace` passes (all tests green)
- [x] No remaining `from_millis(100)` in source
- [x] Visual-only change — no logic modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)