### PR TITLE
fix: add penguin spinners to azlin list command

### DIFF
--- a/rust/crates/azlin/src/cmd_list.rs
+++ b/rust/crates/azlin/src/cmd_list.rs
@@ -60,6 +60,7 @@ pub(crate) async fn dispatch(
                     resource_group.as_deref().unwrap_or("(default)")
                 );
             }
+            let pb = penguin_spinner("Fetching VMs...");
             let mut all_vms = if all_contexts {
                 // Read all context files from ~/.azlin/contexts/ and aggregate VMs
                 let ctx_dir = home_dir()?.join(".azlin").join("contexts");
@@ -149,6 +150,7 @@ pub(crate) async fn dispatch(
                 }
             };
 
+            pb.finish_and_clear();
             if verbose {
                 eprintln!("[VERBOSE] Fetched {} VMs", all_vms.len());
             }
@@ -174,7 +176,10 @@ pub(crate) async fn dispatch(
                 .map(|v| v.resource_group.as_str())
                 .unwrap_or("");
             if matches!(output, azlin_cli::OutputFormat::Table) && !effective_rg.is_empty() {
-                if let Ok(bastions) = crate::list_helpers::detect_bastion_hosts(effective_rg) {
+                let pb = penguin_spinner("Detecting bastion hosts...");
+                let bastion_result = crate::list_helpers::detect_bastion_hosts(effective_rg);
+                pb.finish_and_clear();
+                if let Ok(bastions) = bastion_result {
                     if !bastions.is_empty() {
                         let mut bastion_table = crate::table_render::SimpleTable::new(
                             &["Name", "Location", "SKU"],
@@ -198,31 +203,43 @@ pub(crate) async fn dispatch(
                 eprintln!("[VERBOSE] Collecting tmux sessions via bastion SSH...");
             }
             let tmux_sessions = if !no_tmux {
-                crate::cmd_list_data::collect_tmux_sessions(
+                let pb = penguin_spinner("Collecting tmux sessions...");
+                let sessions = crate::cmd_list_data::collect_tmux_sessions(
                     &all_vms,
                     effective_rg,
                     matches!(output, azlin_cli::OutputFormat::Table),
                     verbose,
                     vm_manager.subscription_id(),
-                )
+                );
+                pb.finish_and_clear();
+                sessions
             } else {
                 std::collections::HashMap::new()
             };
 
             let latencies = if with_latency {
-                crate::cmd_list_data::collect_latencies(&all_vms)
+                let pb = penguin_spinner("Measuring latencies...");
+                let result = crate::cmd_list_data::collect_latencies(&all_vms);
+                pb.finish_and_clear();
+                result
             } else {
                 std::collections::HashMap::new()
             };
 
             let health_data = if with_health {
-                crate::cmd_list_data::collect_health(&all_vms, verbose)
+                let pb = penguin_spinner("Checking VM health...");
+                let result = crate::cmd_list_data::collect_health(&all_vms, verbose);
+                pb.finish_and_clear();
+                result
             } else {
                 std::collections::HashMap::new()
             };
 
             let proc_data = if show_procs {
-                crate::cmd_list_data::collect_procs(&all_vms)
+                let pb = penguin_spinner("Collecting process data...");
+                let result = crate::cmd_list_data::collect_procs(&all_vms);
+                pb.finish_and_clear();
+                result
             } else {
                 std::collections::HashMap::new()
             };


### PR DESCRIPTION
## Summary

The penguin spinner PR (#812) only replaced existing spinners — it didn't add new ones. `cmd_list.rs` never had spinners, so users saw no progress during 10-30 second waits.

Closes #819

## Changes

Added `penguin_spinner()` calls around all slow operations in `cmd_list.rs`:
- **Fetching VMs** — Azure API call (~5s)
- **Detecting bastion hosts** — bastion enumeration (~2s)
- **Collecting tmux sessions** — SSH to each VM (~20s)
- **Measuring latencies** — TCP probes (when `--with-latency`)
- **Checking VM health** — SSH uptime checks (when `--with-health`)
- **Collecting process data** — SSH process listing (when `--show-procs`)

## Step 13: Local Testing Results

**Test Environment**: feat/issue-819-list-spinner, release build, 2026-03-10
**Tests Executed**:

1. Simple: `azlin list --no-tmux` via `script(1)` pseudo-terminal → Penguin visible during "Fetching VMs..." and "Detecting bastion hosts..." ✅
2. Complex: `azlin list` (full, with tmux) via `script(1)` → All three spinner phases visible: Fetching VMs, Detecting bastion hosts, Collecting tmux sessions ✅
3. Regression: `cargo test --workspace` → All tests pass, 0 failures ✅

**Regressions**: None detected
**Issues Found**: None

## Step 19: Outside-In Testing Results

**Test Environment**: Release binary on live Azure with 5 VMs + 4 bastions
**Interface Type**: CLI

**User Flows Tested**:
1. `azlin list --no-tmux` — penguin waddles during VM fetch + bastion detection (~7s) ✅
2. `azlin list` (full) — penguin waddles through all phases (~31s total) ✅
3. Output verified: spinner clears cleanly, table renders correctly after ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)