### PR TITLE
fix: update broken links in README.md to point to existing AZDOIT.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2223,8 +2223,8 @@ azlin doit cleanup --force      # Delete all doit resources
 ```
 
 **📖 Learn More:**
-- [Quick Start Guide](QUICKSTART_DOIT.md)
-- [Tagging & Management](DOIT_TAGGING_AND_MANAGEMENT.md)
+- [Quick Start Guide](docs/AZDOIT.md)
+- [Tagging & Management](docs/AZDOIT.md)
 - [Architecture Docs](src/azlin/doit/README.md)
 
 ---


### PR DESCRIPTION
The links QUICKSTART_DOIT.md and DOIT_TAGGING_AND_MANAGEMENT.md no longer exist in the repository. This PR updates them to point to docs/AZDOIT.md which contains relevant documentation for the doit feature.

Fixes #743