### PR TITLE
fix: restore_tmux_sessions strips session suffix, routes WSL correctly, isolates stdio

### DIFF
--- a/rust/crates/azlin/src/cmd_list_data.rs
+++ b/rust/crates/azlin/src/cmd_list_data.rs
@@ -240,31 +240,101 @@ pub(crate) fn collect_procs(vms: &[VmInfo]) -> HashMap<String, String> {
     proc_data
 }
 
+/// Parse a raw tmux session string (e.g. `"main:1"`) into a validated session name.
+///
+/// Splits on `:` to strip the `attached` count suffix, trims whitespace, then validates
+/// the name against the alphanumeric + `_` + `-` allowlist.  Returns `None` when the
+/// name is empty, exceeds 128 characters, or contains any disallowed character.
+pub(crate) fn parse_session_name(raw: &str) -> Option<String> {
+    let name = raw.split(':').next().unwrap_or("").trim().to_string();
+    if name.is_empty() || name.len() > 128 {
+        return None;
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return None;
+    }
+    Some(name)
+}
+
+/// Validate a VM name before using it in process arguments.
+///
+/// Allowlist permits alphanumeric characters, underscores, hyphens, and dots (dots are
+/// required for Azure FQDNs) and rejects everything else, preventing argument injection.
+pub(crate) fn is_valid_restore_vm_name(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    name.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
+}
+
 /// Restore tmux sessions by connecting to each VM.
 pub(crate) fn restore_tmux_sessions(tmux_sessions: &HashMap<String, Vec<String>>) {
     println!("\nRestoring tmux sessions...");
     let use_wt = std::env::var("WT_SESSION").is_ok();
+
     for (vm_name, sessions) in tmux_sessions {
-        if let Some(first_session) = sessions.first() {
+        if !is_valid_restore_vm_name(vm_name) {
+            eprintln!("  Warning: skipping VM with invalid name");
+            continue;
+        }
+
+        if let Some(raw_session) = sessions.first() {
+            let first_session = match parse_session_name(raw_session) {
+                Some(s) => s,
+                None => {
+                    eprintln!(
+                        "  Warning: skipping invalid session name for {}",
+                        vm_name
+                    );
+                    continue;
+                }
+            };
+
             if use_wt {
                 println!("  Opening tab: {} (session: {})", vm_name, first_session);
-                let _ = std::process::Command::new("wt.exe")
-                    .args([
-                        "-w",
-                        "0",
-                        "new-tab",
-                        "azlin",
-                        "connect",
-                        vm_name,
-                        "--tmux-session",
-                        first_session,
-                    ])
-                    .spawn();
+                // WT_SESSION is set inside WSL when running under Windows Terminal.
+                // wt.exe new-tab runs its command in the default WT profile (often
+                // PowerShell), so we must explicitly use wsl.exe to re-enter WSL
+                // where the azlin binary lives.
+                let wsl_distro =
+                    std::env::var("WSL_DISTRO_NAME").unwrap_or_else(|_| "".to_string());
+                let mut wt_args: Vec<&str> =
+                    vec!["-w", "0", "new-tab"];
+                if !wsl_distro.is_empty() {
+                    wt_args.extend_from_slice(&[
+                        "wsl.exe", "-d", &wsl_distro, "--",
+                    ]);
+                }
+                wt_args.extend_from_slice(&[
+                    "azlin", "connect", vm_name,
+                    "--tmux-session", &first_session,
+                ]);
+                if let Err(e) = std::process::Command::new("wt.exe")
+                    .args(&wt_args)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn()
+                {
+                    eprintln!("  Warning: failed to open tab for {}: {}", vm_name, e);
+                }
             } else {
                 println!("  Connecting to {} (session: {})", vm_name, first_session);
-                let _ = std::process::Command::new("azlin")
-                    .args(["connect", vm_name, "--tmux-session", first_session])
-                    .spawn();
+                // Isolate stdio so the spawned SSH process does not inherit the parent
+                // terminal handles — prevents display corruption and credential capture.
+                if let Err(e) = std::process::Command::new("azlin")
+                    .args(["connect", vm_name, "--tmux-session", &first_session])
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn()
+                {
+                    eprintln!("  Warning: failed to connect to {}: {}", vm_name, e);
+                }
             }
         }
     }

--- a/rust/crates/azlin/src/tests/mod.rs
+++ b/rust/crates/azlin/src/tests/mod.rs
@@ -61,3 +61,4 @@ mod test_group_58;
 mod test_group_59;
 mod test_group_60;
 mod test_group_61;
+mod test_group_62;

--- a/rust/crates/azlin/src/tests/test_group_62.rs
+++ b/rust/crates/azlin/src/tests/test_group_62.rs
@@ -1,0 +1,294 @@
+//! Unit tests for restore_tmux_sessions helper functions.
+//!
+//! Covers parse_session_name (24 cases) and is_valid_restore_vm_name (11 cases)
+//! plus behavioural smoke tests for restore_tmux_sessions itself (10 cases).
+
+use crate::cmd_list_data::{is_valid_restore_vm_name, parse_session_name, restore_tmux_sessions};
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// parse_session_name — valid inputs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_parse_strips_attached_suffix() {
+    assert_eq!(parse_session_name("main:1"), Some("main".to_string()));
+}
+
+#[test]
+fn test_parse_strips_zero_attached() {
+    assert_eq!(parse_session_name("dev-work:0"), Some("dev-work".to_string()));
+}
+
+#[test]
+fn test_parse_strips_high_count() {
+    assert_eq!(parse_session_name("session99:42"), Some("session99".to_string()));
+}
+
+#[test]
+fn test_parse_trims_leading_whitespace() {
+    assert_eq!(parse_session_name("  dev-work:0"), Some("dev-work".to_string()));
+}
+
+#[test]
+fn test_parse_trims_trailing_whitespace() {
+    assert_eq!(parse_session_name("dev-work:0  "), Some("dev-work".to_string()));
+}
+
+#[test]
+fn test_parse_trims_both_sides_whitespace() {
+    assert_eq!(parse_session_name("  dev-work :0"), Some("dev-work".to_string()));
+}
+
+#[test]
+fn test_parse_single_char_name() {
+    assert_eq!(parse_session_name("a:0"), Some("a".to_string()));
+}
+
+#[test]
+fn test_parse_underscore_name() {
+    assert_eq!(parse_session_name("my_session:1"), Some("my_session".to_string()));
+}
+
+#[test]
+fn test_parse_hyphen_name() {
+    assert_eq!(parse_session_name("my-session:1"), Some("my-session".to_string()));
+}
+
+#[test]
+fn test_parse_alphanumeric_only() {
+    assert_eq!(parse_session_name("ABC123:0"), Some("ABC123".to_string()));
+}
+
+#[test]
+fn test_parse_name_no_colon_still_valid() {
+    // tmux format without attached count — treat the whole string as the name
+    assert_eq!(parse_session_name("plainname"), Some("plainname".to_string()));
+}
+
+#[test]
+fn test_parse_exactly_128_chars_valid() {
+    let name = "a".repeat(128);
+    let raw = format!("{}:0", name);
+    assert_eq!(parse_session_name(&raw), Some(name));
+}
+
+// ---------------------------------------------------------------------------
+// parse_session_name — invalid / rejected inputs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_parse_empty_string_returns_none() {
+    assert_eq!(parse_session_name(""), None);
+}
+
+#[test]
+fn test_parse_colon_only_empty_name_returns_none() {
+    assert_eq!(parse_session_name(":1"), None);
+}
+
+#[test]
+fn test_parse_whitespace_only_before_colon_returns_none() {
+    assert_eq!(parse_session_name("   :1"), None);
+}
+
+#[test]
+fn test_parse_semicolon_metachar_returns_none() {
+    assert_eq!(parse_session_name("session;evil:0"), None);
+}
+
+#[test]
+fn test_parse_percent_expansion_returns_none() {
+    assert_eq!(parse_session_name("sess%COMSPEC%:0"), None);
+}
+
+#[test]
+fn test_parse_caret_escape_returns_none() {
+    assert_eq!(parse_session_name("sess^inject:0"), None);
+}
+
+#[test]
+fn test_parse_ampersand_returns_none() {
+    assert_eq!(parse_session_name("sess&cmd:0"), None);
+}
+
+#[test]
+fn test_parse_pipe_returns_none() {
+    assert_eq!(parse_session_name("sess|cmd:0"), None);
+}
+
+#[test]
+fn test_parse_dot_returns_none() {
+    // Dots are not in the session-name allowlist (only vm-name allows dots for FQDNs)
+    assert_eq!(parse_session_name("sess.ion:0"), None);
+}
+
+#[test]
+fn test_parse_slash_returns_none() {
+    assert_eq!(parse_session_name("../../evil:0"), None);
+}
+
+#[test]
+fn test_parse_129_chars_returns_none() {
+    let name = "a".repeat(129);
+    let raw = format!("{}:0", name);
+    assert_eq!(parse_session_name(&raw), None);
+}
+
+#[test]
+fn test_parse_ansi_escape_returns_none() {
+    // ANSI CSI sequence contains '[' and digits — '[' is not in the allowlist
+    assert_eq!(parse_session_name("\x1b[32mmain\x1b[0m:1"), None);
+}
+
+// ---------------------------------------------------------------------------
+// is_valid_restore_vm_name — valid inputs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_vm_name_simple_valid() {
+    assert!(is_valid_restore_vm_name("myvm"));
+}
+
+#[test]
+fn test_vm_name_with_hyphen_valid() {
+    assert!(is_valid_restore_vm_name("my-vm-01"));
+}
+
+#[test]
+fn test_vm_name_with_underscore_valid() {
+    assert!(is_valid_restore_vm_name("my_vm"));
+}
+
+#[test]
+fn test_vm_name_with_dot_valid() {
+    // Dots permitted for Azure FQDNs
+    assert!(is_valid_restore_vm_name("vm.example.com"));
+}
+
+#[test]
+fn test_vm_name_alphanumeric_mixed_case_valid() {
+    assert!(is_valid_restore_vm_name("DevVM01"));
+}
+
+// ---------------------------------------------------------------------------
+// is_valid_restore_vm_name — invalid inputs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_vm_name_empty_invalid() {
+    assert!(!is_valid_restore_vm_name(""));
+}
+
+#[test]
+fn test_vm_name_ampersand_invalid() {
+    assert!(!is_valid_restore_vm_name("vm&inject"));
+}
+
+#[test]
+fn test_vm_name_semicolon_invalid() {
+    assert!(!is_valid_restore_vm_name("vm;cmd"));
+}
+
+#[test]
+fn test_vm_name_path_traversal_invalid() {
+    assert!(!is_valid_restore_vm_name("../traversal"));
+}
+
+#[test]
+fn test_vm_name_space_invalid() {
+    assert!(!is_valid_restore_vm_name("my vm"));
+}
+
+#[test]
+fn test_vm_name_pipe_invalid() {
+    assert!(!is_valid_restore_vm_name("vm|cat"));
+}
+
+// ---------------------------------------------------------------------------
+// restore_tmux_sessions — behavioural smoke tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_restore_empty_map_no_panic() {
+    let sessions: HashMap<String, Vec<String>> = HashMap::new();
+    // Should complete without panic
+    restore_tmux_sessions(&sessions);
+}
+
+#[test]
+fn test_restore_empty_session_list_no_panic() {
+    let mut sessions: HashMap<String, Vec<String>> = HashMap::new();
+    sessions.insert("myvm".to_string(), vec![]);
+    restore_tmux_sessions(&sessions);
+}
+
+#[test]
+fn test_restore_valid_colon_format_no_panic() {
+    // Bug 1 regression: "main:1" should be stripped to "main" without panic or warning
+    let mut sessions: HashMap<String, Vec<String>> = HashMap::new();
+    sessions.insert("myvm".to_string(), vec!["main:1".to_string()]);
+    restore_tmux_sessions(&sessions);
+}
+
+#[test]
+fn test_restore_invalid_session_name_skipped_no_panic() {
+    // Security: session with injection chars must be skipped, not passed to spawn
+    let mut sessions: HashMap<String, Vec<String>> = HashMap::new();
+    sessions.insert("myvm".to_string(), vec!["session;evil:0".to_string()]);
+    restore_tmux_sessions(&sessions);
+}
+
+#[test]
+fn test_restore_invalid_vm_name_skipped_no_panic() {
+    // Security: VM name with injection chars must be skipped
+    let mut sessions: HashMap<String, Vec<String>> = HashMap::new();
+    sessions.insert("vm&inject".to_string(), vec!["main:0".to_string()]);
+    restore_tmux_sessions(&sessions);
+}
+
+#[test]
+fn test_restore_multiple_sessions_only_first_used_no_panic() {
+    // Only the first session per VM is used (by design)
+    let mut sessions: HashMap<String, Vec<String>> = HashMap::new();
+    sessions.insert(
+        "myvm".to_string(),
+        vec!["first:1".to_string(), "second:0".to_string()],
+    );
+    restore_tmux_sessions(&sessions);
+}
+
+#[test]
+fn test_restore_multiple_vms_no_panic() {
+    let mut sessions: HashMap<String, Vec<String>> = HashMap::new();
+    sessions.insert("vm-alpha".to_string(), vec!["work:1".to_string()]);
+    sessions.insert("vm-beta".to_string(), vec!["play:0".to_string()]);
+    restore_tmux_sessions(&sessions);
+}
+
+#[test]
+fn test_restore_empty_vm_name_skipped_no_panic() {
+    // Edge case: empty key in map
+    let mut sessions: HashMap<String, Vec<String>> = HashMap::new();
+    sessions.insert("".to_string(), vec!["main:0".to_string()]);
+    restore_tmux_sessions(&sessions);
+}
+
+#[test]
+fn test_restore_session_name_at_max_length_no_panic() {
+    let name = "a".repeat(128);
+    let raw = format!("{}:0", name);
+    let mut sessions: HashMap<String, Vec<String>> = HashMap::new();
+    sessions.insert("myvm".to_string(), vec![raw]);
+    restore_tmux_sessions(&sessions);
+}
+
+#[test]
+fn test_restore_session_name_over_max_length_skipped_no_panic() {
+    let name = "a".repeat(129);
+    let raw = format!("{}:0", name);
+    let mut sessions: HashMap<String, Vec<String>> = HashMap::new();
+    sessions.insert("myvm".to_string(), vec![raw]);
+    // Should not panic; name is skipped with a warning
+    restore_tmux_sessions(&sessions);
+}


### PR DESCRIPTION
## Summary

- Strips `:attached_count` suffix from tmux session names (e.g. `mem:1` → `mem`) via new `parse_session_name()` helper
- Routes `wt.exe new-tab` through `wsl.exe -d <distro>` when `WSL_DISTRO_NAME` is set, fixing error 0x80070002 ("file not found") in WSL environments
- Isolates all spawned processes with `Stdio::null()` to prevent terminal corruption
- Adds input validation (`is_valid_restore_vm_name`) to reject shell metacharacters before `Command::args`
- 45 new tests in `test_group_62`

Fixes the bug where `azlin restore` / `azlin list -r` fails with `[error 2147942402 (0x80070002)]` on every terminal tab opened, and corrupts the originating terminal.

## Test plan

- [x] `cargo check -p azlin` — compiles clean
- [x] `cargo test --bin azlin -- test_group_62` — 45/45 pass
- [ ] CI passes
- [ ] Manual test: `azlin list -r` in WSL with Windows Terminal opens tabs correctly
- [ ] Manual test: `azlin list -r` in plain terminal doesn't corrupt parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)