### PR TITLE
fix: Rust command parity — new, clone, bastion routing, CLI gaps

### DIFF
--- a/docs-site/commands/vm/new.md
+++ b/docs-site/commands/vm/new.md
@@ -402,9 +402,9 @@ azlin new --name temp-vm --no-auto-connect
 
 ## Source Code
 
-- [vm_provisioning.py](https://github.com/rysweet/azlin/blob/main/src/azlin/vm_provisioning.py) - Core provisioning logic
-- [cli.py](https://github.com/rysweet/azlin/blob/main/src/azlin/cli.py) - CLI command definition
-- [cloud-init template](https://github.com/rysweet/azlin/blob/main/src/azlin/cloud_init_config.py) - Cloud-init script
+- [vm.rs](https://github.com/rysweet/azlin/blob/main/rust/crates/azlin-azure/src/vm.rs) - Core provisioning logic (`create_vm`)
+- [cmd_vm_ops.rs](https://github.com/rysweet/azlin/blob/main/rust/crates/azlin/src/cmd_vm_ops.rs) - `new` command handler
+- [lib.rs](https://github.com/rysweet/azlin/blob/main/rust/crates/azlin-cli/src/lib.rs) - CLI command definitions
 
 ## See Also
 

--- a/docs-site/commands/vm/stop.md
+++ b/docs-site/commands/vm/stop.md
@@ -346,8 +346,9 @@ jobs:
 
 ## Source Code
 
-- [vm_lifecycle_control.py](https://github.com/rysweet/azlin/blob/main/src/azlin/vm_lifecycle_control.py) - Start/stop logic
-- [cli.py](https://github.com/rysweet/azlin/blob/main/src/azlin/cli.py) - CLI command definition
+- [cmd_lifecycle.rs](https://github.com/rysweet/azlin/blob/main/rust/crates/azlin/src/cmd_lifecycle.rs) - Start/stop dispatch
+- [vm.rs](https://github.com/rysweet/azlin/blob/main/rust/crates/azlin-azure/src/vm.rs) - VM stop/deallocate operations
+- [lib.rs](https://github.com/rysweet/azlin/blob/main/rust/crates/azlin-cli/src/lib.rs) - CLI command definitions
 
 ## See Also
 

--- a/rust/crates/azlin-azure/src/vm.rs
+++ b/rust/crates/azlin-azure/src/vm.rs
@@ -369,14 +369,20 @@ impl VmManager {
 
     // ── Provisioning ───────────────────────────────────────────────────
 
-    /// Provision a new VM with all required networking resources.
+    /// Provision a new VM, letting `az vm create` handle networking automatically.
     ///
-    /// Creates: resource group -> NSG -> VNet/subnet -> public IP -> NIC -> VM.
+    /// This matches the Python reference implementation: instead of manually
+    /// creating NSG, VNet, subnet, PIP, and NIC (which causes resource name
+    /// clashes and wrong VNet for bastion), we let the Azure CLI handle
+    /// networking.
+    ///
+    /// For bastion-only VMs (`public_ip_enabled == false`), we explicitly
+    /// specify `--public-ip-address ""` and route through the bastion VNet
+    /// (`azlin-bastion-{region}-vnet`).
     pub fn create_vm(&self, params: &CreateVmParams) -> Result<VmInfo> {
         let rg = &params.resource_group;
         let location = &params.region;
         let vm_name = &params.name;
-        let names = build_vm_resource_names(vm_name);
         let timeout = self.az_cli_timeout;
 
         let az = |args: &[&str]| -> Result<String> { az_cli_with_timeout(args, timeout) };
@@ -401,178 +407,73 @@ impl VmManager {
                 .context(format!("Failed to create resource group '{rg}'"))?;
         }
 
-        // 2. Create NSG with SSH + HTTPS rules
-        debug!(nsg_name = %names.nsg, "Creating NSG");
-        az(&[
-            "network",
-            "nsg",
-            "create",
-            "--resource-group",
-            rg,
-            "--name",
-            &names.nsg,
-            "--location",
-            location,
-        ])
-        .context(format!("Failed to create NSG '{}'", names.nsg))?;
-
-        az(&[
-            "network",
-            "nsg",
-            "rule",
-            "create",
-            "--resource-group",
-            rg,
-            "--nsg-name",
-            &names.nsg,
-            "--name",
-            "AllowSSH",
-            "--priority",
-            "1000",
-            "--protocol",
-            "Tcp",
-            "--destination-port-ranges",
-            "22",
-            "--access",
-            "Allow",
-            "--direction",
-            "Inbound",
-        ])
-        .context("Failed to create SSH NSG rule")?;
-
-        az(&[
-            "network",
-            "nsg",
-            "rule",
-            "create",
-            "--resource-group",
-            rg,
-            "--nsg-name",
-            &names.nsg,
-            "--name",
-            "AllowHTTPS",
-            "--priority",
-            "1001",
-            "--protocol",
-            "Tcp",
-            "--destination-port-ranges",
-            "443",
-            "--access",
-            "Allow",
-            "--direction",
-            "Inbound",
-        ])
-        .context("Failed to create HTTPS NSG rule")?;
-
-        // 3. Create VNet + subnet
-        debug!(vnet_name = %names.vnet, subnet_name = %names.subnet, "Creating VNet and subnet");
-        az(&[
-            "network",
-            "vnet",
-            "create",
-            "--resource-group",
-            rg,
-            "--name",
-            &names.vnet,
-            "--address-prefix",
-            "10.0.0.0/16",
-            "--subnet-name",
-            &names.subnet,
-            "--subnet-prefix",
-            "10.0.0.0/24",
-            "--location",
-            location,
-            "--network-security-group",
-            &names.nsg,
-        ])
-        .context(format!("Failed to create VNet '{}'", names.vnet))?;
-
-        // 4. Create public IP
-        debug!(pip_name = %names.pip, "Creating public IP");
-        az(&[
-            "network",
-            "public-ip",
-            "create",
-            "--resource-group",
-            rg,
-            "--name",
-            &names.pip,
-            "--sku",
-            "Standard",
-            "--allocation-method",
-            "Static",
-            "--location",
-            location,
-        ])
-        .context(format!("Failed to create public IP '{}'", names.pip))?;
-
-        // 5. Create NIC
-        debug!(nic_name = %names.nic, "Creating NIC");
-        az(&[
-            "network",
-            "nic",
-            "create",
-            "--resource-group",
-            rg,
-            "--name",
-            &names.nic,
-            "--vnet-name",
-            &names.vnet,
-            "--subnet",
-            &names.subnet,
-            "--public-ip-address",
-            &names.pip,
-            "--network-security-group",
-            &names.nsg,
-            "--location",
-            location,
-        ])
-        .context(format!("Failed to create NIC '{}'", names.nic))?;
-
-        // 6. Create the VM
-        debug!(%vm_name, "Creating VM");
+        // 2. Build the `az vm create` command — let Azure handle networking
+        debug!(%vm_name, "Creating VM (Azure-managed networking)");
         let image_urn = params.image.to_string();
 
         let cloud_init_file = create_cloud_init_file(&params.admin_username)?;
         let cloud_init_path = cloud_init_file.path().to_string_lossy().to_string();
-        let mut az_args = vec![
-            "vm",
-            "create",
-            "--resource-group",
-            rg,
-            "--name",
-            vm_name,
-            "--location",
-            location,
-            "--nics",
-            &names.nic,
-            "--image",
-            &image_urn,
-            "--size",
-            &params.vm_size,
-            "--admin-username",
-            &params.admin_username,
-            "--ssh-key-value",
-            ssh_pub_key.trim(),
-            "--authentication-type",
-            "ssh",
-            "--custom-data",
-            &cloud_init_path,
+        let mut az_args: Vec<String> = vec![
+            "vm".into(),
+            "create".into(),
+            "--resource-group".into(),
+            rg.into(),
+            "--name".into(),
+            vm_name.into(),
+            "--location".into(),
+            location.into(),
+            "--image".into(),
+            image_urn,
+            "--size".into(),
+            params.vm_size.clone(),
+            "--admin-username".into(),
+            params.admin_username.clone(),
+            "--ssh-key-value".into(),
+            ssh_pub_key.trim().to_string(),
+            "--authentication-type".into(),
+            "ssh".into(),
+            "--custom-data".into(),
+            cloud_init_path,
         ];
 
-        let tag_strs = format_tag_cli_args(&params.tags);
-        if !tag_strs.is_empty() {
-            az_args.push("--tags");
-            for t in &tag_strs {
-                az_args.push(t);
+        // Handle public IP: create with Standard SKU, or disable for bastion VMs
+        if params.public_ip_enabled {
+            az_args.push("--public-ip-sku".into());
+            az_args.push("Standard".into());
+        } else {
+            // Bastion-only: disable public IP and use the bastion VNet
+            az_args.push("--public-ip-address".into());
+            az_args.push(String::new()); // empty string disables public IP
+            let vnet_name = format!("azlin-bastion-{location}-vnet");
+            az_args.push("--subnet".into());
+            az_args.push("default".into());
+            az_args.push("--vnet-name".into());
+            az_args.push(vnet_name);
+        }
+
+        // Attach data disks during VM creation so cloud-init can find them
+        // Order matters: first disk = lun0, second = lun1, etc.
+        if !params.disk_ids.is_empty() {
+            az_args.push("--attach-data-disks".into());
+            for disk_id in &params.disk_ids {
+                az_args.push(disk_id.clone());
             }
         }
 
-        az(&az_args).context(format!("Failed to create VM '{vm_name}'"))?;
+        let tag_strs = format_tag_cli_args(&params.tags);
+        if !tag_strs.is_empty() {
+            az_args.push("--tags".into());
+            for t in &tag_strs {
+                az_args.push(t.clone());
+            }
+        }
+
+        let az_arg_refs: Vec<&str> = az_args.iter().map(|s| s.as_str()).collect();
+        az(&az_arg_refs).context(format!("Failed to create VM '{vm_name}'"))?;
 
         // cloud_init_file is dropped here, which auto-deletes the temp file
 
-        // 7. Fetch and return VM info
+        // 3. Fetch and return VM info
         debug!(%vm_name, "Fetching created VM details");
         let vm_info = self.get_vm(rg, vm_name)?;
         Ok(vm_info)
@@ -801,7 +702,10 @@ echo "cloud-init provisioning complete"
 // ── Resource naming helpers ────────────────────────────────────────────
 
 /// Struct holding derived resource names for VM provisioning.
+/// Retained for tests; no longer used in `create_vm()` since networking
+/// is now handled automatically by `az vm create`.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(not(test), allow(dead_code))]
 struct VmResourceNames {
     nsg: String,
     vnet: String,
@@ -811,6 +715,7 @@ struct VmResourceNames {
 }
 
 /// Build the conventional resource names for a VM (NSG, VNet, subnet, PIP, NIC).
+#[cfg_attr(not(test), allow(dead_code))]
 fn build_vm_resource_names(vm_name: &str) -> VmResourceNames {
     VmResourceNames {
         nsg: format!("{vm_name}-nsg"),

--- a/rust/crates/azlin-cli/src/lib.rs
+++ b/rust/crates/azlin-cli/src/lib.rs
@@ -358,9 +358,14 @@ pub enum Commands {
         #[arg(long)]
         config: Option<PathBuf>,
 
-        /// Deallocate to save costs (default: yes)
-        #[arg(long, default_value = "true")]
+        /// Deallocate to save costs (default: yes). Use --no-deallocate to
+        /// power off without deallocation.
+        #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
         deallocate: bool,
+
+        /// Power off without deallocating (keeps reserved IPs, faster restart)
+        #[arg(long, conflicts_with = "deallocate")]
+        no_deallocate: bool,
     },
 
     /// Connect to existing VM via SSH
@@ -2283,6 +2288,22 @@ mod tests {
         {
             assert_eq!(vm_name, "my-vm");
             assert!(deallocate);
+        } else {
+            panic!("Expected Stop command");
+        }
+    }
+
+    #[test]
+    fn test_stop_no_deallocate_command() {
+        let cli = Cli::parse_from(["azlin", "stop", "my-vm", "--no-deallocate"]);
+        if let Commands::Stop {
+            vm_name,
+            no_deallocate,
+            ..
+        } = cli.command
+        {
+            assert_eq!(vm_name, "my-vm");
+            assert!(no_deallocate);
         } else {
             panic!("Expected Stop command");
         }

--- a/rust/crates/azlin-core/src/models.rs
+++ b/rust/crates/azlin-core/src/models.rs
@@ -165,6 +165,17 @@ pub struct CreateVmParams {
     pub ssh_key_path: PathBuf,
     pub image: VmImage,
     pub tags: HashMap<String, String>,
+    /// Whether to create a public IP. Set to false for bastion-only VMs.
+    #[serde(default = "default_true")]
+    pub public_ip_enabled: bool,
+    /// Optional list of managed-disk resource IDs to attach during creation.
+    /// Order matters: first disk = lun0, second = lun1, etc.
+    #[serde(default)]
+    pub disk_ids: Vec<String>,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl CreateVmParams {
@@ -446,6 +457,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/tmp/nonexistent.pub"),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         assert!(params.validate().is_err());
         assert!(params.validate().unwrap_err().contains("name"));
@@ -462,6 +475,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/tmp/nonexistent.pub"),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         assert!(params.validate().is_err());
         assert!(params.validate().unwrap_err().contains("64 characters"));
@@ -478,6 +493,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/home/user/.ssh/id_rsa.pub"),
             image: VmImage::default(),
             tags: HashMap::from([("env".into(), "dev".into())]),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         let json = serde_json::to_string(&params).unwrap();
         let deserialized: CreateVmParams = serde_json::from_str(&json).unwrap();
@@ -498,6 +515,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/tmp/nonexistent_key_abc123.pub"),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         let err = params.validate().unwrap_err();
         assert!(err.contains("SSH public key not found"));
@@ -618,6 +637,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/tmp/nonexistent.pub"),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         let err = params.validate().unwrap_err();
         assert!(err.contains("Resource group"));
@@ -634,6 +655,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/tmp/nonexistent.pub"),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         let err = params.validate().unwrap_err();
         assert!(err.contains("Region"));
@@ -650,6 +673,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/tmp/nonexistent.pub"),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         let err = params.validate().unwrap_err();
         assert!(err.contains("VM size"));
@@ -666,6 +691,8 @@ mod tests {
             ssh_key_path: PathBuf::from("/tmp/nonexistent.pub"),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         let err = params.validate().unwrap_err();
         assert!(err.contains("username"));
@@ -684,6 +711,8 @@ mod tests {
             ssh_key_path: keyfile.path().to_path_buf(),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         assert!(params.validate().is_ok());
     }
@@ -701,6 +730,8 @@ mod tests {
             ssh_key_path: keyfile.path().to_path_buf(),
             image: VmImage::default(),
             tags: HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
         assert!(params.validate().is_ok());
     }

--- a/rust/crates/azlin/src/cmd_lifecycle.rs
+++ b/rust/crates/azlin/src/cmd_lifecycle.rs
@@ -35,19 +35,23 @@ pub(crate) async fn dispatch(
             vm_name,
             resource_group,
             deallocate,
+            no_deallocate,
             ..
         } => {
             let auth = create_auth()?;
             let vm_manager = azlin_azure::VmManager::new(&auth);
             let rg = resolve_resource_group(resource_group)?;
 
-            let (action, _done) = crate::stop_helpers::stop_action_labels(deallocate);
+            // --no-deallocate overrides the default deallocate=true
+            let effective_deallocate = deallocate && !no_deallocate;
+            let (action, _done) = crate::stop_helpers::stop_action_labels(effective_deallocate);
             let pb = ProgressBar::new_spinner();
             pb.set_style(fleet_spinner_style());
             pb.set_prefix(format!("{:>20}", vm_name));
             pb.set_message(crate::lifecycle_helpers::progress_message(action, &vm_name));
             pb.enable_steady_tick(std::time::Duration::from_millis(120));
-            let msg = crate::handlers::handle_stop(&vm_manager, &rg, &vm_name, deallocate)?;
+            let msg =
+                crate::handlers::handle_stop(&vm_manager, &rg, &vm_name, effective_deallocate)?;
             pb.finish_with_message(crate::lifecycle_helpers::finished_ok(&msg));
         }
         azlin_cli::Commands::Delete {

--- a/rust/crates/azlin/src/cmd_vm_ops.rs
+++ b/rust/crates/azlin/src/cmd_vm_ops.rs
@@ -92,7 +92,10 @@ pub(crate) async fn handle_vm_new(
                 n.clone()
             }
         } else {
-            format!("azlin-vm-{}", chrono::Utc::now().format("%Y%m%d-%H%M%S"))
+            format!(
+                "azlin-vm-{}",
+                chrono::Utc::now().format("%Y%m%d-%H%M%S%6f")
+            )
         };
 
         azlin_core::models::validate_vm_name(&vm_name).map_err(|e| anyhow::anyhow!(e))?;
@@ -106,6 +109,8 @@ pub(crate) async fn handle_vm_new(
             ssh_key_path: ssh_key_path.clone(),
             image: azlin_core::models::VmImage::default(),
             tags: std::collections::HashMap::new(),
+            public_ip_enabled: true,
+            disk_ids: vec![],
         };
 
         if let Err(e) = params.validate() {

--- a/rust/crates/azlin/src/cmd_vm_ops2.rs
+++ b/rust/crates/azlin/src/cmd_vm_ops2.rs
@@ -105,23 +105,43 @@ pub(crate) fn handle_vm_clone(
             println!("  Created disk '{}' from snapshot", disk_name);
             let pb = penguin_spinner(&format!("Creating VM '{}'...", clone_name));
 
+            let mut clone_args = vec![
+                "vm".to_string(),
+                "create".to_string(),
+                "--resource-group".to_string(),
+                rg.clone(),
+                "--name".to_string(),
+                clone_name.clone(),
+                "--attach-os-disk".to_string(),
+                disk_name.clone(),
+                "--os-type".to_string(),
+                "Linux".to_string(),
+                "--location".to_string(),
+                location.clone(),
+                "--output".to_string(),
+                "json".to_string(),
+            ];
+
+            // For bastion VMs (no public IP on source), route through bastion VNet
+            // and disable public IP on the clone too.
+            let is_bastion =
+                match crate::dispatch_helpers::lookup_vm_public_ip(&rg, source_vm) {
+                    Ok(None) => true,
+                    Ok(Some(ref ip)) if ip.is_empty() => true,
+                    _ => false,
+                };
+            if is_bastion {
+                clone_args.push("--public-ip-address".to_string());
+                clone_args.push(String::new());
+                let vnet_name = format!("azlin-bastion-{}-vnet", location);
+                clone_args.push("--subnet".to_string());
+                clone_args.push("default".to_string());
+                clone_args.push("--vnet-name".to_string());
+                clone_args.push(vnet_name);
+            }
+
             let vm_out = std::process::Command::new("az")
-                .args([
-                    "vm",
-                    "create",
-                    "--resource-group",
-                    &rg,
-                    "--name",
-                    &clone_name,
-                    "--attach-os-disk",
-                    &disk_name,
-                    "--os-type",
-                    "Linux",
-                    "--nsg",
-                    "",
-                    "--output",
-                    "json",
-                ])
+                .args(&clone_args)
                 .output()?;
             pb.finish_and_clear();
 

--- a/rust/crates/azlin/src/dispatch_helpers.rs
+++ b/rust/crates/azlin/src/dispatch_helpers.rs
@@ -108,6 +108,41 @@ pub(crate) fn lookup_vm_disk_info(rg: &str, vm_name: &str) -> Result<(String, St
     Ok((parts[0].to_string(), parts[1].to_string()))
 }
 
+/// Look up a VM's public IP address. Returns `Ok(None)` if the VM has no public IP
+/// (bastion-only), `Ok(Some(ip))` if it has one.
+pub(crate) fn lookup_vm_public_ip(rg: &str, vm_name: &str) -> Result<Option<String>> {
+    let output = std::process::Command::new("az")
+        .args([
+            "vm",
+            "list-ip-addresses",
+            "--resource-group",
+            rg,
+            "--name",
+            vm_name,
+            "--query",
+            "[0].virtualMachine.network.publicIpAddresses[0].ipAddress",
+            "--output",
+            "tsv",
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "Failed to get public IP for VM '{}': {}",
+            vm_name,
+            azlin_core::sanitizer::sanitize(stderr.trim())
+        );
+    }
+
+    let ip = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if ip.is_empty() || ip == "None" {
+        Ok(None)
+    } else {
+        Ok(Some(ip))
+    }
+}
+
 /// Resolve a single VM to a `VmSshTarget`, using --ip flag if provided.
 /// Routes through bastion automatically for private-IP-only VMs.
 pub(crate) async fn resolve_vm_ssh_target(

--- a/rust/crates/azlin/src/handlers/tests/test_group_03.rs
+++ b/rust/crates/azlin/src/handlers/tests/test_group_03.rs
@@ -167,6 +167,8 @@ fn test_create_vm_via_mock() {
         admin_username: "azureuser".to_string(),
         ssh_key_path: PathBuf::from("/tmp/fake-key.pub"),
         tags: HashMap::new(),
+        public_ip_enabled: true,
+        disk_ids: vec![],
     };
     let vm = mock.create_vm(&params).unwrap();
     assert_eq!(vm.name, "new-vm");


### PR DESCRIPTION
## Summary

Fixes Rust command parity gaps with the Python reference implementation for `new`, `clone`, `stop`, and bastion routing (closes #787).

- **`new` command**: Rewrote `create_vm()` to let `az vm create` handle networking automatically instead of manually creating NSG/VNet/subnet/PIP/NIC. This fixes resource name clashes, wrong VNet for bastion, and unconditional public IP creation. Added `public_ip_enabled` and `disk_ids` fields to `CreateVmParams` for bastion-only VMs and data disk attachment.
- **`clone` command**: Added `--location` to clone VM creation, auto-detects bastion mode from source VM, routes clones through bastion VNet when source has no public IP.
- **`stop --no-deallocate`**: Added `--no-deallocate` CLI flag matching Python's `--deallocate/--no-deallocate` toggle.
- **Pool name collision**: Changed auto-generated VM name timestamps from second to microsecond precision to prevent collisions in parallel pool creation.
- **Docs**: Updated source code references in `new.md` and `stop.md` to point to Rust files.

## Test plan

- [x] `cargo build` passes (all crates)
- [x] `cargo test -p azlin-core -p azlin-azure -p azlin-cli` — 472 tests pass
- [x] `cargo clippy` passes (no new warnings)
- [x] New test: `test_stop_no_deallocate_command` verifies `--no-deallocate` flag parsing
- [ ] Manual: `azlin new --name test-vm --region westus2 --no-auto-connect` creates VM successfully
- [ ] Manual: `azlin clone devo` creates a clone with correct networking
- [ ] Manual: `azlin stop devo --no-deallocate` powers off without deallocation
- [ ] Manual: Verify bastion-only VMs use correct VNet (`azlin-bastion-{region}-vnet`)

## Files changed

| File | Change |
|------|--------|
| `rust/crates/azlin-azure/src/vm.rs` | Rewrote `create_vm()` — removed manual networking, added bastion/disk support |
| `rust/crates/azlin-core/src/models.rs` | Added `public_ip_enabled`, `disk_ids` to `CreateVmParams` |
| `rust/crates/azlin-cli/src/lib.rs` | Added `--no-deallocate` flag, new test |
| `rust/crates/azlin/src/cmd_lifecycle.rs` | Handle `no_deallocate` in stop dispatch |
| `rust/crates/azlin/src/cmd_vm_ops.rs` | Added new fields to params, microsecond timestamps |
| `rust/crates/azlin/src/cmd_vm_ops2.rs` | Clone: added location, bastion detection |
| `rust/crates/azlin/src/dispatch_helpers.rs` | New `lookup_vm_public_ip()` helper |
| `rust/crates/azlin/src/handlers/tests/test_group_03.rs` | Updated test for new fields |
| `docs-site/commands/vm/new.md` | Updated source code links to Rust |
| `docs-site/commands/vm/stop.md` | Updated source code links to Rust |

🤖 Generated with [Claude Code](https://claude.com/claude-code)