### PR TITLE
feat: wire native russh SSH + persistent bastion tunnel daemon

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/azlin-azure",
     "crates/azlin-ai",
     "crates/azlin-cli",
+    "crates/azlin-ssh",
     "crates/azlin",
 ]
 
@@ -73,6 +74,8 @@ tempfile = "3"
 shell-escape = "0.1"
 shlex = "1"
 async-trait = "0.1"
+russh = "0.49"
+russh-keys = "0.49"
 wait-timeout = "0.2"
 openssl = { version = "0.10", features = ["vendored"] }
 

--- a/rust/crates/azlin-ssh/src/lib.rs
+++ b/rust/crates/azlin-ssh/src/lib.rs
@@ -14,6 +14,7 @@ use azlin_core::models::CommandResult;
 use azlin_core::{AzlinError, Result};
 use russh::client::{self, Handle};
 use russh::ChannelMsg;
+use russh_keys::key::PrivateKeyWithHashAlg;
 use russh_keys::load_secret_key;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
@@ -91,8 +92,11 @@ impl SshClient {
         .map_err(|_| AzlinError::Ssh(format!("connection to {} timed out", config.host)))?
         .map_err(|e| AzlinError::Ssh(format!("connection failed: {e}")))?;
 
+        let key_with_alg = PrivateKeyWithHashAlg::new(Arc::new(key), None)
+            .map_err(|e| AzlinError::SshKey(format!("key hash alg: {e}")))?;
+
         let authenticated = handle
-            .authenticate_publickey(&config.username, Arc::new(key))
+            .authenticate_publickey(&config.username, key_with_alg)
             .await
             .map_err(|e| AzlinError::Ssh(format!("auth failed: {e}")))?;
 

--- a/rust/crates/azlin/Cargo.toml
+++ b/rust/crates/azlin/Cargo.toml
@@ -19,6 +19,7 @@ azlin-core = { path = "../azlin-core" }
 azlin-azure = { path = "../azlin-azure" }
 azlin-ai = { path = "../azlin-ai" }
 azlin-cli = { path = "../azlin-cli" }
+azlin-ssh = { path = "../azlin-ssh" }
 tokio = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }

--- a/rust/crates/azlin/src/bastion_tunnel.rs
+++ b/rust/crates/azlin/src/bastion_tunnel.rs
@@ -1,62 +1,315 @@
-//! Scoped bastion tunnel for one-shot SSH/SCP operations through Azure Bastion.
+//! Persistent bastion tunnel daemon for SSH/SCP through Azure Bastion.
 //!
-//! Starts an `az network bastion tunnel` subprocess bound to a local port,
-//! then tears it down automatically on drop.
+//! Instead of creating/destroying tunnels per operation, this module maintains
+//! a tunnel registry at `/tmp/azlin-tunnels/registry.json`. Tunnels are reused
+//! across commands and kept alive by a background watchdog thread.
+//!
+//! ## Architecture
+//!
+//! - **Registry**: JSON state file tracking active tunnels (VM, local port, PID)
+//! - **Reuse**: `get_or_create_tunnel()` checks registry before spawning new tunnels
+//! - **Keepalive**: Background thread periodically checks tunnel health and prunes dead entries
+//! - **Cleanup**: `cleanup_all_tunnels()` tears down everything on explicit request
+//! - **`ScopedBastionTunnel`**: Backward-compatible wrapper; on drop it does NOT kill the tunnel
+//!   (the daemon owns it). Only explicit cleanup removes tunnels.
 
-use anyhow::Result;
-use std::sync::atomic::{AtomicU16, Ordering};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use tracing::debug;
 
 /// Global port counter to avoid collisions across concurrent tunnels.
 static NEXT_PORT: AtomicU16 = AtomicU16::new(50200);
 
-/// A running bastion tunnel that forwards a local port to a VM's SSH port.
-/// The tunnel subprocess is killed when this struct is dropped.
+/// Whether the keepalive watchdog has been started.
+static WATCHDOG_STARTED: AtomicBool = AtomicBool::new(false);
+
+/// Directory for tunnel state files.
+const TUNNEL_DIR: &str = "/tmp/azlin-tunnels";
+
+/// Registry file path.
+fn registry_path() -> PathBuf {
+    PathBuf::from(TUNNEL_DIR).join("registry.json")
+}
+
+// ---- Registry data model ----
+
+/// A single tunnel entry in the registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelRegistryEntry {
+    pub vm_resource_id: String,
+    pub bastion_name: String,
+    pub resource_group: String,
+    pub local_port: u16,
+    pub pid: u32,
+    pub created_at: u64,
+}
+
+/// The full tunnel registry.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TunnelRegistry {
+    pub tunnels: HashMap<String, TunnelRegistryEntry>,
+}
+
+impl TunnelRegistry {
+    /// Load the registry from disk. Returns empty registry if file doesn't exist.
+    pub fn load() -> Self {
+        let path = registry_path();
+        if !path.exists() {
+            return Self::default();
+        }
+        match std::fs::read_to_string(&path) {
+            Ok(data) => serde_json::from_str(&data).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Save the registry to disk.
+    pub fn save(&self) -> Result<()> {
+        let dir = Path::new(TUNNEL_DIR);
+        if !dir.exists() {
+            std::fs::create_dir_all(dir).context("creating tunnel directory")?;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700));
+        }
+        let data = serde_json::to_string_pretty(self)?;
+        std::fs::write(registry_path(), data).context("writing tunnel registry")?;
+        Ok(())
+    }
+
+    /// Remove entries whose processes are no longer running.
+    pub fn prune(&mut self) {
+        self.tunnels.retain(|key, entry| {
+            if process_is_running(entry.pid) {
+                true
+            } else {
+                debug!("pruning dead tunnel for {key} (pid {})", entry.pid);
+                false
+            }
+        });
+    }
+
+    /// Look up a tunnel by VM resource ID.
+    pub fn get(&self, vm_resource_id: &str) -> Option<&TunnelRegistryEntry> {
+        self.tunnels.get(vm_resource_id)
+    }
+
+    /// Insert or update a tunnel entry.
+    pub fn insert(&mut self, entry: TunnelRegistryEntry) {
+        self.tunnels.insert(entry.vm_resource_id.clone(), entry);
+    }
+
+    /// Remove a specific tunnel and kill its process.
+    pub fn remove(&mut self, vm_resource_id: &str) -> Option<TunnelRegistryEntry> {
+        if let Some(entry) = self.tunnels.remove(vm_resource_id) {
+            kill_process(entry.pid);
+            Some(entry)
+        } else {
+            None
+        }
+    }
+
+    /// Kill all tunnels and clear the registry.
+    pub fn remove_all(&mut self) {
+        for (_, entry) in self.tunnels.drain() {
+            kill_process(entry.pid);
+        }
+    }
+}
+
+// ---- Process utilities ----
+
+fn process_is_running(pid: u32) -> bool {
+    std::process::Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn kill_process(pid: u32) {
+    let _ = std::process::Command::new("kill")
+        .arg(pid.to_string())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+// ---- Keepalive watchdog ----
+
+/// Start the background keepalive watchdog (idempotent).
+///
+/// The watchdog runs every 30 seconds, prunes dead tunnels from the registry.
+pub fn ensure_watchdog_running() {
+    if WATCHDOG_STARTED
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
+        .is_ok()
+    {
+        std::thread::Builder::new()
+            .name("azlin-tunnel-watchdog".to_string())
+            .spawn(|| {
+                debug!("bastion tunnel watchdog started");
+                loop {
+                    std::thread::sleep(std::time::Duration::from_secs(30));
+                    let mut registry = TunnelRegistry::load();
+                    let before = registry.tunnels.len();
+                    registry.prune();
+                    let after = registry.tunnels.len();
+                    if before != after {
+                        debug!(
+                            "watchdog pruned {} dead tunnels ({} remaining)",
+                            before - after,
+                            after
+                        );
+                        let _ = registry.save();
+                    }
+                }
+            })
+            .ok();
+    }
+}
+
+// ---- Public API ----
+
+/// Get or create a bastion tunnel for a VM. Reuses existing tunnels from the registry.
+///
+/// Returns the local port the tunnel is bound to.
+pub fn get_or_create_tunnel(
+    bastion_name: &str,
+    resource_group: &str,
+    vm_resource_id: &str,
+) -> Result<u16> {
+    ensure_watchdog_running();
+
+    let mut registry = TunnelRegistry::load();
+    registry.prune();
+
+    // Reuse existing tunnel if alive
+    if let Some(entry) = registry.get(vm_resource_id) {
+        if process_is_running(entry.pid) {
+            debug!(
+                "reusing existing bastion tunnel for {} on port {}",
+                vm_resource_id, entry.local_port
+            );
+            return Ok(entry.local_port);
+        }
+    }
+
+    // Spawn a new tunnel
+    let port = NEXT_PORT.fetch_add(1, Ordering::SeqCst);
+    let child = std::process::Command::new("az")
+        .args([
+            "network",
+            "bastion",
+            "tunnel",
+            "--name",
+            bastion_name,
+            "--resource-group",
+            resource_group,
+            "--target-resource-id",
+            vm_resource_id,
+            "--resource-port",
+            "22",
+            "--port",
+            &port.to_string(),
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .context("Failed to spawn az bastion tunnel")?;
+
+    let pid = child.id();
+    std::mem::forget(child);
+
+    // Wait for tunnel to establish
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    if !process_is_running(pid) {
+        anyhow::bail!(
+            "Bastion tunnel for {} failed to start (process exited immediately)",
+            vm_resource_id
+        );
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    registry.insert(TunnelRegistryEntry {
+        vm_resource_id: vm_resource_id.to_string(),
+        bastion_name: bastion_name.to_string(),
+        resource_group: resource_group.to_string(),
+        local_port: port,
+        pid,
+        created_at: now,
+    });
+    registry.save()?;
+
+    debug!(
+        "started new bastion tunnel for {} on port {} (pid {})",
+        vm_resource_id, port, pid
+    );
+
+    Ok(port)
+}
+
+/// Clean up all bastion tunnels.
+pub fn cleanup_all_tunnels() {
+    let mut registry = TunnelRegistry::load();
+    let count = registry.tunnels.len();
+    registry.remove_all();
+    if registry.save().is_err() {
+        let _ = std::fs::remove_file(registry_path());
+    }
+    if count > 0 {
+        debug!("cleaned up {} bastion tunnels", count);
+    }
+}
+
+/// Clean up a specific tunnel by VM resource ID.
+pub fn cleanup_tunnel(vm_resource_id: &str) -> Result<()> {
+    let mut registry = TunnelRegistry::load();
+    if registry.remove(vm_resource_id).is_some() {
+        registry.save()?;
+    }
+    Ok(())
+}
+
+// ---- Backward-compatible ScopedBastionTunnel ----
+
+/// A bastion tunnel handle. Dropping this does NOT kill the tunnel; the daemon
+/// registry owns tunnel lifecycles. The tunnel persists for reuse.
 pub struct ScopedBastionTunnel {
     pub local_port: u16,
-    child: std::process::Child,
+    pub vm_resource_id: String,
 }
 
 impl ScopedBastionTunnel {
-    /// Spin up a bastion tunnel and wait briefly for it to establish.
+    /// Get or create a bastion tunnel. The tunnel persists beyond this handle's lifetime.
     pub fn new(bastion_name: &str, resource_group: &str, vm_resource_id: &str) -> Result<Self> {
-        let port = NEXT_PORT.fetch_add(1, Ordering::SeqCst);
-        let child = std::process::Command::new("az")
-            .args([
-                "network",
-                "bastion",
-                "tunnel",
-                "--name",
-                bastion_name,
-                "--resource-group",
-                resource_group,
-                "--target-resource-id",
-                vm_resource_id,
-                "--resource-port",
-                "22",
-                "--port",
-                &port.to_string(),
-            ])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()?;
-        // Wait briefly for tunnel to establish
-        std::thread::sleep(std::time::Duration::from_secs(2));
+        let local_port = get_or_create_tunnel(bastion_name, resource_group, vm_resource_id)?;
         Ok(Self {
-            local_port: port,
-            child,
+            local_port,
+            vm_resource_id: vm_resource_id.to_string(),
         })
     }
 }
 
-impl Drop for ScopedBastionTunnel {
-    fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-    }
-}
-
 /// Build SSH args that route through a bastion tunnel (127.0.0.1 on a local port).
-pub fn bastion_ssh_args(user: &str, local_port: u16, cmd: &str, connect_timeout: u64) -> Vec<String> {
+pub fn bastion_ssh_args(
+    user: &str,
+    local_port: u16,
+    cmd: &str,
+    connect_timeout: u64,
+) -> Vec<String> {
     vec![
         "-o".to_string(),
         "StrictHostKeyChecking=accept-new".to_string(),
@@ -72,7 +325,6 @@ pub fn bastion_ssh_args(user: &str, local_port: u16, cmd: &str, connect_timeout:
 }
 
 /// Build SCP args that route through a bastion tunnel.
-/// `sources` are local file paths, `remote_path` is the destination on the VM.
 pub fn bastion_scp_args(
     user: &str,
     local_port: u16,
@@ -159,5 +411,44 @@ mod tests {
         let args = bastion_scp_download_args("admin", 50203, "~/file.txt", "/tmp/file.txt", 30);
         assert!(args.contains(&"admin@127.0.0.1:~/file.txt".to_string()));
         assert!(args.contains(&"/tmp/file.txt".to_string()));
+    }
+
+    #[test]
+    fn test_registry_load_empty() {
+        let r = TunnelRegistry::default();
+        assert!(r.tunnels.is_empty());
+    }
+
+    #[test]
+    fn test_registry_roundtrip() {
+        let mut r = TunnelRegistry::default();
+        r.insert(TunnelRegistryEntry {
+            vm_resource_id: "/sub/rg/vm/test".to_string(),
+            bastion_name: "bastion1".to_string(),
+            resource_group: "rg1".to_string(),
+            local_port: 50200,
+            pid: 99999,
+            created_at: 1000,
+        });
+
+        let json = serde_json::to_string(&r).unwrap();
+        let r2: TunnelRegistry = serde_json::from_str(&json).unwrap();
+        assert_eq!(r2.tunnels.len(), 1);
+        assert_eq!(r2.tunnels["/sub/rg/vm/test"].local_port, 50200);
+    }
+
+    #[test]
+    fn test_registry_prune_removes_dead() {
+        let mut r = TunnelRegistry::default();
+        r.insert(TunnelRegistryEntry {
+            vm_resource_id: "/dead/vm".to_string(),
+            bastion_name: "b".to_string(),
+            resource_group: "rg".to_string(),
+            local_port: 50200,
+            pid: 999999999,
+            created_at: 1000,
+        });
+        r.prune();
+        assert!(r.tunnels.is_empty(), "dead PID should be pruned");
     }
 }

--- a/rust/crates/azlin/src/main.rs
+++ b/rust/crates/azlin/src/main.rs
@@ -57,6 +57,14 @@ fn ssh_exec(ip: &str, user: &str, cmd: &str) -> Result<(i32, String, String)> {
     ))
 }
 
+/// Try native SSH via russh connection pool. Uses `block_in_place` to bridge
+/// async russh into the synchronous `exec_inner` call path without deadlocking.
+fn try_native_ssh(ip: &str, user: &str, cmd: &str) -> Result<(i32, String, String)> {
+    let handle = tokio::runtime::Handle::try_current()
+        .map_err(|_| anyhow::anyhow!("no tokio runtime for native SSH"))?;
+    tokio::task::block_in_place(|| handle.block_on(native_ssh::native_exec(ip, user, cmd)))
+}
+
 /// Run a command on a VM through Azure Bastion and return (exit_code, stdout, stderr).
 fn bastion_ssh_exec(
     bastion_name: &str,
@@ -240,7 +248,19 @@ impl VmSshTarget {
                 cmd,
             )
         } else {
-            ssh_exec(&self.ip, &self.user, cmd)
+            // Try native russh first for direct SSH (lower latency, connection reuse).
+            // Fall back to subprocess SSH on any failure.
+            match try_native_ssh(&self.ip, &self.user, cmd) {
+                Ok(result) => Ok(result),
+                Err(e) => {
+                    tracing::debug!(
+                        "native SSH to {} failed ({}), falling back to subprocess",
+                        self.ip,
+                        e
+                    );
+                    ssh_exec(&self.ip, &self.user, cmd)
+                }
+            }
         }
     }
 
@@ -821,6 +841,10 @@ mod bastion_helpers;
 /// Scoped bastion tunnel for SSH/SCP through Azure Bastion.
 #[allow(dead_code)]
 mod bastion_tunnel;
+
+/// Native SSH execution via russh (connection pool).
+#[allow(dead_code)]
+mod native_ssh;
 
 /// Helpers for log tail computation.
 #[allow(dead_code)]

--- a/rust/crates/azlin/src/native_ssh.rs
+++ b/rust/crates/azlin/src/native_ssh.rs
@@ -1,0 +1,86 @@
+//! Native SSH execution via `azlin-ssh` (russh).
+//!
+//! Provides a global connection pool that `VmSshTarget` uses for direct SSH
+//! to VMs with public IPs. Falls back to subprocess SSH on any error.
+
+use anyhow::Result;
+use azlin_ssh::{SshConfig, SshPool};
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::Duration;
+use tracing::{debug, warn};
+
+/// Global SSH connection pool, lazily initialized.
+static POOL: OnceLock<SshPool> = OnceLock::new();
+
+/// Get or initialize the global SSH connection pool.
+fn global_pool() -> &'static SshPool {
+    POOL.get_or_init(|| SshPool::new(20, Duration::from_secs(300)))
+}
+
+/// Resolve the preferred SSH private key path.
+fn resolve_key_path() -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    let ssh_dir = home.join(".ssh");
+    for name in &["azlin_key", "id_ed25519_azlin", "id_ed25519", "id_rsa"] {
+        let path = ssh_dir.join(name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Execute a command on a remote host using native russh.
+///
+/// Returns `Ok((exit_code, stdout, stderr))` on success, or `Err` if the
+/// connection itself fails (caller should fall back to subprocess SSH).
+pub async fn native_exec(
+    ip: &str,
+    user: &str,
+    cmd: &str,
+) -> Result<(i32, String, String)> {
+    let key_path = resolve_key_path()
+        .ok_or_else(|| anyhow::anyhow!("no SSH private key found for native SSH"))?;
+
+    let config = SshConfig::new(ip, user, key_path);
+    let pool = global_pool();
+
+    let mut client = pool.get_or_connect(&config).await.map_err(|e| {
+        anyhow::anyhow!("native SSH connect to {}: {}", ip, e)
+    })?;
+
+    let result = client.execute(cmd).await;
+
+    match result {
+        Ok(r) => {
+            pool.release(client).await;
+            debug!(
+                "native SSH exec on {} completed (exit={})",
+                ip, r.exit_code
+            );
+            Ok((r.exit_code, r.stdout, r.stderr))
+        }
+        Err(e) => {
+            warn!("native SSH exec failed on {}: {}", ip, e);
+            Err(anyhow::anyhow!("native SSH exec: {}", e))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_key_path_returns_option() {
+        let _ = resolve_key_path();
+    }
+
+    #[test]
+    fn global_pool_is_consistent() {
+        let p1 = global_pool() as *const SshPool;
+        let p2 = global_pool() as *const SshPool;
+        assert_eq!(p1, p2, "global pool should be a singleton");
+    }
+}


### PR DESCRIPTION
## Summary

- **Issue #780**: Wire the existing `azlin-ssh` crate (russh connection pool) into actual SSH command dispatch. VMs with public IPs now use native russh for lower latency and connection reuse, with automatic fallback to subprocess SSH on any error.
- **Issue #778**: Replace ephemeral bastion tunnels with a persistent tunnel daemon. Tunnels are registered in `/tmp/azlin-tunnels/registry.json`, reused across commands, and kept alive by a background watchdog thread that prunes dead entries every 30 seconds.
- Fix `azlin-ssh` for russh 0.49 API (`PrivateKeyWithHashAlg` for `authenticate_publickey`)
- Add `azlin-ssh` to workspace members and as dependency of main `azlin` crate

## Changes

| File | Change |
|------|--------|
| `rust/Cargo.toml` | Add `azlin-ssh` to workspace members, add `russh`/`russh-keys` workspace deps |
| `rust/crates/azlin-ssh/src/lib.rs` | Fix russh 0.49 API for `authenticate_publickey` |
| `rust/crates/azlin/Cargo.toml` | Add `azlin-ssh` dependency |
| `rust/crates/azlin/src/native_ssh.rs` | **New** - Global `SshPool` singleton, `native_exec()` async function |
| `rust/crates/azlin/src/bastion_tunnel.rs` | **Rewritten** - Persistent tunnel registry, watchdog, reuse across commands |
| `rust/crates/azlin/src/main.rs` | Wire native SSH into `exec_inner`, add `try_native_ssh` bridge function |

## Test plan

- [x] `cargo check` passes (all crates compile)
- [x] `cargo test -p azlin-ssh` - 89 tests pass
- [x] `cargo test -p azlin -- bastion_tunnel` - 7 tests pass (registry roundtrip, prune, arg builders)
- [x] `cargo test -p azlin -- native_ssh` - 2 tests pass (singleton pool, key resolution)
- [ ] QA team test with gadugi YAML scenarios
- [ ] Docs updated for new SSH behavior
- [ ] Quality audit (3+ cycles)

Closes #780, Closes #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)