### PR TITLE
fix: Rust quality audit + penguin spinner verification (#798, #812)

### DIFF
--- a/rust/crates/azlin/src/cmd_autopilot.rs
+++ b/rust/crates/azlin/src/cmd_autopilot.rs
@@ -106,7 +106,6 @@ pub(crate) async fn dispatch(
             }
             azlin_cli::AutopilotAction::Run { dry_run } => {
                 // Check VM utilization and recommend actions
-                let _config = azlin_core::AzlinConfig::load().unwrap_or_default();
                 let rg = resolve_resource_group(None)?;
                 let auth = create_auth()?;
                 let vm_manager = azlin_azure::VmManager::new(&auth);
@@ -141,11 +140,10 @@ pub(crate) async fn dispatch(
                     );
                     match ssh_result {
                         Ok((0, stdout, _)) => {
-                            let lines: Vec<&str> = stdout.trim().lines().collect();
-                            let cpu_pct: f64 =
-                                lines.first().and_then(|s| s.parse().ok()).unwrap_or(100.0);
-                            let uptime_secs: f64 =
-                                lines.get(1).and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                            // parse_idle_check defaults: cpu=100% (assume busy),
+                            // uptime=0 (assume just booted) — safe conservative defaults
+                            let (cpu_pct, uptime_secs) =
+                                crate::autopilot_parse_helpers::parse_idle_check(&stdout);
                             if let Some(action_name) = crate::handlers::classify_autopilot_vm(
                                 cpu_pct,
                                 uptime_secs,

--- a/rust/crates/azlin/src/cmd_list.rs
+++ b/rust/crates/azlin/src/cmd_list.rs
@@ -287,7 +287,13 @@ pub(crate) async fn dispatch(
                 };
                 println!("\nvCPU Quota:");
                 // Use the configured default region instead of hardcoding "westus"
-                let config_for_quota = azlin_core::AzlinConfig::load().unwrap_or_default();
+                let config_for_quota = match azlin_core::AzlinConfig::load() {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("Warning: failed to load config for quota check, using defaults: {e}");
+                        azlin_core::AzlinConfig::default()
+                    }
+                };
                 let quota_location = config_for_quota.default_region.clone();
                 let output = std::process::Command::new("az")
                     .args([

--- a/rust/crates/azlin/src/cmd_self_update.rs
+++ b/rust/crates/azlin/src/cmd_self_update.rs
@@ -130,7 +130,9 @@ fn download_and_replace(url: &str, version: &str) -> Result<()> {
     pb.set_message("Replacing binary...");
     let backup = current_exe.with_extension("old");
     if backup.exists() {
-        fs::remove_file(&backup).ok();
+        if let Err(e) = fs::remove_file(&backup) {
+            eprintln!("Warning: failed to remove old backup: {e}");
+        }
     }
     fs::rename(&current_exe, &backup)
         .context("Failed to backup current binary (try running with sudo)")?;
@@ -143,8 +145,12 @@ fn download_and_replace(url: &str, version: &str) -> Result<()> {
     }
 
     // Clean up backup and temp dir
-    fs::remove_file(&backup).ok();
-    fs::remove_dir_all(&tmp_dir).ok();
+    if let Err(e) = fs::remove_file(&backup) {
+        eprintln!("Warning: failed to clean up backup file: {e}");
+    }
+    if let Err(e) = fs::remove_dir_all(&tmp_dir) {
+        eprintln!("Warning: failed to clean up temp directory: {e}");
+    }
 
     pb.finish_and_clear();
     println!("Updated azlin: {} → {}", CURRENT_VERSION, version);

--- a/rust/crates/azlin/src/cmd_vm_ops.rs
+++ b/rust/crates/azlin/src/cmd_vm_ops.rs
@@ -19,7 +19,13 @@ pub(crate) async fn handle_vm_new(
     let rg = resolve_resource_group(resource_group)?;
 
     let vm_count = pool.unwrap_or(1);
-    let config_defaults = azlin_core::AzlinConfig::load().unwrap_or_default();
+    let config_defaults = match azlin_core::AzlinConfig::load() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Warning: failed to load config, using defaults: {e}");
+            azlin_core::AzlinConfig::default()
+        }
+    };
     let user_specified_size = vm_size.is_some();
     let user_specified_region = region.is_some();
     let size = vm_size.unwrap_or_else(|| config_defaults.default_vm_size.clone());

--- a/rust/crates/azlin/src/main.rs
+++ b/rust/crates/azlin/src/main.rs
@@ -695,7 +695,9 @@ fn run_on_fleet(targets: &[VmSshTarget], command: &str, show_output: bool) {
 
 fn main() {
     let start = std::time::Instant::now();
-    color_eyre::install().ok();
+    if let Err(e) = color_eyre::install() {
+        eprintln!("Warning: failed to install color_eyre error handler: {e}");
+    }
 
     let result = tokio::runtime::Runtime::new()
         .expect("Failed to create tokio runtime")


### PR DESCRIPTION
## Summary

- **#798 Quality audit fixes**: Address high and medium severity findings from Rust crate quality audit
- **#812 Penguin spinner**: Verified all ~40 spinner instances across 19 files use penguin animation (already implemented)

## Quality Audit Changes (#798)

### High Severity
- **H3**: Replace silent `unwrap_or_default()` on config load with explicit warning messages in `cmd_vm_ops.rs` and `cmd_list.rs`

### Medium Severity
- **M2**: Replace `color_eyre::install().ok()` with proper error reporting in `main.rs`
- **M4**: Replace cleanup `.ok()` calls in `cmd_self_update.rs` with warning log messages
- **M5**: Use `parse_idle_check()` helper in `cmd_autopilot.rs` instead of inline `unwrap_or()` with misleading defaults
- Removed unused `config` variable in `cmd_autopilot.rs` (clippy fix)

## Penguin Spinner Verification (#812)

All spinners confirmed using penguin animation:
- `penguin_spinner()` helper (40+ call sites across 19 files)
- `fleet_spinner_style()` for multi-VM fleet operations (5 call sites)
- `PENGUIN_TICKS` constant with waddling penguin frames
- 120ms tick interval for visual effect

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes with zero warnings
- [x] All spinners use penguin animation (verified via grep)
- [x] No logic changes — error handling improvements only
- [x] All `unwrap_or_default()` on config loads now warn on failure

Closes #798
Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)