### PR TITLE
fix: azlin list --with-health shows actual health metrics instead of uptime

### DIFF
--- a/rust/crates/azlin/src/cmd_list_data.rs
+++ b/rust/crates/azlin/src/cmd_list_data.rs
@@ -168,43 +168,189 @@ pub(crate) fn collect_latencies(vms: &[VmInfo]) -> HashMap<String, u64> {
     latencies
 }
 
-/// Collect health data for running VMs via SSH uptime check.
-pub(crate) fn collect_health(vms: &[VmInfo], _verbose: bool, connect_timeout: u64) -> HashMap<String, String> {
+/// Health metrics for a VM (mirrors main.rs HealthMetrics for list command).
+#[derive(Debug, Clone)]
+pub(crate) struct HealthMetricsData {
+    pub vm_name: String,
+    pub power_state: String,
+    pub agent_status: String,
+    pub error_count: u32,
+    pub cpu_percent: f32,
+    pub mem_percent: f32,
+    pub disk_percent: f32,
+}
+
+/// Collect health data for running VMs via SSH using actual health metrics.
+pub(crate) fn collect_health(vms: &[VmInfo], _verbose: bool, connect_timeout: u64) -> HashMap<String, HealthMetricsData> {
     let mut health_data = HashMap::new();
+
+    // Resolve SSH key path
+    let ssh_key = home_dir()
+        .ok()
+        .map(|h| h.join(".ssh").join("azlin_key"))
+        .filter(|p| p.exists())
+        .or_else(|| {
+            home_dir()
+                .ok()
+                .map(|h| h.join(".ssh").join("id_rsa"))
+                .filter(|p| p.exists())
+        });
+
     for vm in vms {
         if vm.power_state != azlin_core::models::PowerState::Running {
+            // Insert default metrics for non-running VMs
+            health_data.insert(vm.name.clone(), HealthMetricsData {
+                vm_name: vm.name.clone(),
+                power_state: vm.power_state.to_string(),
+                agent_status: "-".to_string(),
+                error_count: 0,
+                cpu_percent: 0.0,
+                mem_percent: 0.0,
+                disk_percent: 0.0,
+            });
             continue;
         }
+
         let ip = vm.public_ip.as_deref().or(vm.private_ip.as_deref());
         if let Some(ip) = ip {
             let user = vm
                 .admin_username
                 .as_deref()
                 .unwrap_or(DEFAULT_ADMIN_USERNAME);
-            let timeout_val = format!("ConnectTimeout={}", connect_timeout);
-            let output = std::process::Command::new("ssh")
-                .args([
-                    "-o",
-                    "StrictHostKeyChecking=accept-new",
-                    "-o",
-                    &timeout_val,
-                    "-o",
-                    "BatchMode=yes",
-                    &format!("{}@{}", user, ip),
-                    "uptime -p 2>/dev/null || uptime",
-                ])
-                .output();
-            if let Ok(out) = output {
-                if out.status.success() {
-                    let summary = String::from_utf8_lossy(&out.stdout).trim().to_string();
-                    if !summary.is_empty() {
-                        health_data.insert(vm.name.clone(), summary);
-                    }
-                }
-            }
+
+            // Collect metrics via SSH
+            let metrics = collect_vm_health_metrics(&vm.name, ip, user, connect_timeout, ssh_key.as_deref());
+            health_data.insert(vm.name.clone(), metrics);
+        } else {
+            // No IP available
+            health_data.insert(vm.name.clone(), HealthMetricsData {
+                vm_name: vm.name.clone(),
+                power_state: vm.power_state.to_string(),
+                agent_status: "-".to_string(),
+                error_count: 0,
+                cpu_percent: 0.0,
+                mem_percent: 0.0,
+                disk_percent: 0.0,
+            });
         }
     }
     health_data
+}
+
+/// Collect health metrics from a single VM via SSH.
+fn collect_vm_health_metrics(
+    vm_name: &str,
+    ip: &str,
+    user: &str,
+    connect_timeout: u64,
+    ssh_key: Option<&std::path::Path>,
+) -> HealthMetricsData {
+    let timeout_val = format!("ConnectTimeout={}", connect_timeout);
+    let mut ssh_args = vec![
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-o",
+        &timeout_val,
+        "-o",
+        "BatchMode=yes",
+    ];
+    if let Some(key) = ssh_key {
+        ssh_args.push("-i");
+        ssh_args.push(key.to_str().unwrap_or(""));
+    }
+
+    // CPU usage from top
+    let user_host = format!("{}@{}", user, ip);
+    let cpu_cmd = "top -bn1 | grep 'Cpu(s)' | sed 's/.*, *\\([0-9.]*\\)%* id.*/\\1/' | awk '{print 100 - $1}'";
+    let cpu = std::process::Command::new("ssh")
+        .args(&ssh_args)
+        .args([&user_host, cpu_cmd])
+        .output()
+        .ok()
+        .and_then(|out| {
+            if out.status.success() {
+                String::from_utf8_lossy(&out.stdout).trim().parse::<f32>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0.0);
+
+    // Memory usage from free
+    let mem_cmd = "free | awk '/Mem:/{printf \"%.1f\", $3/$2 * 100}'";
+    let mem = std::process::Command::new("ssh")
+        .args(&ssh_args)
+        .args([&user_host, mem_cmd])
+        .output()
+        .ok()
+        .and_then(|out| {
+            if out.status.success() {
+                String::from_utf8_lossy(&out.stdout).trim().parse::<f32>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0.0);
+
+    // Disk usage from df
+    let disk_cmd = "df / --output=pcent | tail -1 | tr -d ' %'";
+    let disk = std::process::Command::new("ssh")
+        .args(&ssh_args)
+        .args([&user_host, disk_cmd])
+        .output()
+        .ok()
+        .and_then(|out| {
+            if out.status.success() {
+                String::from_utf8_lossy(&out.stdout).trim().parse::<f32>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0.0);
+
+    // Agent status from walinuxagent service
+    let agent_cmd = "systemctl is-active walinuxagent 2>/dev/null || echo 'N/A'";
+    let agent = std::process::Command::new("ssh")
+        .args(&ssh_args)
+        .args([&user_host, agent_cmd])
+        .output()
+        .ok()
+        .map(|out| {
+            let status = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            match status.as_str() {
+                "active" => "Active".to_string(),
+                "inactive" => "Inactive".to_string(),
+                "failed" => "Failed".to_string(),
+                _ => "N/A".to_string(),
+            }
+        })
+        .unwrap_or_else(|| "N/A".to_string());
+
+    // Error count from journalctl (last hour)
+    let error_cmd = "journalctl -p err --since '1 hour ago' --no-pager -q 2>/dev/null | wc -l";
+    let errors = std::process::Command::new("ssh")
+        .args(&ssh_args)
+        .args([&user_host, error_cmd])
+        .output()
+        .ok()
+        .and_then(|out| {
+            if out.status.success() {
+                String::from_utf8_lossy(&out.stdout).trim().parse::<u32>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0);
+
+    HealthMetricsData {
+        vm_name: vm_name.to_string(),
+        power_state: "Running".to_string(),
+        agent_status: agent,
+        error_count: errors,
+        cpu_percent: cpu,
+        mem_percent: mem,
+        disk_percent: disk,
+    }
 }
 
 /// Collect top process data for running VMs.

--- a/rust/crates/azlin/src/cmd_list_render.rs
+++ b/rust/crates/azlin/src/cmd_list_render.rs
@@ -1,6 +1,7 @@
 //! Rendering logic for the list command (table, JSON, CSV output).
 #![allow(dead_code)]
 
+use crate::cmd_list_data::HealthMetricsData;
 use anyhow::Result;
 use azlin_core::models::VmInfo;
 use std::collections::HashMap;
@@ -22,7 +23,7 @@ pub(crate) struct ListRenderData<'a> {
     pub vms: &'a [VmInfo],
     pub tmux_sessions: &'a HashMap<String, Vec<String>>,
     pub latencies: &'a HashMap<String, u64>,
-    pub health_data: &'a HashMap<String, String>,
+    pub health_data: &'a HashMap<String, HealthMetricsData>,
     pub proc_data: &'a HashMap<String, String>,
 }
 
@@ -258,9 +259,24 @@ fn render_table(cfg: &ListRenderConfig, data: &ListRenderData) {
     }
     if cfg.with_health {
         cols.push(ColDef {
-            header: "Health",
+            header: "Agent",
             width: 8,
             right_align: false,
+        });
+        cols.push(ColDef {
+            header: "CPU%",
+            width: 5,
+            right_align: true,
+        });
+        cols.push(ColDef {
+            header: "Mem%",
+            width: 5,
+            right_align: true,
+        });
+        cols.push(ColDef {
+            header: "Disk%",
+            width: 5,
+            right_align: true,
         });
     }
     if cfg.show_procs {
@@ -440,14 +456,35 @@ fn render_table(cfg: &ListRenderConfig, data: &ListRenderData) {
             col_i += 1;
         }
 
-        // Health
+        // Health - 4 columns: Agent, CPU%, Mem%, Disk%
         if cfg.with_health {
-            let h = data
-                .health_data
-                .get(&vm.name)
-                .cloned()
-                .unwrap_or_else(|| "-".to_string());
-            cells.push(trunc(&h, cols[col_i].width));
+            let health = data.health_data.get(&vm.name);
+
+            // Agent status
+            let agent = health.map(|h| h.agent_status.as_str()).unwrap_or("-");
+            let agent_colored = match agent {
+                "Active" => green(agent),
+                "Inactive" | "N/A" => dim(agent),
+                "Failed" => red(agent),
+                _ => dim(agent),
+            };
+            let agent_padded = trunc(&agent_colored, cols[col_i].width);
+            cells.push(agent_padded);
+            col_i += 1;
+
+            // CPU%
+            let cpu = health.map(|h| format!("{:.1}", h.cpu_percent)).unwrap_or_else(|| "-".to_string());
+            cells.push(dim(&trunc_right(&cpu, cols[col_i].width)));
+            col_i += 1;
+
+            // Mem%
+            let mem = health.map(|h| format!("{:.1}", h.mem_percent)).unwrap_or_else(|| "-".to_string());
+            cells.push(dim(&trunc_right(&mem, cols[col_i].width)));
+            col_i += 1;
+
+            // Disk%
+            let disk = health.map(|h| format!("{:.1}", h.disk_percent)).unwrap_or_else(|| "-".to_string());
+            cells.push(dim(&trunc_right(&disk, cols[col_i].width)));
             col_i += 1;
         }
 
@@ -537,7 +574,17 @@ fn render_json(cfg: &ListRenderConfig, data: &ListRenderData) -> Result<()> {
                 obj["latency_ms"] = serde_json::json!(data.latencies.get(&vm.name));
             }
             if cfg.with_health {
-                obj["health"] = serde_json::json!(data.health_data.get(&vm.name));
+                if let Some(health) = data.health_data.get(&vm.name) {
+                    obj["health"] = serde_json::json!({
+                        "agent_status": health.agent_status,
+                        "cpu_percent": health.cpu_percent,
+                        "mem_percent": health.mem_percent,
+                        "disk_percent": health.disk_percent,
+                        "error_count": health.error_count,
+                    });
+                } else {
+                    obj["health"] = serde_json::Value::Null;
+                }
             }
             obj
         })
@@ -564,6 +611,9 @@ fn render_csv(cfg: &ListRenderConfig, data: &ListRenderData) {
     headers.extend_from_slice(&["CPU", "Mem"]);
     if cfg.with_latency {
         headers.push("Latency");
+    }
+    if cfg.with_health {
+        headers.extend_from_slice(&["Agent", "CPU%", "Mem%", "Disk%"]);
     }
     println!("{}", headers.join(","));
 
@@ -609,6 +659,19 @@ fn render_csv(cfg: &ListRenderConfig, data: &ListRenderData) {
                     .unwrap_or_default()
             ));
         }
+        if cfg.with_health {
+            if let Some(health) = data.health_data.get(&vm.name) {
+                row.push_str(&format!(
+                    ",{},{:.1},{:.1},{:.1}",
+                    health.agent_status,
+                    health.cpu_percent,
+                    health.mem_percent,
+                    health.disk_percent
+                ));
+            } else {
+                row.push_str(",-,-,-,-");
+            }
+        }
         println!("{}", row);
     }
 }
@@ -616,6 +679,7 @@ fn render_csv(cfg: &ListRenderConfig, data: &ListRenderData) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cmd_list_data::HealthMetricsData;
 
     // ── format_tmux_plain ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes #849

Previously, the &#96;--with-health&#96; flag showed VM uptime instead of actual health metrics.

## Changes

### cmd_list_data.rs
- Added &#96;HealthMetricsData&#96; struct to hold health metrics (CPU%, Memory%, Disk%, Agent status)
- Updated &#96;collect_health()&#96; to collect actual health metrics via SSH:
  - CPU usage from &#96;top&#96; command
  - Memory usage from &#96;free&#96; command  
  - Disk usage from &#96;df&#96; command
  - Agent status from &#96;systemctl is-active walinuxagent&#96;
  - Error count from &#96;journalctl&#96;

### cmd_list_render.rs
- Updated table rendering to show 4 health columns instead of 1:
  - Agent (status with color coding)
  - CPU% (percentage)
  - Mem% (percentage)
  - Disk% (percentage)
- Updated JSON output to include structured health data
- Updated CSV output with separate columns for each metric

## Testing

The code compiles successfully with &#96;cargo check&#96;.

## Screenshots

Before: Single &quot;Health&quot; column showing uptime string
After: Four columns (Agent, CPU%, Mem%, Disk%) showing actual metrics