### PR TITLE
fix: azlin list --with-health shows real health metrics (#849)

### DIFF
--- a/rust/crates/azlin/src/cmd_list_render.rs
+++ b/rust/crates/azlin/src/cmd_list_render.rs
@@ -643,7 +643,7 @@ fn render_csv(cfg: &ListRenderConfig, data: &ListRenderData) {
         row.push_str(&format!(",{},{}", cpu, mem));
         if cfg.with_latency {
             row.push_str(&format!(
-                ",{}",
+                ", {}",
                 data.latencies
                     .get(&vm.name)
                     .map(|l| format!("{}ms", l))
@@ -652,13 +652,14 @@ fn render_csv(cfg: &ListRenderConfig, data: &ListRenderData) {
         }
         if cfg.with_health {
             if let Some(m) = data.health_data.get(&vm.name) {
-                row.push_str(&format!(",{},{:.0},{:.0},{:.0}", m.agent_status, m.cpu_percent, m.mem_percent, m.disk_percent));
+                row.push_str(&format!(",{}, {:.0}, {:.0}, {:.0}", m.agent_status, m.cpu_percent, m.mem_percent, m.disk_percent));
             } else {
                 row.push_str(",,,,");
             }
         }
         println!("{}", row);
     }
+}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

`azlin list --with-health` in the Rust implementation only runs `uptime -p` via SSH and shows a single "Health" column with uptime text. The Python implementation shows 4 columns (Agent, CPU%, Mem%, Disk%) using proper health metrics.

## Solution

Replace the `collect_health()` function that only ran `uptime -p` via SSH with `collect_health_data()` that reuses the same `collect_health_metrics()` function used by `azlin health`. Now shows 4 color-coded columns:
- Agent (OK/FAIL)
- CPU%
- Mem%
- Disk%

Also updates JSON and CSV output formats with individual health fields.

## Files Changed

- `cmd_list_data.rs` - Replace `collect_health()` with `collect_health_data()` using `collect_health_metrics()`
- `cmd_list.rs` - Update function call to use new `collect_health_data()`
- `cmd_list_render.rs` - Replace single "Health" column with Agent/CPU%/Mem%/Disk% columns, add color-coded thresholds

Fixes #849