### PR TITLE
docs: remove stale v2.1 labels and outdated pip install instruction (#857)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1989,7 +1989,7 @@ azlin snapshot sync --vm my-vm
 
 ## Natural Language Commands (AI-Powered)
 
-**New in v2.1**: Use natural language to control azlin with Claude AI
+Use natural language to control azlin with Claude AI
 
 The `azlin doit` command understands what you want and executes the appropriate commands automatically. Just describe what you need in plain English, and azlin figures out the right commands to run.
 
@@ -1998,9 +1998,6 @@ The `azlin doit` command understands what you want and executes the appropriate 
 ```bash
 # Install via uvx (no installation needed)
 uvx --from git+https://github.com/rysweet/azlin azlin doit "list all my vms"
-
-# Or install locally
-pip install git+https://github.com/rysweet/azlin
 
 # Configure your API key (required)
 export ANTHROPIC_API_KEY=sk-ant-xxxxx...
@@ -2345,7 +2342,7 @@ azlin start my-vm  # Start if stopped
 ```
 
 **Connection drops frequently?**
-- Auto-reconnect feature will prompt you (new in v2.1!)
+- Auto-reconnect feature will prompt you
 - Check network stability
 - Consider using screen/tmux for persistence
 


### PR DESCRIPTION
# Three minor documentation cleanups in README.md to reduce user confusion and remove outdated information now that the project is on v2.6.20.
## Changes:

- **Line 1992** — Removed `**New in v2.1**:` prefix from the Natural Language Commands section heading. The feature has been present for several major versions and the label adds no useful context.
- **Line 2003** — Deleted the `pip install git+https://github.com/rysweet/azlin` line. azlin is now a Rust binary with a Python bridge, so pip installation is no longer the correct approach. The `uvx` method immediately above already covers this use case.
- **Line 2348** — Removed `(new in v2.1!)` from the auto-reconnect troubleshooting bullet. Same rationale — the feature is long-established.