### PR TITLE
docs(storage): update Premium SSD availability note

### DIFF
--- a/docs/how-to/separate-home-disk.md
+++ b/docs/how-to/separate-home-disk.md
@@ -202,7 +202,7 @@ For better performance, consider Premium SSD:
 | 256GB (E15) | $38.40     | 1100 | 125 MB/s   | Database    |
 | 512GB (E20) | $73.22     | 2300 | 150 MB/s   | High perf   |
 
-**Note**: azlin currently defaults to Standard HDD. Premium SSD support coming soon.
+**Note**: azlin currently defaults to Standard HDD. Premium SSD is already available for higher-performance storage when needed.
 
 ### Cost-Benefit Comparison
 


### PR DESCRIPTION
## Summary
Fixes #855 by updating `docs/how-to/separate-home-disk.md` so it matches the current product state.

## Changes
- replaced the outdated note that said Premium SSD support was "coming soon"
- clarified that Premium SSD is already available for higher-performance storage

## Validation
- confirmed the outdated wording is removed from `docs/how-to/separate-home-disk.md`
- confirmed the replacement wording is present after the edit

## AI Disclosure
This pull request was prepared with assistance from an AI coding agent.