### PR TITLE
"Take the currently validated local fixes for GitHub issues #876, #878, #879, and #880 in /home/azureuser/src/azlin and turn them into actual GitHub pull requests that are ready for review. Use the re

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,13 @@ azlin = "azlin.rust_bridge:entry"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/azlin"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+
+[dependency-groups]
+dev = [
+    "click",
+    "pytest>=9.0.2",
+    "pyyaml",
+]

--- a/scripts/cli_documentation/example_manager.py
+++ b/scripts/cli_documentation/example_manager.py
@@ -11,12 +11,14 @@ Philosophy:
 """
 
 import re
-import sys
 from pathlib import Path
 
 import yaml
 
-from .models import CommandExample
+from .models import CommandExample, DocumentationError
+
+# Pre-compiled pattern for command name validation (compiled once at import time)
+_VALID_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 class ExampleManager:
@@ -55,7 +57,7 @@ class ExampleManager:
             ValueError: Invalid command name: ../etc/passwd
         """
         # Only allow alphanumeric, dash, and underscore
-        if not re.match(r"^[a-zA-Z0-9_-]+$", command_name):
+        if not _VALID_NAME_RE.match(command_name):
             raise ValueError(f"Invalid command name: {command_name}")
         return command_name
 
@@ -74,12 +76,9 @@ class ExampleManager:
             >>> for ex in examples:
             ...     print(ex.title)
         """
-        # Sanitize command name to prevent path traversal
-        try:
-            safe_command_name = self._sanitize_command_name(command_name)
-        except ValueError as e:
-            print(f"Warning: {e}", file=sys.stderr)
-            return []
+        # Sanitize command name to prevent path traversal.
+        # ValueError propagates to the caller — silent swallowing is #878.
+        safe_command_name = self._sanitize_command_name(command_name)
 
         # Try to find YAML file for this command
         yaml_file = self.examples_dir / f"{safe_command_name}.yaml"
@@ -140,7 +139,7 @@ class ExampleManager:
                   Expected output here
         """
         try:
-            with open(yaml_file) as f:
+            with open(yaml_file, encoding="utf-8") as f:
                 data = yaml.safe_load(f)
 
             if not data or "examples" not in data:
@@ -148,23 +147,29 @@ class ExampleManager:
 
             examples = []
             for ex_data in data["examples"]:
+                command = ex_data.get("command")
+                if not command:
+                    raise DocumentationError(
+                        f"Example entry in '{yaml_file}' is missing required field 'command'"
+                    )
                 example = CommandExample(
                     title=ex_data.get("title", ""),
                     description=ex_data.get("description", ""),
-                    command=ex_data.get("command", ""),
+                    command=command,
                     output=ex_data.get("output"),
                 )
                 examples.append(example)
 
             return examples
 
-        except Exception as e:
-            # Log error but fail gracefully
-            print(
-                f"Warning: Failed to load examples from '{yaml_file}': {e}",
-                file=sys.stderr,
-            )
+        except FileNotFoundError:
             return []
+        except DocumentationError:
+            raise
+        except Exception as e:
+            raise DocumentationError(
+                f"Failed to load examples for command '{yaml_file.stem}'"
+            ) from e
 
     def save_examples(self, command_name: str, examples: list[CommandExample]) -> bool:
         """Save examples to a YAML file.
@@ -174,7 +179,11 @@ class ExampleManager:
             examples: List of examples to save
 
         Returns:
-            True if save succeeded, False otherwise
+            True if save succeeded.
+
+        Raises:
+            DocumentationError: If the file cannot be written due to I/O or
+                other unexpected errors.
 
         Example:
             >>> manager = ExampleManager("scripts/examples/")
@@ -186,10 +195,11 @@ class ExampleManager:
             >>> manager.save_examples("mount", examples)
             True
         """
-        try:
-            # Sanitize command name to prevent path traversal
-            safe_command_name = self._sanitize_command_name(command_name)
+        # Sanitize command name to prevent path traversal.
+        # ValueError propagates to the caller — consistent with load_examples (#878).
+        safe_command_name = self._sanitize_command_name(command_name)
 
+        try:
             yaml_file = self.examples_dir / f"{safe_command_name}.yaml"
             yaml_file.parent.mkdir(parents=True, exist_ok=True)
 
@@ -206,18 +216,21 @@ class ExampleManager:
                 ],
             }
 
-            with open(yaml_file, "w") as f:
-                yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+            with open(yaml_file, "w", encoding="utf-8") as f:
+                yaml.dump(
+                    data,
+                    f,
+                    default_flow_style=False,
+                    sort_keys=False,
+                    allow_unicode=True,
+                )
 
             return True
 
         except Exception as e:
-            # Log error but fail gracefully
-            print(
-                f"Warning: Failed to save examples for command '{command_name}': {e}",
-                file=sys.stderr,
-            )
-            return False
+            raise DocumentationError(
+                f"Failed to save examples for '{safe_command_name}': {e}"
+            ) from e
 
 
 __all__ = ["ExampleManager"]

--- a/scripts/cli_documentation/example_manager.py
+++ b/scripts/cli_documentation/example_manager.py
@@ -229,7 +229,7 @@ class ExampleManager:
 
         except Exception as e:
             raise DocumentationError(
-                f"Failed to save examples for '{safe_command_name}': {e}"
+                f"Failed to save examples for '{safe_command_name}'"
             ) from e
 
 

--- a/scripts/cli_documentation/extractor.py
+++ b/scripts/cli_documentation/extractor.py
@@ -15,7 +15,7 @@ import sys
 
 import click
 
-from .models import CLIArgument, CLIMetadata, CLIOption
+from .models import CLIArgument, CLIMetadata, CLIOption, DocumentationError
 
 
 class CLIExtractor:
@@ -42,7 +42,10 @@ class CLIExtractor:
             command_name: Name of the Click command to extract
 
         Returns:
-            CLIMetadata object or None if command not found
+            CLIMetadata object or None if command not found in the module.
+
+        Raises:
+            DocumentationError: If the module import or metadata extraction fails.
 
         Example:
             >>> extractor = CLIExtractor()
@@ -71,12 +74,9 @@ class CLIExtractor:
             return self._extract_from_click_command(command)
 
         except Exception as e:
-            # Log error but fail gracefully
-            print(
-                f"Warning: Failed to extract command '{command_name}': {e}",
-                file=sys.stderr,
-            )
-            return None
+            raise DocumentationError(
+                f"Failed to extract command '{command_name}'"
+            ) from e
 
     def extract_all_commands(self, module_path: str) -> list[CLIMetadata]:
         """Extract metadata from all commands in a module.
@@ -85,7 +85,10 @@ class CLIExtractor:
             module_path: Python module path (e.g., "azlin.cli")
 
         Returns:
-            List of CLIMetadata objects for all found commands
+            List of CLIMetadata objects for all found commands.
+
+        Raises:
+            DocumentationError: If the module import or metadata extraction fails.
 
         Example:
             >>> extractor = CLIExtractor()
@@ -119,12 +122,9 @@ class CLIExtractor:
             return commands
 
         except Exception as e:
-            # Log error but fail gracefully
-            print(
-                f"Warning: Failed to extract commands from module '{module_path}': {e}",
-                file=sys.stderr,
-            )
-            return []
+            raise DocumentationError(
+                f"Failed to extract commands from module '{module_path}'"
+            ) from e
 
     def _extract_from_click_command(
         self, command: click.Command, parent_path: str = ""
@@ -176,13 +176,8 @@ class CLIExtractor:
             )
 
         except Exception as e:
-            # Log error but fail gracefully
-            command_name = getattr(command, "name", "unknown")
-            print(
-                f"Warning: Failed to extract metadata from command '{command_name}': {e}",
-                file=sys.stderr,
-            )
-            return None
+            name = getattr(command, "name", "unknown")
+            raise DocumentationError(f"Failed to extract subcommand '{name}'") from e
 
     def _get_docstring(self, command: click.Command) -> str:
         """Extract docstring from command callback function."""

--- a/scripts/cli_documentation/extractor.py
+++ b/scripts/cli_documentation/extractor.py
@@ -115,9 +115,7 @@ class CLIExtractor:
 
                 # Check if it's a Click command or group
                 if isinstance(attr, (click.Command, click.Group)):
-                    metadata = self._extract_from_click_command(attr)
-                    if metadata:
-                        commands.append(metadata)
+                    commands.append(self._extract_from_click_command(attr))
 
             return commands
 
@@ -128,7 +126,7 @@ class CLIExtractor:
 
     def _extract_from_click_command(
         self, command: click.Command, parent_path: str = ""
-    ) -> CLIMetadata | None:
+    ) -> CLIMetadata:
         """Extract metadata from a Click command object.
 
         Args:
@@ -159,11 +157,9 @@ class CLIExtractor:
                 for subcmd_name in command.list_commands(None):
                     subcmd = command.get_command(None, subcmd_name)
                     if subcmd:
-                        sub_metadata = self._extract_from_click_command(
-                            subcmd, full_path
+                        subcommands.append(
+                            self._extract_from_click_command(subcmd, full_path)
                         )
-                        if sub_metadata:
-                            subcommands.append(sub_metadata)
 
             return CLIMetadata(
                 name=name,

--- a/scripts/cli_documentation/hasher.py
+++ b/scripts/cli_documentation/hasher.py
@@ -197,8 +197,14 @@ class CLIHasher:
                 self._hashes = json.load(f)
         except FileNotFoundError:
             self._hashes = {}
-        except Exception as e:
-            raise DocumentationError("Failed to load hashes from hash file") from e
+        except json.JSONDecodeError as e:
+            raise DocumentationError(
+                f"Hash file {self.hash_file} is corrupt: {e}"
+            ) from e
+        except OSError as e:
+            raise DocumentationError(
+                f"Cannot read hash file {self.hash_file}: {e}"
+            ) from e
 
     def clear_hashes(self) -> None:
         """Clear all stored hashes (force full regeneration)."""

--- a/scripts/cli_documentation/hasher.py
+++ b/scripts/cli_documentation/hasher.py
@@ -12,10 +12,9 @@ Philosophy:
 
 import hashlib
 import json
-import sys
 from pathlib import Path
 
-from .models import ChangeSet, CLIMetadata
+from .models import ChangeSet, CLIMetadata, DocumentationError
 
 
 class CLIHasher:
@@ -125,7 +124,11 @@ class CLIHasher:
         """Save all hashes to disk.
 
         Returns:
-            True if save succeeded, False otherwise
+            True if save succeeded.
+
+        Raises:
+            DocumentationError: If the file cannot be written due to I/O or
+                other unexpected errors.
 
         Example:
             >>> hasher = CLIHasher()
@@ -137,17 +140,13 @@ class CLIHasher:
         try:
             self.hash_file.parent.mkdir(parents=True, exist_ok=True)
 
-            with open(self.hash_file, "w") as f:
+            with open(self.hash_file, "w", encoding="utf-8") as f:
                 json.dump(self._hashes, f, indent=2, sort_keys=True)
 
             return True
 
         except Exception as e:
-            print(
-                f"Warning: Failed to save hashes to '{self.hash_file}': {e}",
-                file=sys.stderr,
-            )
-            return False
+            raise DocumentationError("Failed to save hashes to hash file") from e
 
     def compare_hashes(self, current_commands: dict[str, CLIMetadata]) -> ChangeSet:
         """Compare current commands with stored hashes.
@@ -184,20 +183,22 @@ class CLIHasher:
         return ChangeSet(changed=changed, added=added, removed=removed)
 
     def _load_hashes(self) -> None:
-        """Load hashes from disk."""
+        """Load hashes from disk.
+
+        Raises:
+            DocumentationError: If the file exists but cannot be read or parsed.
+        """
         if not self.hash_file.exists():
             self._hashes = {}
             return
 
         try:
-            with open(self.hash_file) as f:
+            with open(self.hash_file, encoding="utf-8") as f:
                 self._hashes = json.load(f)
-        except Exception as e:
-            print(
-                f"Warning: Failed to load hashes from '{self.hash_file}': {e}",
-                file=sys.stderr,
-            )
+        except FileNotFoundError:
             self._hashes = {}
+        except Exception as e:
+            raise DocumentationError("Failed to load hashes from hash file") from e
 
     def clear_hashes(self) -> None:
         """Clear all stored hashes (force full regeneration)."""

--- a/scripts/cli_documentation/models.py
+++ b/scripts/cli_documentation/models.py
@@ -169,12 +169,22 @@ class ChangeSet:
         return bool(self.changed or self.added or self.removed)
 
 
+class DocumentationError(Exception):
+    """Raised when a documentation file cannot be read or written unexpectedly.
+
+    This exception is raised when an I/O or parse error occurs that is not
+    simply a missing file. FileNotFoundError is handled gracefully (return
+    empty/default); all other failures propagate as DocumentationError.
+    """
+
+
 __all__ = [
     "CLIArgument",
     "CLIMetadata",
     "CLIOption",
     "ChangeSet",
     "CommandExample",
+    "DocumentationError",
     "SyncResult",
     "ValidationResult",
 ]

--- a/scripts/cli_documentation/sync_manager.py
+++ b/scripts/cli_documentation/sync_manager.py
@@ -20,8 +20,11 @@ from .example_manager import ExampleManager
 from .extractor import CLIExtractor
 from .generator import DocGenerator
 from .hasher import CLIHasher
-from .models import CLIMetadata, SyncResult
+from .models import CLIMetadata, DocumentationError, SyncResult
 from .validator import SyncValidator
+
+# Pre-compiled pattern for path component validation (compiled once at import time)
+_VALID_PATH_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 class DocSyncManager:
@@ -86,13 +89,10 @@ class DocSyncManager:
             # Regenerate all
             commands_to_sync = commands
         else:
-            # Only sync changed commands
+            # Only sync changed commands; use a set for O(1) membership tests
             changeset = self.hasher.compare_hashes(command_dict)
-            commands_to_sync = [
-                cmd
-                for cmd in commands
-                if cmd.name in changeset.changed or cmd.name in changeset.added
-            ]
+            needs_sync = set(changeset.changed) | set(changeset.added)
+            commands_to_sync = [cmd for cmd in commands if cmd.name in needs_sync]
 
         # Sync each command
         for command in commands_to_sync:
@@ -139,7 +139,7 @@ class DocSyncManager:
 
             # Write to file
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_text(markdown)
+            output_path.write_text(markdown, encoding="utf-8")
 
             # Validate if requested
             validation_result = None
@@ -162,7 +162,7 @@ class DocSyncManager:
                 validation_result=validation_result,
             )
 
-        except Exception as e:
+        except DocumentationError as e:
             return SyncResult(
                 command_name=command.name,
                 error=str(e),
@@ -207,7 +207,7 @@ class DocSyncManager:
             ValueError: If component contains invalid characters
         """
         # Only allow alphanumeric, dash, and underscore
-        if not re.match(r"^[a-zA-Z0-9_-]+$", component):
+        if not _VALID_PATH_RE.match(component):
             raise ValueError(f"Invalid path component: {component}")
         return component
 

--- a/scripts/cli_documentation/validator.py
+++ b/scripts/cli_documentation/validator.py
@@ -66,7 +66,7 @@ class SyncValidator:
 
         # Read content
         try:
-            content = path.read_text()
+            content = path.read_text(encoding="utf-8")
         except Exception as e:
             errors.append(f"Failed to read file: {e}")
             return ValidationResult(

--- a/src/azlin/rust_bridge.py
+++ b/src/azlin/rust_bridge.py
@@ -15,18 +15,30 @@ If none found, attempts (in order):
   3. Exit with error
 """
 
+import copy
+import json
 import os
 import platform
 import shutil
 import stat
 import subprocess
 import sys
+import tarfile
+import tempfile
+import urllib.error
 import urllib.request
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 GITHUB_REPO = "rysweet/azlin"
 MANAGED_BIN_DIR = Path.home() / ".azlin" / "bin"
 MANAGED_BIN = MANAGED_BIN_DIR / "azlin"
+
+# Computed once at import time; used to select tar extraction strategy
+_PY312_PLUS = sys.version_info >= (3, 12)
+
+
+class SecurityError(Exception):
+    """Raised when a security violation is detected during binary installation."""
 
 
 def _platform_suffix() -> str | None:
@@ -80,11 +92,75 @@ def _find_rust_binary() -> str | None:
     return None
 
 
+def _is_release_binary_member(name: str) -> bool:
+    """Return True if the tar member name corresponds to the azlin binary.
+
+    Pure predicate — no I/O.
+    """
+    return name == "azlin" or name.endswith("/azlin")
+
+
+def _validate_release_member(member: tarfile.TarInfo) -> None:
+    """Raise SecurityError if a tar member is unsafe to extract.
+
+    Checks performed:
+    - Absolute path (e.g. /etc/cron.d/evil)
+    - Parent-directory traversal (e.g. ../../usr/bin/evil)
+    - Non-regular-file on Python < 3.12 (symlinks, device files, hard links)
+
+    On Python >= 3.12 filter='data' handles non-regular-file filtering at
+    extraction time, so only path checks are required here.
+    """
+    path = PurePosixPath(member.name)
+
+    if path.is_absolute():
+        raise SecurityError(f"Absolute path in archive: {member.name!r}")
+
+    if ".." in path.parts:
+        raise SecurityError(f"Path traversal in archive: {member.name!r}")
+
+    if not _PY312_PLUS:
+        # filter='data' is unavailable before 3.12 — check member type manually
+        if not member.isfile():
+            raise SecurityError(
+                f"Non-regular-file in archive: {member.name!r} (type={member.type})"
+            )
+
+
+def _extract_release_binary(tmp_path: Path, destination: Path) -> None:
+    """Extract only the azlin binary from a release tarball.
+
+    Validates every member before extraction and normalises the output
+    filename to 'azlin' regardless of the member's name in the archive.
+
+    Raises:
+        SecurityError: If any tar member fails validation or the binary is
+            absent from the archive.
+    """
+    with tarfile.open(tmp_path, "r:gz") as tar:
+        for member in tar.getmembers():
+            if not _is_release_binary_member(member.name):
+                continue
+
+            _validate_release_member(member)
+
+            # Normalise name: always write to destination/azlin regardless of
+            # the member's original name inside the archive (defence-in-depth).
+            safe_member = copy.copy(member)
+            safe_member.name = "azlin"
+
+            if _PY312_PLUS:
+                tar.extract(safe_member, path=str(destination), filter="data")
+            else:
+                tar.extract(safe_member, path=str(destination))
+
+            return  # Successfully extracted exactly one binary — done
+
+    raise SecurityError("azlin binary not found in archive")
+
+
 def _download_from_release() -> str | None:
     """Download pre-built binary from GitHub Releases."""
-    import tarfile
-    import tempfile
-
     suffix = _platform_suffix()
     if not suffix:
         return None
@@ -95,10 +171,8 @@ def _download_from_release() -> str | None:
             api_url, headers={"Accept": "application/vnd.github+json"}
         )  # noqa: S310
         with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310  # nosec B310
-            import json
-
             releases = json.loads(resp.read())
-    except Exception:
+    except (urllib.error.URLError, OSError):
         return None
 
     # Find the latest Rust release asset for this platform
@@ -125,19 +199,15 @@ def _download_from_release() -> str | None:
     sys.stderr.write(
         f"azlin: installing Rust binary v{version} from GitHub Releases...\n"
     )
+    tmp_path = None
     try:
         with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
-            urllib.request.urlretrieve(download_url, tmp.name)  # noqa: S310  # nosec B310
-            tmp_path = tmp.name
+            tmp_path = Path(tmp.name)
 
-        with tarfile.open(tmp_path, "r:gz") as tar:
-            for member in tar.getmembers():
-                if member.name.endswith("/azlin") or member.name == "azlin":
-                    member.name = "azlin"
-                    tar.extract(member, path=str(MANAGED_BIN_DIR))
-                    break
+        urllib.request.urlretrieve(download_url, str(tmp_path))  # noqa: S310  # nosec B310
 
-        os.unlink(tmp_path)
+        # SecurityError propagates uncaught — installation is aborted loudly
+        _extract_release_binary(tmp_path, MANAGED_BIN_DIR)
 
         if MANAGED_BIN.exists():
             MANAGED_BIN.chmod(
@@ -145,8 +215,13 @@ def _download_from_release() -> str | None:
             )
             sys.stderr.write(f"azlin: installed to {MANAGED_BIN}\n")
             return str(MANAGED_BIN)
-    except Exception as e:
+    except (urllib.error.URLError, OSError) as e:
         sys.stderr.write(f"azlin: download failed: {e}\n")
+    finally:
+        # Always clean up the temp file — even if SecurityError is raised
+        if tmp_path is not None and tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+
     return None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Test configuration and path setup.
+
+Adds the repository root to sys.path so that both
+`azlin` (src/azlin/) and `scripts` are importable
+during pytest collection and execution.
+"""
+
+import sys
+from pathlib import Path
+
+# Repository root: tests/ is one level below the root
+REPO_ROOT = Path(__file__).parent.parent
+
+# src/azlin must be on the path for `import azlin`
+_src = str(REPO_ROOT / "src")
+if _src not in sys.path:
+    sys.path.insert(0, _src)
+
+# Repo root must be on the path for `import scripts.cli_documentation`
+_root = str(REPO_ROOT)
+if _root not in sys.path:
+    sys.path.insert(0, _root)

--- a/tests/unit/test_cli_documentation.py
+++ b/tests/unit/test_cli_documentation.py
@@ -1,0 +1,535 @@
+"""Tests for scripts/cli_documentation — issues #878, #879, #880.
+
+Covers:
+- Corrupt-file scenario raises DocumentationError instead of silently returning empty
+- UTF-8 round-trip for non-ASCII content in both hasher and example_manager
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.cli_documentation.example_manager import ExampleManager
+from scripts.cli_documentation.hasher import CLIHasher
+from scripts.cli_documentation.models import (
+    ChangeSet,
+    CommandExample,
+    DocumentationError,
+)
+from scripts.cli_documentation.models import (
+    CLIMetadata as _CLIMetadata,
+)  # used in helpers
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_valid_hash_file(path: Path) -> None:
+    """Write a minimal valid JSON hash file."""
+    path.write_text('{"cmd": "abc123"}', encoding="utf-8")
+
+
+def make_corrupt_hash_file(path: Path) -> None:
+    """Write an invalid JSON hash file."""
+    path.write_text("this is not valid JSON }{", encoding="utf-8")
+
+
+def make_valid_yaml_file(path: Path, title: str = "Example") -> None:
+    """Write a minimal valid YAML examples file."""
+    data = {
+        "command": "test",
+        "examples": [
+            {
+                "title": title,
+                "description": "desc",
+                "command": "azlin test",
+                "output": None,
+            }
+        ],
+    }
+    path.write_text(yaml.dump(data), encoding="utf-8")
+
+
+def make_corrupt_yaml_file(path: Path) -> None:
+    """Write an invalid YAML file."""
+    path.write_text("key: [unclosed bracket", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Issue #878 — error-swallowing: hasher
+# ---------------------------------------------------------------------------
+
+
+class TestHasherCorruptFile:
+    """CLIHasher raises DocumentationError on corrupt hash file (issue #878)."""
+
+    def test_load_hashes_raises_on_corrupt_json(self, tmp_path):
+        """_load_hashes raises DocumentationError when JSON is invalid."""
+        hash_file = tmp_path / ".cli_doc_hashes.json"
+        make_corrupt_hash_file(hash_file)
+
+        with pytest.raises(DocumentationError, match="Failed to load hashes"):
+            CLIHasher(hash_file=str(hash_file))
+
+    def test_load_hashes_succeeds_when_file_missing(self, tmp_path):
+        """_load_hashes returns empty dict silently when file is absent."""
+        hash_file = tmp_path / "nonexistent.json"
+        hasher = CLIHasher(hash_file=str(hash_file))
+        assert hasher._hashes == {}
+
+    def test_save_hashes_raises_on_unwritable_path(self, tmp_path):
+        """save_hashes raises DocumentationError when target path is unwritable."""
+        hash_file = tmp_path / ".cli_doc_hashes.json"
+        hasher = CLIHasher(hash_file=str(hash_file))
+
+        # Make the directory read-only so write fails
+        tmp_path.chmod(0o555)
+        try:
+            with pytest.raises(DocumentationError, match="Failed to save hashes"):
+                hasher.save_hashes()
+        finally:
+            tmp_path.chmod(0o755)  # restore so pytest cleanup works
+
+
+# ---------------------------------------------------------------------------
+# Issue #878 — error-swallowing: example_manager
+# ---------------------------------------------------------------------------
+
+
+class TestExampleManagerCorruptFile:
+    """ExampleManager raises DocumentationError on corrupt YAML file (issue #878)."""
+
+    def test_load_from_file_raises_on_corrupt_yaml(self, tmp_path):
+        """_load_from_file raises DocumentationError when YAML is invalid."""
+        yaml_file = tmp_path / "test.yaml"
+        make_corrupt_yaml_file(yaml_file)
+
+        manager = ExampleManager(examples_dir=str(tmp_path))
+        with pytest.raises(DocumentationError, match="Failed to load examples"):
+            manager._load_from_file(yaml_file)
+
+    def test_load_examples_returns_empty_when_file_missing(self, tmp_path):
+        """load_examples returns [] silently when the file does not exist."""
+        manager = ExampleManager(examples_dir=str(tmp_path))
+        result = manager.load_examples("nofile")
+        assert result == []
+
+    def test_save_examples_raises_on_unwritable_dir(self, tmp_path):
+        """save_examples raises DocumentationError when dir is unwritable."""
+        manager = ExampleManager(examples_dir=str(tmp_path))
+        examples = [CommandExample(title="t", description="d", command="azlin x")]
+
+        tmp_path.chmod(0o555)
+        try:
+            with pytest.raises(DocumentationError, match="Failed to save examples"):
+                manager.save_examples("mount", examples)
+        finally:
+            tmp_path.chmod(0o755)
+
+
+# ---------------------------------------------------------------------------
+# Issue #879 — UTF-8 round-trip: hasher
+# ---------------------------------------------------------------------------
+
+
+class TestHasherUtf8:
+    """CLIHasher reads/writes hash files with explicit UTF-8 encoding (issue #879)."""
+
+    def test_save_and_load_ascii(self, tmp_path):
+        """Round-trip save/load works for ASCII command names."""
+        hash_file = tmp_path / ".cli_doc_hashes.json"
+        hasher = CLIHasher(hash_file=str(hash_file))
+        hasher._hashes = {"my-cmd": "deadbeef"}
+        hasher.save_hashes()
+
+        hasher2 = CLIHasher(hash_file=str(hash_file))
+        assert hasher2._hashes == {"my-cmd": "deadbeef"}
+
+    def test_save_and_load_non_ascii_command_name(self, tmp_path):
+        """Round-trip save/load preserves non-ASCII characters in hash values.
+
+        json.dump escapes non-ASCII as \\uXXXX by default — this is valid UTF-8
+        JSON and the values survive the round-trip intact.
+        """
+        hash_file = tmp_path / ".cli_doc_hashes.json"
+        hasher = CLIHasher(hash_file=str(hash_file))
+        # Non-ASCII in the stored hash value (command names are ASCII in practice,
+        # but the JSON value field can hold any string)
+        hasher._hashes = {"cmd": "café-résumé-hash"}
+        hasher.save_hashes()
+
+        # File is valid UTF-8 JSON (non-ASCII may be \uXXXX-escaped — that's fine)
+        raw = hash_file.read_text(encoding="utf-8")
+        assert "cmd" in raw  # key is present
+
+        # Round-trip: values are preserved exactly
+        hasher2 = CLIHasher(hash_file=str(hash_file))
+        assert hasher2._hashes["cmd"] == "café-résumé-hash"
+
+
+# ---------------------------------------------------------------------------
+# Issue #879 — UTF-8 round-trip: example_manager
+# ---------------------------------------------------------------------------
+
+
+class TestExampleManagerUtf8:
+    """ExampleManager reads/writes YAML files with explicit UTF-8 encoding (issue #879)."""
+
+    def test_save_and_load_ascii_example(self, tmp_path):
+        """Round-trip save/load works for ASCII content."""
+        manager = ExampleManager(examples_dir=str(tmp_path))
+        examples = [
+            CommandExample(
+                title="Basic mount",
+                description="Mounts a storage share",
+                command="azlin mount storage",
+            )
+        ]
+        assert manager.save_examples("mount", examples) is True
+
+        loaded = manager.load_examples("mount")
+        assert len(loaded) == 1
+        assert loaded[0].title == "Basic mount"
+
+    def test_save_and_load_non_ascii_content(self, tmp_path):
+        """Round-trip save/load preserves non-ASCII characters in examples."""
+        manager = ExampleManager(examples_dir=str(tmp_path))
+        examples = [
+            CommandExample(
+                title="Ünïcödé títlé",
+                description="Démonstration avec des caractères spéciaux: 日本語",
+                command="azlin mount storage --label résumé",
+            )
+        ]
+        assert manager.save_examples("mount", examples) is True
+
+        yaml_file = tmp_path / "mount.yaml"
+        raw = yaml_file.read_text(encoding="utf-8")
+        assert "résumé" in raw
+
+        loaded = manager.load_examples("mount")
+        assert len(loaded) == 1
+        assert loaded[0].title == "Ünïcödé títlé"
+        assert "日本語" in loaded[0].description
+
+
+# ---------------------------------------------------------------------------
+# DocumentationError contract
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentationError:
+    """DocumentationError is a proper Exception subclass with chaining support."""
+
+    def test_is_exception_subclass(self):
+        """DocumentationError inherits from Exception so callers can catch it."""
+        err = DocumentationError("something went wrong")
+        assert isinstance(err, Exception)
+
+    def test_message_preserved(self):
+        """String message is accessible via str() / args."""
+        msg = "Failed to load hashes from 'foo.json': [Errno 13] Permission denied"
+        err = DocumentationError(msg)
+        assert msg in str(err)
+
+    def test_exception_chaining(self):
+        """'raise DocumentationError(...) from e' preserves the original cause."""
+        original = OSError("disk full")
+        try:
+            try:
+                raise original
+            except OSError as e:
+                raise DocumentationError("save failed") from e
+        except DocumentationError as doc_err:
+            assert doc_err.__cause__ is original
+
+
+# ---------------------------------------------------------------------------
+# ChangeSet — has_changes property
+# ---------------------------------------------------------------------------
+
+
+class TestChangeSet:
+    """ChangeSet.has_changes reflects any non-empty list."""
+
+    def test_has_changes_false_when_all_empty(self):
+        """Empty ChangeSet reports no changes."""
+        cs = ChangeSet()
+        assert cs.has_changes is False
+
+    def test_has_changes_true_when_changed(self):
+        """A changed command triggers has_changes."""
+        cs = ChangeSet(changed=["mount"])
+        assert cs.has_changes is True
+
+    def test_has_changes_true_when_added(self):
+        """A newly added command triggers has_changes."""
+        cs = ChangeSet(added=["unmount"])
+        assert cs.has_changes is True
+
+    def test_has_changes_true_when_removed(self):
+        """A removed command triggers has_changes."""
+        cs = ChangeSet(removed=["old-cmd"])
+        assert cs.has_changes is True
+
+
+# ---------------------------------------------------------------------------
+# CLIHasher — compute_hash
+# ---------------------------------------------------------------------------
+
+
+def _make_metadata(
+    name: str = "mount",
+    full_path: str = "azlin mount",
+    help_text: str = "Mount a storage share",
+    description: str = "Mounts the specified storage share.",
+) -> _CLIMetadata:
+    """Build a minimal CLIMetadata for hashing tests."""
+    return _CLIMetadata(
+        name=name,
+        full_path=full_path,
+        help_text=help_text,
+        description=description,
+    )
+
+
+class TestHasherComputeHash:
+    """CLIHasher.compute_hash produces correct SHA-256 digests."""
+
+    def test_returns_64_char_hex_string(self, tmp_path):
+        """SHA-256 hex digest is always 64 characters."""
+        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
+        result = hasher.compute_hash(_make_metadata())
+        assert len(result) == 64
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_is_deterministic(self, tmp_path):
+        """Same metadata always produces the same hash."""
+        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
+        meta = _make_metadata()
+        assert hasher.compute_hash(meta) == hasher.compute_hash(meta)
+
+    def test_different_names_produce_different_hashes(self, tmp_path):
+        """Two commands with different names have different hashes."""
+        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
+        h1 = hasher.compute_hash(_make_metadata(name="mount"))
+        h2 = hasher.compute_hash(_make_metadata(name="unmount"))
+        assert h1 != h2
+
+    def test_changes_when_help_text_changes(self, tmp_path):
+        """Changing help_text changes the hash."""
+        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
+        h1 = hasher.compute_hash(_make_metadata(help_text="Mount a share"))
+        h2 = hasher.compute_hash(_make_metadata(help_text="Unmount a share"))
+        assert h1 != h2
+
+    def test_changes_when_description_changes(self, tmp_path):
+        """Changing description changes the hash."""
+        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
+        h1 = hasher.compute_hash(_make_metadata(description="Short desc."))
+        h2 = hasher.compute_hash(_make_metadata(description="Completely different."))
+        assert h1 != h2
+
+
+# ---------------------------------------------------------------------------
+# CLIHasher — has_changed / update_hash
+# ---------------------------------------------------------------------------
+
+
+class TestHasherHasChanged:
+    """CLIHasher.has_changed tracks command mutations correctly."""
+
+    def test_new_command_has_changed(self, tmp_path):
+        """A command with no stored hash is considered changed (new)."""
+        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
+        assert hasher.has_changed(_make_metadata()) is True
+
+    def test_unchanged_after_update_hash(self, tmp_path):
+        """After update_hash, has_changed returns False for the same metadata."""
+        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
+        meta = _make_metadata()
+        hasher.update_hash(meta)
+        assert hasher.has_changed(meta) is False
+
+    def test_changed_after_metadata_modification(self, tmp_path):
+        """has_changed returns True after the command help text is altered."""
+        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
+        original = _make_metadata(help_text="Old help")
+        modified = _make_metadata(help_text="New help")
+        hasher.update_hash(original)
+        assert hasher.has_changed(modified) is True
+
+
+# ---------------------------------------------------------------------------
+# CLIHasher — compare_hashes
+# ---------------------------------------------------------------------------
+
+
+class TestHasherCompareHashes:
+    """CLIHasher.compare_hashes detects added, changed, and removed commands."""
+
+    def test_detects_added_command(self, tmp_path):
+        """Commands absent from stored hashes appear in ChangeSet.added."""
+        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
+        meta = _make_metadata(name="new-cmd")
+        changeset = hasher.compare_hashes({"new-cmd": meta})
+        assert "new-cmd" in changeset.added
+        assert changeset.changed == []
+        assert changeset.removed == []
+
+    def test_detects_removed_command(self, tmp_path):
+        """Commands in stored hashes but absent from current appear in removed."""
+        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
+        meta = _make_metadata(name="old-cmd")
+        hasher.update_hash(meta)
+        changeset = hasher.compare_hashes({})  # command no longer present
+        assert "old-cmd" in changeset.removed
+        assert changeset.added == []
+        assert changeset.changed == []
+
+    def test_detects_changed_command(self, tmp_path):
+        """Commands present in stored hashes but with new content appear in changed."""
+        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
+        original = _make_metadata(name="mount", help_text="Old help")
+        modified = _make_metadata(name="mount", help_text="New help")
+        hasher.update_hash(original)
+        changeset = hasher.compare_hashes({"mount": modified})
+        assert "mount" in changeset.changed
+        assert changeset.added == []
+        assert changeset.removed == []
+
+    def test_no_changes_when_up_to_date(self, tmp_path):
+        """Commands with matching hashes produce an empty ChangeSet."""
+        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
+        meta = _make_metadata(name="mount")
+        hasher.update_hash(meta)
+        changeset = hasher.compare_hashes({"mount": meta})
+        assert changeset.has_changes is False
+
+
+# ---------------------------------------------------------------------------
+# CLIHasher — clear_hashes
+# ---------------------------------------------------------------------------
+
+
+class TestHasherClearHashes:
+    """CLIHasher.clear_hashes wipes in-memory and on-disk state."""
+
+    def test_clear_removes_in_memory_hashes(self, tmp_path):
+        """After clear_hashes, _hashes is empty."""
+        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
+        hasher.update_hash(_make_metadata())
+        hasher.clear_hashes()
+        assert hasher._hashes == {}
+
+    def test_clear_deletes_hash_file(self, tmp_path):
+        """After save then clear, the JSON file no longer exists on disk."""
+        hash_file = tmp_path / "h.json"
+        hasher = CLIHasher(hash_file=str(hash_file))
+        hasher.update_hash(_make_metadata())
+        hasher.save_hashes()
+        assert hash_file.exists()
+        hasher.clear_hashes()
+        assert not hash_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# ExampleManager — _sanitize_command_name
+# ---------------------------------------------------------------------------
+
+
+class TestExampleManagerSanitize:
+    """ExampleManager._sanitize_command_name blocks path-traversal attacks."""
+
+    def test_valid_alphanumeric_name_passes(self, tmp_path):
+        """Plain alphanumeric command names are accepted unchanged."""
+        mgr = ExampleManager(examples_dir=str(tmp_path))
+        assert mgr._sanitize_command_name("mount") == "mount"
+
+    def test_valid_hyphenated_name_passes(self, tmp_path):
+        """Names with hyphens and underscores are accepted."""
+        mgr = ExampleManager(examples_dir=str(tmp_path))
+        assert mgr._sanitize_command_name("storage-mount_v2") == "storage-mount_v2"
+
+    def test_path_traversal_raises_value_error(self, tmp_path):
+        """Path-traversal sequences raise ValueError, not NameError."""
+        mgr = ExampleManager(examples_dir=str(tmp_path))
+        with pytest.raises(ValueError, match="Invalid command name"):
+            mgr._sanitize_command_name("../etc/passwd")
+
+    def test_dot_in_name_raises_value_error(self, tmp_path):
+        """A dot in the command name is rejected (prevents .yaml extension tricks)."""
+        mgr = ExampleManager(examples_dir=str(tmp_path))
+        with pytest.raises(ValueError, match="Invalid command name"):
+            mgr._sanitize_command_name("cmd.evil")
+
+
+# ---------------------------------------------------------------------------
+# ExampleManager — load_examples with invalid command name
+# ---------------------------------------------------------------------------
+
+
+class TestExampleManagerInvalidCommandName:
+    """load_examples with an invalid command name propagates ValueError (#878)."""
+
+    def test_load_examples_path_traversal_raises_value_error(self, tmp_path):
+        """load_examples('../etc/passwd') raises ValueError (no error-swallowing)."""
+        mgr = ExampleManager(examples_dir=str(tmp_path))
+        with pytest.raises(ValueError, match="Invalid command name"):
+            mgr.load_examples("../etc/passwd")
+
+    def test_load_examples_space_in_name_raises_value_error(self, tmp_path):
+        """load_examples('cmd with spaces') raises ValueError."""
+        mgr = ExampleManager(examples_dir=str(tmp_path))
+        with pytest.raises(ValueError, match="Invalid command name"):
+            mgr.load_examples("cmd with spaces")
+
+
+# ---------------------------------------------------------------------------
+# ExampleManager — load_all_examples
+# ---------------------------------------------------------------------------
+
+
+class TestExampleManagerLoadAll:
+    """ExampleManager.load_all_examples scans the examples directory."""
+
+    def test_empty_directory_returns_empty_dict(self, tmp_path):
+        """No YAML files → empty result dict."""
+        mgr = ExampleManager(examples_dir=str(tmp_path))
+        result = mgr.load_all_examples()
+        assert result == {}
+
+    def test_nonexistent_directory_returns_empty_dict(self, tmp_path):
+        """A non-existent directory returns {} without raising."""
+        mgr = ExampleManager(examples_dir=str(tmp_path / "no-such-dir"))
+        result = mgr.load_all_examples()
+        assert result == {}
+
+    def test_loads_multiple_yaml_files(self, tmp_path):
+        """All YAML files in the directory are loaded and keyed by stem."""
+        mgr = ExampleManager(examples_dir=str(tmp_path))
+        examples_a = [
+            CommandExample(title="A", description="desc A", command="azlin a")
+        ]
+        examples_b = [
+            CommandExample(title="B", description="desc B", command="azlin b")
+        ]
+        mgr.save_examples("cmd-a", examples_a)
+        mgr.save_examples("cmd-b", examples_b)
+
+        result = mgr.load_all_examples()
+        assert "cmd-a" in result
+        assert "cmd-b" in result
+        assert result["cmd-a"][0].title == "A"
+        assert result["cmd-b"][0].title == "B"
+
+    def test_corrupt_yaml_propagates_documentation_error(self, tmp_path):
+        """A corrupt YAML file inside the directory raises DocumentationError."""
+        corrupt = tmp_path / "bad.yaml"
+        make_corrupt_yaml_file(corrupt)
+        mgr = ExampleManager(examples_dir=str(tmp_path))
+        with pytest.raises(DocumentationError):
+            mgr.load_all_examples()

--- a/tests/unit/test_cli_documentation.py
+++ b/tests/unit/test_cli_documentation.py
@@ -1,535 +1,809 @@
-"""Tests for scripts/cli_documentation — issues #878, #879, #880.
+"""Tests for CLI documentation subsystem — Issues #878, #879, #880.
 
-Covers:
-- Corrupt-file scenario raises DocumentationError instead of silently returning empty
-- UTF-8 round-trip for non-ASCII content in both hasher and example_manager
+These tests define the contract for the following changes:
+
+    models.py       — adds DocumentationError(Exception)
+    hasher.py       — encoding='utf-8' on all open() calls; FileNotFoundError →
+                      return {}; JSONDecodeError → raise DocumentationError
+    example_manager.py — propagate ValueError from _sanitize_command_name;
+                         validate required 'command' field (raises DocumentationError);
+                         encoding='utf-8' on all open() calls
+    sync_manager.py — narrow except Exception → except DocumentationError;
+                      encoding='utf-8' on write_text()
+    extractor.py    — raise DocumentationError on parse failure (not return None)
+    scripts/__init__.py — package marker (created separately)
+
+All tests in this file will FAIL until DocumentationError exists in models.py
+(the module-level import below raises ImportError until then).  Individual
+tests will continue to fail for behavioural reasons until the full
+implementation is in place.
+
+Design spec refs:
+    SEC-R-08  ValueError from _sanitize_command_name propagates (Issue #878)
+    SEC-R-10  encoding='utf-8' on every open()/write_text() (Issue #879)
+    SEC-R-11  'command' field check: 'command' not in data, not falsy test (Issue #880)
+    SEC-R-12  except DocumentationError only — bugs must not be swallowed
+    SEC-R-14  JSONDecodeError re-raised as DocumentationError (from e)
 """
 
+import json
 from pathlib import Path
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 import yaml
 
+# ---------------------------------------------------------------------------
+# This import will raise ImportError until DocumentationError is added to
+# scripts/cli_documentation/models.py.  Every test in the file therefore
+# fails during collection until the implementation is complete — that is the
+# intended TDD behaviour.
+# ---------------------------------------------------------------------------
+from scripts.cli_documentation.models import (
+    CLIArgument,
+    CLIMetadata,
+    CLIOption,
+    CommandExample,
+    DocumentationError,  # NEW — does not exist yet
+)
 from scripts.cli_documentation.example_manager import ExampleManager
 from scripts.cli_documentation.hasher import CLIHasher
-from scripts.cli_documentation.models import (
-    ChangeSet,
-    CommandExample,
-    DocumentationError,
-)
-from scripts.cli_documentation.models import (
-    CLIMetadata as _CLIMetadata,
-)  # used in helpers
+from scripts.cli_documentation.sync_manager import DocSyncManager
+from scripts.cli_documentation.extractor import CLIExtractor
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Fixtures / helpers
 # ---------------------------------------------------------------------------
 
 
-def make_valid_hash_file(path: Path) -> None:
-    """Write a minimal valid JSON hash file."""
-    path.write_text('{"cmd": "abc123"}', encoding="utf-8")
-
-
-def make_corrupt_hash_file(path: Path) -> None:
-    """Write an invalid JSON hash file."""
-    path.write_text("this is not valid JSON }{", encoding="utf-8")
-
-
-def make_valid_yaml_file(path: Path, title: str = "Example") -> None:
-    """Write a minimal valid YAML examples file."""
-    data = {
-        "command": "test",
-        "examples": [
-            {
-                "title": title,
-                "description": "desc",
-                "command": "azlin test",
-                "output": None,
-            }
-        ],
-    }
-    path.write_text(yaml.dump(data), encoding="utf-8")
-
-
-def make_corrupt_yaml_file(path: Path) -> None:
-    """Write an invalid YAML file."""
-    path.write_text("key: [unclosed bracket", encoding="utf-8")
-
-
-# ---------------------------------------------------------------------------
-# Issue #878 — error-swallowing: hasher
-# ---------------------------------------------------------------------------
-
-
-class TestHasherCorruptFile:
-    """CLIHasher raises DocumentationError on corrupt hash file (issue #878)."""
-
-    def test_load_hashes_raises_on_corrupt_json(self, tmp_path):
-        """_load_hashes raises DocumentationError when JSON is invalid."""
-        hash_file = tmp_path / ".cli_doc_hashes.json"
-        make_corrupt_hash_file(hash_file)
-
-        with pytest.raises(DocumentationError, match="Failed to load hashes"):
-            CLIHasher(hash_file=str(hash_file))
-
-    def test_load_hashes_succeeds_when_file_missing(self, tmp_path):
-        """_load_hashes returns empty dict silently when file is absent."""
-        hash_file = tmp_path / "nonexistent.json"
-        hasher = CLIHasher(hash_file=str(hash_file))
-        assert hasher._hashes == {}
-
-    def test_save_hashes_raises_on_unwritable_path(self, tmp_path):
-        """save_hashes raises DocumentationError when target path is unwritable."""
-        hash_file = tmp_path / ".cli_doc_hashes.json"
-        hasher = CLIHasher(hash_file=str(hash_file))
-
-        # Make the directory read-only so write fails
-        tmp_path.chmod(0o555)
-        try:
-            with pytest.raises(DocumentationError, match="Failed to save hashes"):
-                hasher.save_hashes()
-        finally:
-            tmp_path.chmod(0o755)  # restore so pytest cleanup works
-
-
-# ---------------------------------------------------------------------------
-# Issue #878 — error-swallowing: example_manager
-# ---------------------------------------------------------------------------
-
-
-class TestExampleManagerCorruptFile:
-    """ExampleManager raises DocumentationError on corrupt YAML file (issue #878)."""
-
-    def test_load_from_file_raises_on_corrupt_yaml(self, tmp_path):
-        """_load_from_file raises DocumentationError when YAML is invalid."""
-        yaml_file = tmp_path / "test.yaml"
-        make_corrupt_yaml_file(yaml_file)
-
-        manager = ExampleManager(examples_dir=str(tmp_path))
-        with pytest.raises(DocumentationError, match="Failed to load examples"):
-            manager._load_from_file(yaml_file)
-
-    def test_load_examples_returns_empty_when_file_missing(self, tmp_path):
-        """load_examples returns [] silently when the file does not exist."""
-        manager = ExampleManager(examples_dir=str(tmp_path))
-        result = manager.load_examples("nofile")
-        assert result == []
-
-    def test_save_examples_raises_on_unwritable_dir(self, tmp_path):
-        """save_examples raises DocumentationError when dir is unwritable."""
-        manager = ExampleManager(examples_dir=str(tmp_path))
-        examples = [CommandExample(title="t", description="d", command="azlin x")]
-
-        tmp_path.chmod(0o555)
-        try:
-            with pytest.raises(DocumentationError, match="Failed to save examples"):
-                manager.save_examples("mount", examples)
-        finally:
-            tmp_path.chmod(0o755)
-
-
-# ---------------------------------------------------------------------------
-# Issue #879 — UTF-8 round-trip: hasher
-# ---------------------------------------------------------------------------
-
-
-class TestHasherUtf8:
-    """CLIHasher reads/writes hash files with explicit UTF-8 encoding (issue #879)."""
-
-    def test_save_and_load_ascii(self, tmp_path):
-        """Round-trip save/load works for ASCII command names."""
-        hash_file = tmp_path / ".cli_doc_hashes.json"
-        hasher = CLIHasher(hash_file=str(hash_file))
-        hasher._hashes = {"my-cmd": "deadbeef"}
-        hasher.save_hashes()
-
-        hasher2 = CLIHasher(hash_file=str(hash_file))
-        assert hasher2._hashes == {"my-cmd": "deadbeef"}
-
-    def test_save_and_load_non_ascii_command_name(self, tmp_path):
-        """Round-trip save/load preserves non-ASCII characters in hash values.
-
-        json.dump escapes non-ASCII as \\uXXXX by default — this is valid UTF-8
-        JSON and the values survive the round-trip intact.
-        """
-        hash_file = tmp_path / ".cli_doc_hashes.json"
-        hasher = CLIHasher(hash_file=str(hash_file))
-        # Non-ASCII in the stored hash value (command names are ASCII in practice,
-        # but the JSON value field can hold any string)
-        hasher._hashes = {"cmd": "café-résumé-hash"}
-        hasher.save_hashes()
-
-        # File is valid UTF-8 JSON (non-ASCII may be \uXXXX-escaped — that's fine)
-        raw = hash_file.read_text(encoding="utf-8")
-        assert "cmd" in raw  # key is present
-
-        # Round-trip: values are preserved exactly
-        hasher2 = CLIHasher(hash_file=str(hash_file))
-        assert hasher2._hashes["cmd"] == "café-résumé-hash"
-
-
-# ---------------------------------------------------------------------------
-# Issue #879 — UTF-8 round-trip: example_manager
-# ---------------------------------------------------------------------------
-
-
-class TestExampleManagerUtf8:
-    """ExampleManager reads/writes YAML files with explicit UTF-8 encoding (issue #879)."""
-
-    def test_save_and_load_ascii_example(self, tmp_path):
-        """Round-trip save/load works for ASCII content."""
-        manager = ExampleManager(examples_dir=str(tmp_path))
-        examples = [
-            CommandExample(
-                title="Basic mount",
-                description="Mounts a storage share",
-                command="azlin mount storage",
-            )
-        ]
-        assert manager.save_examples("mount", examples) is True
-
-        loaded = manager.load_examples("mount")
-        assert len(loaded) == 1
-        assert loaded[0].title == "Basic mount"
-
-    def test_save_and_load_non_ascii_content(self, tmp_path):
-        """Round-trip save/load preserves non-ASCII characters in examples."""
-        manager = ExampleManager(examples_dir=str(tmp_path))
-        examples = [
-            CommandExample(
-                title="Ünïcödé títlé",
-                description="Démonstration avec des caractères spéciaux: 日本語",
-                command="azlin mount storage --label résumé",
-            )
-        ]
-        assert manager.save_examples("mount", examples) is True
-
-        yaml_file = tmp_path / "mount.yaml"
-        raw = yaml_file.read_text(encoding="utf-8")
-        assert "résumé" in raw
-
-        loaded = manager.load_examples("mount")
-        assert len(loaded) == 1
-        assert loaded[0].title == "Ünïcödé títlé"
-        assert "日本語" in loaded[0].description
-
-
-# ---------------------------------------------------------------------------
-# DocumentationError contract
-# ---------------------------------------------------------------------------
-
-
-class TestDocumentationError:
-    """DocumentationError is a proper Exception subclass with chaining support."""
-
-    def test_is_exception_subclass(self):
-        """DocumentationError inherits from Exception so callers can catch it."""
-        err = DocumentationError("something went wrong")
-        assert isinstance(err, Exception)
-
-    def test_message_preserved(self):
-        """String message is accessible via str() / args."""
-        msg = "Failed to load hashes from 'foo.json': [Errno 13] Permission denied"
-        err = DocumentationError(msg)
-        assert msg in str(err)
-
-    def test_exception_chaining(self):
-        """'raise DocumentationError(...) from e' preserves the original cause."""
-        original = OSError("disk full")
-        try:
-            try:
-                raise original
-            except OSError as e:
-                raise DocumentationError("save failed") from e
-        except DocumentationError as doc_err:
-            assert doc_err.__cause__ is original
-
-
-# ---------------------------------------------------------------------------
-# ChangeSet — has_changes property
-# ---------------------------------------------------------------------------
-
-
-class TestChangeSet:
-    """ChangeSet.has_changes reflects any non-empty list."""
-
-    def test_has_changes_false_when_all_empty(self):
-        """Empty ChangeSet reports no changes."""
-        cs = ChangeSet()
-        assert cs.has_changes is False
-
-    def test_has_changes_true_when_changed(self):
-        """A changed command triggers has_changes."""
-        cs = ChangeSet(changed=["mount"])
-        assert cs.has_changes is True
-
-    def test_has_changes_true_when_added(self):
-        """A newly added command triggers has_changes."""
-        cs = ChangeSet(added=["unmount"])
-        assert cs.has_changes is True
-
-    def test_has_changes_true_when_removed(self):
-        """A removed command triggers has_changes."""
-        cs = ChangeSet(removed=["old-cmd"])
-        assert cs.has_changes is True
-
-
-# ---------------------------------------------------------------------------
-# CLIHasher — compute_hash
-# ---------------------------------------------------------------------------
-
-
-def _make_metadata(
-    name: str = "mount",
-    full_path: str = "azlin mount",
-    help_text: str = "Mount a storage share",
-    description: str = "Mounts the specified storage share.",
-) -> _CLIMetadata:
-    """Build a minimal CLIMetadata for hashing tests."""
-    return _CLIMetadata(
+def _make_metadata(name: str = "test-cmd", full_path: str = "") -> CLIMetadata:
+    """Return a minimal CLIMetadata for use in tests."""
+    return CLIMetadata(
         name=name,
-        full_path=full_path,
-        help_text=help_text,
-        description=description,
+        full_path=full_path or name,
+        help_text="A test command",
+        description="Detailed description of the test command.",
+        arguments=[CLIArgument(name="env", type="TEXT", required=True)],
+        options=[CLIOption(names=["--verbose", "-v"], type="FLAG", is_flag=True)],
     )
 
 
-class TestHasherComputeHash:
-    """CLIHasher.compute_hash produces correct SHA-256 digests."""
-
-    def test_returns_64_char_hex_string(self, tmp_path):
-        """SHA-256 hex digest is always 64 characters."""
-        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
-        result = hasher.compute_hash(_make_metadata())
-        assert len(result) == 64
-        assert all(c in "0123456789abcdef" for c in result)
-
-    def test_is_deterministic(self, tmp_path):
-        """Same metadata always produces the same hash."""
-        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
-        meta = _make_metadata()
-        assert hasher.compute_hash(meta) == hasher.compute_hash(meta)
-
-    def test_different_names_produce_different_hashes(self, tmp_path):
-        """Two commands with different names have different hashes."""
-        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
-        h1 = hasher.compute_hash(_make_metadata(name="mount"))
-        h2 = hasher.compute_hash(_make_metadata(name="unmount"))
-        assert h1 != h2
-
-    def test_changes_when_help_text_changes(self, tmp_path):
-        """Changing help_text changes the hash."""
-        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
-        h1 = hasher.compute_hash(_make_metadata(help_text="Mount a share"))
-        h2 = hasher.compute_hash(_make_metadata(help_text="Unmount a share"))
-        assert h1 != h2
-
-    def test_changes_when_description_changes(self, tmp_path):
-        """Changing description changes the hash."""
-        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
-        h1 = hasher.compute_hash(_make_metadata(description="Short desc."))
-        h2 = hasher.compute_hash(_make_metadata(description="Completely different."))
-        assert h1 != h2
+def _write_yaml(path: Path, data: dict) -> None:
+    """Write *data* as YAML to *path* using UTF-8."""
+    path.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
 
 
-# ---------------------------------------------------------------------------
-# CLIHasher — has_changed / update_hash
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# GROUP 1 — DocumentationError (3 tests)
+# ===========================================================================
 
 
-class TestHasherHasChanged:
-    """CLIHasher.has_changed tracks command mutations correctly."""
+class TestDocumentationError:
+    """DocumentationError must be a typed domain exception in models.py."""
 
-    def test_new_command_has_changed(self, tmp_path):
-        """A command with no stored hash is considered changed (new)."""
-        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
-        assert hasher.has_changed(_make_metadata()) is True
+    def test_is_exception_subclass(self) -> None:
+        """DocumentationError must inherit from Exception so it can be caught
+        with 'except DocumentationError' or 'except Exception'."""
+        assert issubclass(DocumentationError, Exception), (
+            "DocumentationError must be a subclass of Exception"
+        )
 
-    def test_unchanged_after_update_hash(self, tmp_path):
-        """After update_hash, has_changed returns False for the same metadata."""
-        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
-        meta = _make_metadata()
-        hasher.update_hash(meta)
-        assert hasher.has_changed(meta) is False
+    def test_can_be_raised_with_message(self) -> None:
+        """DocumentationError must accept a message string and expose it via str()."""
+        msg = "corrupt JSON in .cli_doc_hashes.json"
+        with pytest.raises(DocumentationError) as exc_info:
+            raise DocumentationError(msg)
+        assert msg in str(exc_info.value)
 
-    def test_changed_after_metadata_modification(self, tmp_path):
-        """has_changed returns True after the command help text is altered."""
-        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
-        original = _make_metadata(help_text="Old help")
-        modified = _make_metadata(help_text="New help")
-        hasher.update_hash(original)
-        assert hasher.has_changed(modified) is True
+    def test_exported_in_models_all(self) -> None:
+        """DocumentationError must be listed in models.__all__ so callers can
+        do 'from scripts.cli_documentation.models import DocumentationError'."""
+        import scripts.cli_documentation.models as models_module
 
-
-# ---------------------------------------------------------------------------
-# CLIHasher — compare_hashes
-# ---------------------------------------------------------------------------
-
-
-class TestHasherCompareHashes:
-    """CLIHasher.compare_hashes detects added, changed, and removed commands."""
-
-    def test_detects_added_command(self, tmp_path):
-        """Commands absent from stored hashes appear in ChangeSet.added."""
-        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
-        meta = _make_metadata(name="new-cmd")
-        changeset = hasher.compare_hashes({"new-cmd": meta})
-        assert "new-cmd" in changeset.added
-        assert changeset.changed == []
-        assert changeset.removed == []
-
-    def test_detects_removed_command(self, tmp_path):
-        """Commands in stored hashes but absent from current appear in removed."""
-        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
-        meta = _make_metadata(name="old-cmd")
-        hasher.update_hash(meta)
-        changeset = hasher.compare_hashes({})  # command no longer present
-        assert "old-cmd" in changeset.removed
-        assert changeset.added == []
-        assert changeset.changed == []
-
-    def test_detects_changed_command(self, tmp_path):
-        """Commands present in stored hashes but with new content appear in changed."""
-        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
-        original = _make_metadata(name="mount", help_text="Old help")
-        modified = _make_metadata(name="mount", help_text="New help")
-        hasher.update_hash(original)
-        changeset = hasher.compare_hashes({"mount": modified})
-        assert "mount" in changeset.changed
-        assert changeset.added == []
-        assert changeset.removed == []
-
-    def test_no_changes_when_up_to_date(self, tmp_path):
-        """Commands with matching hashes produce an empty ChangeSet."""
-        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
-        meta = _make_metadata(name="mount")
-        hasher.update_hash(meta)
-        changeset = hasher.compare_hashes({"mount": meta})
-        assert changeset.has_changes is False
+        assert hasattr(models_module, "__all__"), "models.py must define __all__"
+        assert "DocumentationError" in models_module.__all__, (
+            "DocumentationError must be in models.__all__"
+        )
 
 
-# ---------------------------------------------------------------------------
-# CLIHasher — clear_hashes
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# GROUP 2 — CLIHasher JSON error handling (9 tests)
+# ===========================================================================
 
 
-class TestHasherClearHashes:
-    """CLIHasher.clear_hashes wipes in-memory and on-disk state."""
+class TestCLIHasherErrorHandling:
+    """CLIHasher must distinguish FileNotFoundError from JSONDecodeError and
+    must use encoding='utf-8' on every file operation (Issues #879, #880)."""
 
-    def test_clear_removes_in_memory_hashes(self, tmp_path):
-        """After clear_hashes, _hashes is empty."""
-        hasher = CLIHasher(hash_file=str(tmp_path / "h.json"))
-        hasher.update_hash(_make_metadata())
-        hasher.clear_hashes()
-        assert hasher._hashes == {}
+    def test_corrupt_json_raises_documentation_error(self, tmp_path: Path) -> None:
+        """When the hash file contains malformed JSON, _load_hashes() must
+        raise DocumentationError (not silently return an empty dict).
 
-    def test_clear_deletes_hash_file(self, tmp_path):
-        """After save then clear, the JSON file no longer exists on disk."""
-        hash_file = tmp_path / "h.json"
-        hasher = CLIHasher(hash_file=str(hash_file))
-        hasher.update_hash(_make_metadata())
-        hasher.save_hashes()
-        assert hash_file.exists()
-        hasher.clear_hashes()
-        assert not hash_file.exists()
+        Rationale: corrupt hash files indicate storage problems; swallowing
+        the error causes silent full-regeneration on every run.
+        """
+        hash_file = tmp_path / "hashes.json"
+        hash_file.write_text("{ this is not valid json }", encoding="utf-8")
 
-
-# ---------------------------------------------------------------------------
-# ExampleManager — _sanitize_command_name
-# ---------------------------------------------------------------------------
-
-
-class TestExampleManagerSanitize:
-    """ExampleManager._sanitize_command_name blocks path-traversal attacks."""
-
-    def test_valid_alphanumeric_name_passes(self, tmp_path):
-        """Plain alphanumeric command names are accepted unchanged."""
-        mgr = ExampleManager(examples_dir=str(tmp_path))
-        assert mgr._sanitize_command_name("mount") == "mount"
-
-    def test_valid_hyphenated_name_passes(self, tmp_path):
-        """Names with hyphens and underscores are accepted."""
-        mgr = ExampleManager(examples_dir=str(tmp_path))
-        assert mgr._sanitize_command_name("storage-mount_v2") == "storage-mount_v2"
-
-    def test_path_traversal_raises_value_error(self, tmp_path):
-        """Path-traversal sequences raise ValueError, not NameError."""
-        mgr = ExampleManager(examples_dir=str(tmp_path))
-        with pytest.raises(ValueError, match="Invalid command name"):
-            mgr._sanitize_command_name("../etc/passwd")
-
-    def test_dot_in_name_raises_value_error(self, tmp_path):
-        """A dot in the command name is rejected (prevents .yaml extension tricks)."""
-        mgr = ExampleManager(examples_dir=str(tmp_path))
-        with pytest.raises(ValueError, match="Invalid command name"):
-            mgr._sanitize_command_name("cmd.evil")
-
-
-# ---------------------------------------------------------------------------
-# ExampleManager — load_examples with invalid command name
-# ---------------------------------------------------------------------------
-
-
-class TestExampleManagerInvalidCommandName:
-    """load_examples with an invalid command name propagates ValueError (#878)."""
-
-    def test_load_examples_path_traversal_raises_value_error(self, tmp_path):
-        """load_examples('../etc/passwd') raises ValueError (no error-swallowing)."""
-        mgr = ExampleManager(examples_dir=str(tmp_path))
-        with pytest.raises(ValueError, match="Invalid command name"):
-            mgr.load_examples("../etc/passwd")
-
-    def test_load_examples_space_in_name_raises_value_error(self, tmp_path):
-        """load_examples('cmd with spaces') raises ValueError."""
-        mgr = ExampleManager(examples_dir=str(tmp_path))
-        with pytest.raises(ValueError, match="Invalid command name"):
-            mgr.load_examples("cmd with spaces")
-
-
-# ---------------------------------------------------------------------------
-# ExampleManager — load_all_examples
-# ---------------------------------------------------------------------------
-
-
-class TestExampleManagerLoadAll:
-    """ExampleManager.load_all_examples scans the examples directory."""
-
-    def test_empty_directory_returns_empty_dict(self, tmp_path):
-        """No YAML files → empty result dict."""
-        mgr = ExampleManager(examples_dir=str(tmp_path))
-        result = mgr.load_all_examples()
-        assert result == {}
-
-    def test_nonexistent_directory_returns_empty_dict(self, tmp_path):
-        """A non-existent directory returns {} without raising."""
-        mgr = ExampleManager(examples_dir=str(tmp_path / "no-such-dir"))
-        result = mgr.load_all_examples()
-        assert result == {}
-
-    def test_loads_multiple_yaml_files(self, tmp_path):
-        """All YAML files in the directory are loaded and keyed by stem."""
-        mgr = ExampleManager(examples_dir=str(tmp_path))
-        examples_a = [
-            CommandExample(title="A", description="desc A", command="azlin a")
-        ]
-        examples_b = [
-            CommandExample(title="B", description="desc B", command="azlin b")
-        ]
-        mgr.save_examples("cmd-a", examples_a)
-        mgr.save_examples("cmd-b", examples_b)
-
-        result = mgr.load_all_examples()
-        assert "cmd-a" in result
-        assert "cmd-b" in result
-        assert result["cmd-a"][0].title == "A"
-        assert result["cmd-b"][0].title == "B"
-
-    def test_corrupt_yaml_propagates_documentation_error(self, tmp_path):
-        """A corrupt YAML file inside the directory raises DocumentationError."""
-        corrupt = tmp_path / "bad.yaml"
-        make_corrupt_yaml_file(corrupt)
-        mgr = ExampleManager(examples_dir=str(tmp_path))
         with pytest.raises(DocumentationError):
-            mgr.load_all_examples()
+            CLIHasher(str(hash_file))
+
+    def test_missing_file_returns_empty_dict(self, tmp_path: Path) -> None:
+        """When the hash file does not exist, CLIHasher must initialise with
+        an empty hash dict — this is normal first-run behaviour."""
+        hash_file = tmp_path / "does_not_exist.json"
+        hasher = CLIHasher(str(hash_file))
+        assert hasher._hashes == {}, (
+            "Missing hash file must yield an empty hash dict, not an exception"
+        )
+
+    def test_file_not_found_does_not_raise(self, tmp_path: Path) -> None:
+        """FileNotFoundError during load must NOT raise DocumentationError.
+        It must be treated as an empty store (normal first-run)."""
+        hash_file = tmp_path / "nonexistent.json"
+        # Must not raise any exception
+        hasher = CLIHasher(str(hash_file))
+        assert isinstance(hasher._hashes, dict)
+
+    def test_json_decode_error_chains_to_documentation_error(
+        self, tmp_path: Path
+    ) -> None:
+        """JSONDecodeError must be re-raised as DocumentationError with the
+        original exception chained ('raise DocumentationError(...) from e').
+
+        SEC-R-14: chaining preserves the original traceback for debugging.
+        """
+        hash_file = tmp_path / "bad.json"
+        hash_file.write_text("[[[invalid", encoding="utf-8")
+
+        with pytest.raises(DocumentationError) as exc_info:
+            CLIHasher(str(hash_file))
+
+        assert exc_info.value.__cause__ is not None, (
+            "DocumentationError must chain the original JSONDecodeError via 'from e'"
+        )
+        assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)
+
+    def test_save_uses_utf8_encoding(self, tmp_path: Path) -> None:
+        """save_hashes() must open the output file with encoding='utf-8'.
+
+        SEC-R-10: on systems where the default locale is not UTF-8
+        (e.g., Windows cp1252), omitting encoding causes silent data corruption.
+        """
+        hash_file = tmp_path / "hashes.json"
+        hasher = CLIHasher(str(hash_file))
+        metadata = _make_metadata()
+        hasher.update_hash(metadata)
+
+        # Patch open() and verify encoding='utf-8' is passed
+        original_open = open
+
+        calls_seen: list = []
+
+        def capturing_open(file, mode="r", **kwargs):
+            calls_seen.append((str(file), mode, kwargs))
+            return original_open(file, mode, **kwargs)
+
+        with patch("builtins.open", side_effect=capturing_open):
+            hasher.save_hashes()
+
+        write_calls = [c for c in calls_seen if "w" in c[1]]
+        assert write_calls, "save_hashes() must call open() in write mode"
+        for _, _, kwargs in write_calls:
+            assert kwargs.get("encoding") == "utf-8", (
+                f"save_hashes() open() call missing encoding='utf-8': {kwargs}"
+            )
+
+    def test_load_handles_utf8_content(self, tmp_path: Path) -> None:
+        """_load_hashes() must correctly read a UTF-8 encoded hash file."""
+        hash_file = tmp_path / "hashes.json"
+        content = {"café": "abc123", "naïve": "def456"}
+        hash_file.write_text(json.dumps(content), encoding="utf-8")
+
+        hasher = CLIHasher(str(hash_file))
+        assert hasher._hashes == content
+
+    def test_unicode_hash_roundtrip(self, tmp_path: Path) -> None:
+        """A command with Unicode in its help text must survive a
+        save→load round-trip with identical hash values."""
+        hash_file = tmp_path / "hashes.json"
+        hasher = CLIHasher(str(hash_file))
+
+        meta = CLIMetadata(
+            name="café",
+            full_path="café",
+            help_text="Manages the café ☕ resources",
+            description="Détails complets pour café.",
+        )
+        hasher.update_hash(meta)
+        original_hash = hasher._hashes["café"]
+        hasher.save_hashes()
+
+        # Reload from disk
+        hasher2 = CLIHasher(str(hash_file))
+        assert hasher2._hashes.get("café") == original_hash, (
+            "Hash must survive UTF-8 save/load round-trip"
+        )
+
+    def test_os_error_on_save_raises_documentation_error(self, tmp_path: Path) -> None:
+        """If open() raises OSError during save_hashes(), the error must
+        be re-raised as DocumentationError (not silently return False).
+
+        Rationale: a failure to persist hashes means the next run will do
+        a full regeneration — this should be surfaced, not swallowed.
+        """
+        hash_file = tmp_path / "hashes.json"
+        hasher = CLIHasher(str(hash_file))
+        hasher.update_hash(_make_metadata())
+
+        with patch("builtins.open", side_effect=OSError("disk full")):
+            with pytest.raises(DocumentationError):
+                hasher.save_hashes()
+
+    def test_valid_json_loads_correctly(self, tmp_path: Path) -> None:
+        """A well-formed hash file must be loaded into _hashes without error."""
+        data = {"mount": "a" * 64, "list": "b" * 64}
+        hash_file = tmp_path / "hashes.json"
+        hash_file.write_text(json.dumps(data), encoding="utf-8")
+
+        hasher = CLIHasher(str(hash_file))
+        assert hasher._hashes == data
+
+
+# ===========================================================================
+# GROUP 3 — ExampleManager encoding and validation (16 tests)
+# ===========================================================================
+
+
+class TestExampleManagerValidation:
+    """ExampleManager must validate the 'command' field, propagate ValueError,
+    and use encoding='utf-8' on all file operations (Issues #878, #879, #880)."""
+
+    # ------------------------------------------------------------------ #
+    # 'command' field validation — SEC-R-11                               #
+    # ------------------------------------------------------------------ #
+
+    def test_missing_command_field_raises_documentation_error(
+        self, tmp_path: Path
+    ) -> None:
+        """_load_from_file() must raise DocumentationError when an example
+        entry is missing the required 'command' field.
+
+        SEC-R-11: each CommandExample in the examples list must have a
+        non-empty 'command' string; absent key must raise DocumentationError.
+        """
+        yaml_file = tmp_path / "mount.yaml"
+        _write_yaml(
+            yaml_file,
+            {
+                "command": "mount",  # top-level command key is present and valid
+                "examples": [
+                    # 'command' key intentionally absent from this example entry
+                    {"title": "Basic", "description": "test"}
+                ],
+            },
+        )
+
+        manager = ExampleManager(str(tmp_path))
+        with pytest.raises(DocumentationError, match="command"):
+            manager._load_from_file(yaml_file)
+
+    def test_empty_command_field_raises_documentation_error(
+        self, tmp_path: Path
+    ) -> None:
+        """_load_from_file() must raise DocumentationError when an example's
+        'command' field is an empty string.
+
+        SEC-R-11: empty string '' is a distinct invalid state that must be
+        caught (not just missing keys).
+        """
+        yaml_file = tmp_path / "mount.yaml"
+        _write_yaml(
+            yaml_file,
+            {
+                "command": "mount",
+                "examples": [
+                    # 'command' present but empty string — invalid
+                    {"title": "Basic", "description": "test", "command": ""}
+                ],
+            },
+        )
+
+        manager = ExampleManager(str(tmp_path))
+        with pytest.raises(DocumentationError):
+            manager._load_from_file(yaml_file)
+
+    def test_none_command_field_raises_documentation_error(
+        self, tmp_path: Path
+    ) -> None:
+        """_load_from_file() must raise DocumentationError when an example's
+        'command' field is explicitly None."""
+        yaml_file = tmp_path / "mount.yaml"
+        _write_yaml(
+            yaml_file,
+            {
+                "command": "mount",
+                "examples": [
+                    # 'command' present but None — invalid
+                    {"title": "Basic", "description": "test", "command": None}
+                ],
+            },
+        )
+
+        manager = ExampleManager(str(tmp_path))
+        with pytest.raises(DocumentationError):
+            manager._load_from_file(yaml_file)
+
+    def test_present_command_field_succeeds(self, tmp_path: Path) -> None:
+        """When 'command' is present and non-empty, _load_from_file() must
+        return a list of CommandExample objects without raising."""
+        yaml_file = tmp_path / "mount.yaml"
+        _write_yaml(
+            yaml_file,
+            {
+                "command": "mount",
+                "examples": [
+                    {
+                        "title": "Basic mount",
+                        "description": "Mount a storage volume",
+                        "command": "azlin mount my-storage",
+                        "output": "Mounted successfully",
+                    }
+                ],
+            },
+        )
+
+        manager = ExampleManager(str(tmp_path))
+        examples = manager._load_from_file(yaml_file)
+
+        assert len(examples) == 1
+        assert examples[0].title == "Basic mount"
+        assert examples[0].command == "azlin mount my-storage"
+
+    # ------------------------------------------------------------------ #
+    # Encoding — SEC-R-10                                                 #
+    # ------------------------------------------------------------------ #
+
+    def test_load_uses_utf8_encoding(self, tmp_path: Path) -> None:
+        """_load_from_file() must open YAML files with encoding='utf-8'.
+
+        SEC-R-10: on Windows with a non-UTF-8 locale, omitting encoding
+        causes silent data corruption that invalidates SHA-256 hashes.
+        """
+        yaml_file = tmp_path / "mount.yaml"
+        _write_yaml(yaml_file, {"command": "mount", "examples": []})
+
+        manager = ExampleManager(str(tmp_path))
+        original_open = open
+        calls_seen: list = []
+
+        def capturing_open(file, mode="r", **kwargs):
+            calls_seen.append((str(file), mode, kwargs))
+            return original_open(file, mode, **kwargs)
+
+        with patch("builtins.open", side_effect=capturing_open):
+            manager._load_from_file(yaml_file)
+
+        read_calls = [c for c in calls_seen if "r" in c[1] or ("w" not in c[1])]
+        assert read_calls, "_load_from_file must call open()"
+        for _, _, kwargs in read_calls:
+            assert kwargs.get("encoding") == "utf-8", (
+                f"_load_from_file open() call missing encoding='utf-8': {kwargs}"
+            )
+
+    def test_save_uses_utf8_encoding(self, tmp_path: Path) -> None:
+        """save_examples() must open the output YAML file with encoding='utf-8'."""
+        manager = ExampleManager(str(tmp_path))
+        examples = [
+            CommandExample(
+                title="Basic",
+                description="A test example",
+                command="azlin mount x",
+            )
+        ]
+
+        original_open = open
+        calls_seen: list = []
+
+        def capturing_open(file, mode="r", **kwargs):
+            calls_seen.append((str(file), mode, kwargs))
+            return original_open(file, mode, **kwargs)
+
+        with patch("builtins.open", side_effect=capturing_open):
+            manager.save_examples("mount", examples)
+
+        write_calls = [c for c in calls_seen if "w" in c[1]]
+        assert write_calls, "save_examples must call open() in write mode"
+        for _, _, kwargs in write_calls:
+            assert kwargs.get("encoding") == "utf-8", (
+                f"save_examples open() call missing encoding='utf-8': {kwargs}"
+            )
+
+    def test_unicode_roundtrip(self, tmp_path: Path) -> None:
+        """A command example with Unicode characters in its fields must survive
+        a save_examples → load_examples round-trip unchanged.
+
+        SEC-R-10: encoding='utf-8' is required so multi-byte Unicode code
+        points are not corrupted on systems with non-UTF-8 default encodings.
+
+        Note: command *names* must be ASCII (alphanumeric/dash/underscore per
+        _sanitize_command_name). Only the example *content* can be Unicode.
+        """
+        manager = ExampleManager(str(tmp_path))
+        examples = [
+            CommandExample(
+                title="Créer un café ☕",
+                description="Démonstration de l'encodage UTF-8",
+                command="azlin utf8-cmd --option valeur",  # command string (Unicode OK)
+                output="Résultat: ✓",
+            )
+        ]
+        # Command name must be ASCII-safe; use a plain ASCII name
+        assert manager.save_examples("utf8-cmd", examples), (
+            "save_examples must return True"
+        )
+
+        loaded = manager.load_examples("utf8-cmd")
+        assert len(loaded) == 1
+        assert loaded[0].title == "Créer un café ☕"
+        assert loaded[0].output == "Résultat: ✓"
+
+    # ------------------------------------------------------------------ #
+    # ValueError propagation — SEC-R-08 / Issue #878                     #
+    # ------------------------------------------------------------------ #
+
+    def test_load_examples_propagates_value_error(self, tmp_path: Path) -> None:
+        """load_examples() must NOT catch ValueError from _sanitize_command_name.
+
+        SEC-R-08: the current code silently returns [] when the command name is
+        invalid; after the fix, ValueError propagates to the caller so the
+        invalid name is surfaced immediately.
+        """
+        manager = ExampleManager(str(tmp_path))
+        # '../etc/passwd' contains '/' which is not in [a-zA-Z0-9_-]
+        with pytest.raises(ValueError):
+            manager.load_examples("../etc/passwd")
+
+    def test_sanitize_traversal_raises_value_error(self) -> None:
+        """_sanitize_command_name must raise ValueError for names with path
+        separator characters or other invalid characters."""
+        manager = ExampleManager("/tmp")
+        invalid_names = [
+            "../etc/passwd",
+            "foo/bar",
+            "cmd; rm -rf /",
+            "name with spaces",
+            "name\x00null",
+        ]
+        for name in invalid_names:
+            with pytest.raises(ValueError, match="Invalid command name"):
+                manager._sanitize_command_name(name)
+
+    def test_sanitize_valid_name_passes(self) -> None:
+        """_sanitize_command_name must return valid names unchanged."""
+        manager = ExampleManager("/tmp")
+        valid_names = ["mount", "list-vms", "create_vm", "VM123", "a-b-c_1"]
+        for name in valid_names:
+            result = manager._sanitize_command_name(name)
+            assert result == name, f"Sanitize should pass through valid name '{name}'"
+
+    # ------------------------------------------------------------------ #
+    # YAML safety                                                         #
+    # ------------------------------------------------------------------ #
+
+    def test_yaml_safe_load_rejects_python_objects(self, tmp_path: Path) -> None:
+        """yaml.safe_load() must reject !!python/object tags.
+
+        This confirms yaml.safe_load() is used (not yaml.load()) so that
+        YAML deserialization cannot execute arbitrary Python code.
+        """
+        malicious_yaml = """
+command: mount
+examples:
+  - !!python/object/apply:os.system ["echo pwned"]
+"""
+        yaml_file = tmp_path / "mount.yaml"
+        yaml_file.write_text(malicious_yaml, encoding="utf-8")
+
+        manager = ExampleManager(str(tmp_path))
+        # safe_load raises yaml.constructor.ConstructorError or DocumentationError
+        with pytest.raises((yaml.constructor.ConstructorError, DocumentationError)):
+            manager._load_from_file(yaml_file)
+
+    def test_corrupt_yaml_raises_documentation_error(self, tmp_path: Path) -> None:
+        """_load_from_file() must raise DocumentationError when the YAML
+        cannot be parsed (malformed syntax), rather than silently returning [].
+
+        This surfaces storage corruption or incomplete writes early.
+        """
+        yaml_file = tmp_path / "mount.yaml"
+        yaml_file.write_text(": broken: yaml: content: [", encoding="utf-8")
+
+        manager = ExampleManager(str(tmp_path))
+        with pytest.raises(DocumentationError):
+            manager._load_from_file(yaml_file)
+
+    # ------------------------------------------------------------------ #
+    # Graceful handling for missing / empty files                         #
+    # ------------------------------------------------------------------ #
+
+    def test_nonexistent_file_returns_empty_list(self, tmp_path: Path) -> None:
+        """_load_from_file() with a non-existent path must return []
+        (FileNotFoundError is treated as 'no examples')."""
+        yaml_file = tmp_path / "does_not_exist.yaml"
+        manager = ExampleManager(str(tmp_path))
+        # Should not raise; returns empty list
+        result = manager._load_from_file(yaml_file)
+        assert result == []
+
+    def test_no_examples_key_returns_empty_list(self, tmp_path: Path) -> None:
+        """A valid YAML file with a 'command' key but no 'examples' key
+        must return an empty list without raising."""
+        yaml_file = tmp_path / "mount.yaml"
+        _write_yaml(yaml_file, {"command": "mount", "metadata": {"version": 1}})
+
+        manager = ExampleManager(str(tmp_path))
+        result = manager._load_from_file(yaml_file)
+        assert result == []
+
+    def test_save_invalid_command_name_raises_value_error(self, tmp_path: Path) -> None:
+        """save_examples() must raise ValueError when the command name
+        fails _sanitize_command_name validation."""
+        manager = ExampleManager(str(tmp_path))
+        examples = [CommandExample(title="t", description="d", command="azlin x")]
+        with pytest.raises(ValueError):
+            manager.save_examples("../bad", examples)
+
+    def test_load_all_from_empty_dir_returns_empty_dict(self, tmp_path: Path) -> None:
+        """load_all_examples() on an empty directory must return {}."""
+        empty_dir = tmp_path / "examples"
+        empty_dir.mkdir()
+        manager = ExampleManager(str(empty_dir))
+        result = manager.load_all_examples()
+        assert result == {}
+
+
+# ===========================================================================
+# GROUP 4 — DocSyncManager exception narrowing and encoding (8 tests)
+# ===========================================================================
+
+
+class TestDocSyncManagerExceptionNarrowing:
+    """DocSyncManager.sync_command() must catch DocumentationError only;
+    unexpected exceptions (AttributeError, TypeError, etc.) must propagate.
+    write_text() must use encoding='utf-8'. (Issue #879, SEC-R-12)"""
+
+    def test_documentation_error_caught_in_sync_command(self, tmp_path: Path) -> None:
+        """When example_manager.load_examples() raises DocumentationError,
+        sync_command() must catch it and return a SyncResult with error set."""
+        manager = DocSyncManager(output_dir=str(tmp_path))
+        metadata = _make_metadata()
+
+        with patch.object(
+            manager.example_manager,
+            "load_examples",
+            side_effect=DocumentationError("corrupt YAML"),
+        ):
+            result = manager.sync_command(metadata, validate=False)
+
+        assert not result.success, (
+            "SyncResult.success must be False on DocumentationError"
+        )
+        assert result.error is not None
+        assert "corrupt YAML" in result.error
+
+    def test_attribute_error_propagates(self, tmp_path: Path) -> None:
+        """AttributeError inside sync_command() must NOT be caught.
+
+        SEC-R-12: AttributeError indicates a programming bug; swallowing it
+        hides defects and makes debugging impossible.
+        """
+        manager = DocSyncManager(output_dir=str(tmp_path))
+        metadata = _make_metadata()
+
+        with patch.object(
+            manager.example_manager,
+            "load_examples",
+            side_effect=AttributeError("unexpected bug"),
+        ):
+            with pytest.raises(AttributeError):
+                manager.sync_command(metadata, validate=False)
+
+    def test_type_error_propagates(self, tmp_path: Path) -> None:
+        """TypeError inside sync_command() must NOT be caught.
+
+        SEC-R-12: unexpected exception types must propagate to expose bugs.
+        """
+        manager = DocSyncManager(output_dir=str(tmp_path))
+        metadata = _make_metadata()
+
+        with patch.object(
+            manager.generator,
+            "generate",
+            side_effect=TypeError("wrong type"),
+        ):
+            with patch.object(
+                manager.example_manager, "load_examples", return_value=[]
+            ):
+                with pytest.raises(TypeError):
+                    manager.sync_command(metadata, validate=False)
+
+    def test_write_text_uses_utf8(self, tmp_path: Path) -> None:
+        """The output markdown file must be written with encoding='utf-8'.
+
+        SEC-R-10: write_text() without encoding uses the system default,
+        which on Windows is cp1252, silently corrupting non-ASCII content.
+        """
+        manager = DocSyncManager(output_dir=str(tmp_path))
+        metadata = _make_metadata()
+
+        write_text_calls: list = []
+        original_write_text = Path.write_text
+
+        def capturing_write_text(self_path, data, **kwargs):
+            write_text_calls.append((str(self_path), kwargs))
+            return original_write_text(self_path, data, **kwargs)
+
+        with patch.object(manager.example_manager, "load_examples", return_value=[]):
+            with patch.object(
+                manager.generator, "generate", return_value="# test\n## Usage\n"
+            ):
+                with patch.object(Path, "write_text", capturing_write_text):
+                    manager.sync_command(metadata, validate=False)
+
+        assert write_text_calls, "sync_command must call write_text()"
+        for path_str, kwargs in write_text_calls:
+            assert kwargs.get("encoding") == "utf-8", (
+                f"write_text() for '{path_str}' missing encoding='utf-8': {kwargs}"
+            )
+
+    def test_get_output_path_simple_command(self, tmp_path: Path) -> None:
+        """Simple (non-nested) command names yield output_dir/<name>.md."""
+        manager = DocSyncManager(output_dir=str(tmp_path))
+        metadata = _make_metadata(name="list", full_path="list")
+        output_path = manager._get_output_path(metadata)
+        assert output_path == tmp_path / "list.md"
+
+    def test_get_output_path_traversal_rejected(self, tmp_path: Path) -> None:
+        """Path components with non-alnum/dash/underscore chars must raise ValueError."""
+        manager = DocSyncManager(output_dir=str(tmp_path))
+        metadata = _make_metadata(name="../evil", full_path="../evil")
+        with pytest.raises(ValueError):
+            manager._get_output_path(metadata)
+
+    def test_get_output_path_nested_command(self, tmp_path: Path) -> None:
+        """Nested commands (space-separated full_path) yield a subdirectory."""
+        manager = DocSyncManager(output_dir=str(tmp_path))
+        metadata = _make_metadata(name="mount", full_path="storage mount")
+        output_path = manager._get_output_path(metadata)
+        assert output_path == tmp_path / "storage" / "mount.md"
+
+    def test_sync_result_has_error_on_documentation_error(self, tmp_path: Path) -> None:
+        """SyncResult.error must contain the DocumentationError message and
+        SyncResult.success must be False when a DocumentationError is raised."""
+        manager = DocSyncManager(output_dir=str(tmp_path))
+        metadata = _make_metadata()
+
+        error_msg = "hash file is corrupt"
+        with patch.object(
+            manager.example_manager,
+            "load_examples",
+            side_effect=DocumentationError(error_msg),
+        ):
+            result = manager.sync_command(metadata, validate=False)
+
+        assert result.success is False
+        assert error_msg in (result.error or ""), (
+            "SyncResult.error must contain the DocumentationError message"
+        )
+
+
+# ===========================================================================
+# GROUP 5 — CLIExtractor whitelist and DocumentationError (5 tests)
+# ===========================================================================
+
+
+class TestCLIExtractorSecurity:
+    """CLIExtractor must keep ALLOWED_MODULES unchanged and raise
+    DocumentationError on parse failure instead of silently returning None."""
+
+    def test_allowed_modules_unchanged(self) -> None:
+        """The ALLOWED_MODULES whitelist must contain exactly the three entries
+        defined in the original security review.
+
+        SEC-R-13: new modules must be explicitly reviewed before addition.
+        """
+        expected = {"azlin.cli", "azlin.storage", "azlin.context"}
+        actual = set(CLIExtractor.ALLOWED_MODULES)
+        assert actual == expected, (
+            f"ALLOWED_MODULES changed unexpectedly.\n"
+            f"  Expected: {sorted(expected)}\n"
+            f"  Actual:   {sorted(actual)}"
+        )
+
+    def test_unlisted_module_rejected(self) -> None:
+        """extract_command() must return None (with a warning) when the module
+        path is not in ALLOWED_MODULES — this prevents arbitrary code execution."""
+        extractor = CLIExtractor()
+        result = extractor.extract_command("os.path", "join")
+        assert result is None, (
+            "Modules not in ALLOWED_MODULES must be rejected (return None)"
+        )
+
+    def test_raises_documentation_error_on_parse_failure(self) -> None:
+        """When _extract_from_click_command fails with a runtime error,
+        CLIExtractor must raise DocumentationError (not silently return None).
+
+        This change makes parse failures visible so they can be fixed,
+        rather than generating missing documentation silently.
+
+        The mock triggers the failure via command.params (accessed inside the
+        try block by _extract_arguments/_extract_options), so the error is
+        caught by the except clause and re-raised as DocumentationError.
+        The mock uses a plain name attribute so getattr(..., "name", "unknown")
+        in the except handler does not also raise.
+        """
+        import click
+
+        extractor = CLIExtractor()
+
+        # Mock a Click command where .params raises RuntimeError inside the try
+        # block (accessed by _extract_arguments / _extract_options), while
+        # .name is a plain string so the except handler can log the command name.
+        mock_cmd = MagicMock(spec=click.Command)
+        mock_cmd.name = "broken-cmd"
+        mock_cmd.help = "help text"
+        mock_cmd.callback = None
+        type(mock_cmd).params = PropertyMock(side_effect=RuntimeError("corrupt params"))
+
+        with pytest.raises(DocumentationError):
+            extractor._extract_from_click_command(mock_cmd)
+
+    def test_missing_command_returns_none_gracefully(self) -> None:
+        """extract_command() must return None (not raise) when the named
+        attribute exists in the module but is not a Click.Command instance.
+
+        'Not found' is normal (returns None); parse / import failure is an
+        error (raises DocumentationError) — these two cases are distinct.
+        """
+
+        extractor = CLIExtractor()
+
+        # Mock the module so importlib.import_module succeeds, but the attribute
+        # is not a Click.Command instance (simulating a missing command).
+        mock_module = MagicMock()
+        mock_module.nonexistent_cmd = "not_a_click_command"  # wrong type
+
+        with patch("importlib.import_module", return_value=mock_module):
+            result = extractor.extract_command("azlin.cli", "nonexistent_cmd")
+
+        assert result is None, (
+            "extract_command must return None when the attribute exists "
+            "but is not a Click.Command (command not found — not an error)"
+        )
+
+    def test_yaml_load_not_used_in_source(self) -> None:
+        """extractor.py must not call yaml.load() (only yaml.safe_load() is
+        allowed).  This is enforced by inspecting the source file at test time.
+
+        SEC-R-09: a CI grep check prevents regression; this test provides
+        the same guarantee within the pytest suite.
+        """
+        import inspect
+        import scripts.cli_documentation.extractor as extractor_module
+
+        try:
+            source = inspect.getsource(extractor_module)
+        except OSError:
+            pytest.skip("Source not available for inspection")
+
+        # Bare yaml.load( calls (not yaml.safe_load) are forbidden
+        import re
+
+        # Match 'yaml.load(' but not 'yaml.safe_load('
+        forbidden = re.findall(r"\byaml\.load\s*\(", source)
+        assert not forbidden, (
+            "extractor.py must not call yaml.load() — use yaml.safe_load() only. "
+            f"Found: {forbidden}"
+        )

--- a/tests/unit/test_rust_bridge_security.py
+++ b/tests/unit/test_rust_bridge_security.py
@@ -1,0 +1,376 @@
+"""Security tests for rust_bridge.py — binary bootstrapper.
+
+These tests verify that the tar-extraction path cannot be exploited via:
+  - Path traversal members (../../etc/passwd)
+  - Absolute-path members (/etc/cron.d/evil)
+  - Symlink members (on Python < 3.12)
+  - Device-file members (on Python < 3.12)
+  - Archives that contain no azlin binary
+
+Design spec refs:
+    SEC-R-01  Validate all tar members before extraction (CRITICAL)
+    SEC-R-02  filter='data' on Python >= 3.12 (HIGH)
+    SEC-R-03  Normalise extracted member name to "azlin" (HIGH)
+    SEC-R-04  Skip-all-but-one; never extractall() (HIGH)
+    SEC-R-06  Temp file cleanup in finally block (LOW)
+    SEC-R-07  SecurityError NOT caught by download handler (LOW)
+"""
+
+import io
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from azlin.rust_bridge import (
+    SecurityError,
+    _extract_release_binary,
+    _is_release_binary_member,
+    _validate_release_member,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tarball(members: list[tuple[str, bytes, str]]) -> Path:
+    """Write an in-memory tar.gz to a temp file and return its path.
+
+    Each element of *members* is (name, content_bytes, type) where type is
+    one of: 'file', 'symlink', 'hardlink'.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, content, member_type in members:
+            info = tarfile.TarInfo(name=name)
+            if member_type == "file":
+                info.type = tarfile.REGTYPE
+                info.size = len(content)
+                tar.addfile(info, io.BytesIO(content))
+            elif member_type == "symlink":
+                info.type = tarfile.SYMTYPE
+                info.linkname = "target"
+                tar.addfile(info)
+            elif member_type == "hardlink":
+                info.type = tarfile.LNKTYPE
+                info.linkname = "target"
+                tar.addfile(info)
+    buf.seek(0)
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False)
+    tmp.write(buf.read())
+    tmp.flush()
+    tmp.close()
+    return Path(tmp.name)
+
+
+def _make_info(name: str, member_type: str = "file") -> tarfile.TarInfo:
+    """Return a TarInfo with the given name and type."""
+    info = tarfile.TarInfo(name=name)
+    if member_type == "file":
+        info.type = tarfile.REGTYPE
+    elif member_type == "symlink":
+        info.type = tarfile.SYMTYPE
+        info.linkname = "target"
+    elif member_type == "hardlink":
+        info.type = tarfile.LNKTYPE
+        info.linkname = "target"
+    elif member_type == "device":
+        info.type = tarfile.CHRTYPE
+    return info
+
+
+# ---------------------------------------------------------------------------
+# SEC-R-01 / _validate_release_member: path traversal & type checks
+# ---------------------------------------------------------------------------
+
+
+class TestValidateReleaseMember:
+    """Unit tests for _validate_release_member()."""
+
+    def test_valid_regular_file_passes(self):
+        """A plain regular file with a safe relative name is accepted."""
+        info = _make_info("azlin-v1.0/azlin", member_type="file")
+        # Should not raise
+        _validate_release_member(info)
+
+    def test_rejects_absolute_path_member(self):
+        """A member with an absolute path is rejected with SecurityError."""
+        info = _make_info("/etc/cron.d/evil", member_type="file")
+        with pytest.raises(SecurityError, match="Absolute path"):
+            _validate_release_member(info)
+
+    def test_rejects_path_traversal_member(self):
+        """A member with '..' in its path is rejected with SecurityError."""
+        info = _make_info("../../etc/passwd", member_type="file")
+        with pytest.raises(SecurityError, match="Path traversal"):
+            _validate_release_member(info)
+
+    def test_rejects_path_traversal_nested(self):
+        """Traversal nested inside a subdirectory is also rejected."""
+        info = _make_info("legitimate/../../etc/shadow", member_type="file")
+        with pytest.raises(SecurityError, match="Path traversal"):
+            _validate_release_member(info)
+
+    def test_allows_dotdot_in_filename_component(self):
+        """'foo..bar' (dotdot inside a component) is NOT traversal — allowed."""
+        info = _make_info("foo..bar/azlin", member_type="file")
+        # Should not raise — 'foo..bar' is not the same as '..'
+        _validate_release_member(info)
+
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 12),
+        reason="filter='data' handles this on Python 3.12+",
+    )
+    def test_rejects_symlink_member_on_older_python(self):
+        """On Python < 3.12 a symlink member is rejected with SecurityError."""
+        info = _make_info("azlin", member_type="symlink")
+        with pytest.raises(SecurityError, match="Non-regular-file"):
+            _validate_release_member(info)
+
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 12),
+        reason="filter='data' handles this on Python 3.12+",
+    )
+    def test_rejects_hardlink_member_on_older_python(self):
+        """On Python < 3.12 a hard-link member is rejected with SecurityError."""
+        info = _make_info("azlin", member_type="hardlink")
+        with pytest.raises(SecurityError, match="Non-regular-file"):
+            _validate_release_member(info)
+
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 12),
+        reason="filter='data' handles this on Python 3.12+",
+    )
+    def test_rejects_device_file_on_older_python(self):
+        """On Python < 3.12 a device-file member is rejected with SecurityError."""
+        info = _make_info("azlin", member_type="device")
+        with pytest.raises(SecurityError, match="Non-regular-file"):
+            _validate_release_member(info)
+
+
+# ---------------------------------------------------------------------------
+# _is_release_binary_member: predicate
+# ---------------------------------------------------------------------------
+
+
+class TestIsReleaseBinaryMember:
+    def test_exact_name(self):
+        assert _is_release_binary_member("azlin") is True
+
+    def test_path_ending_in_azlin(self):
+        assert _is_release_binary_member("dist/azlin") is True
+
+    def test_version_dir_ending_in_azlin(self):
+        assert _is_release_binary_member("azlin-1.2.3/azlin") is True
+
+    def test_does_not_match_different_binary(self):
+        assert _is_release_binary_member("azlinx") is False
+
+    def test_does_not_match_partial_suffix(self):
+        assert _is_release_binary_member("src/azlin.sh") is False
+
+
+# ---------------------------------------------------------------------------
+# SEC-R-04 / _extract_release_binary: no binary in archive
+# ---------------------------------------------------------------------------
+
+
+class TestExtractReleaseBinary:
+    def test_raises_when_no_binary_in_archive(self, tmp_path):
+        """An archive with no azlin binary raises SecurityError."""
+        tarball = _make_tarball([("README.txt", b"hello", "file")])
+        try:
+            with pytest.raises(SecurityError, match="azlin binary not found"):
+                _extract_release_binary(tarball, tmp_path)
+        finally:
+            tarball.unlink(missing_ok=True)
+
+    def test_extracts_binary_to_normalised_name(self, tmp_path):
+        """The binary is always written as 'azlin', regardless of member name."""
+        content = b"fake-binary-content"
+        tarball = _make_tarball([("dist/v1.2.3/azlin", content, "file")])
+        try:
+            _extract_release_binary(tarball, tmp_path)
+            output = tmp_path / "azlin"
+            assert output.exists(), "azlin binary should be extracted"
+            assert output.read_bytes() == content
+        finally:
+            tarball.unlink(missing_ok=True)
+
+    def test_rejects_traversal_member_named_like_binary(self, tmp_path):
+        """A member like '../../azlin' is rejected even though it ends with /azlin."""
+        tarball = _make_tarball([("../../azlin", b"evil", "file")])
+        try:
+            with pytest.raises(SecurityError, match="Path traversal"):
+                _extract_release_binary(tarball, tmp_path)
+        finally:
+            tarball.unlink(missing_ok=True)
+
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 12),
+        reason="filter='data' handles symlinks on Python 3.12+",
+    )
+    def test_rejects_symlink_named_like_binary(self, tmp_path):
+        """A symlink member named 'azlin' is rejected on Python < 3.12."""
+        tarball = _make_tarball([("azlin", b"", "symlink")])
+        try:
+            with pytest.raises(SecurityError, match="Non-regular-file"):
+                _extract_release_binary(tarball, tmp_path)
+        finally:
+            tarball.unlink(missing_ok=True)
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 12),
+        reason="filter='data' only available on Python 3.12+",
+    )
+    def test_uses_data_filter_on_python_312_plus(self, tmp_path):
+        """On Python >= 3.12 tar.extract() is called with filter='data'."""
+        content = b"fake-binary-content"
+        tarball = _make_tarball([("azlin", content, "file")])
+        try:
+            with patch("azlin.rust_bridge._PY312_PLUS", True):
+                with patch("tarfile.TarFile.extract") as mock_extract:
+                    _extract_release_binary(tarball, tmp_path)
+                    _, kwargs = mock_extract.call_args
+                    assert kwargs.get("filter") == "data", (
+                        "filter='data' must be passed to tar.extract() on Python 3.12+"
+                    )
+        finally:
+            tarball.unlink(missing_ok=True)
+
+    def test_only_binary_member_extracted(self, tmp_path):
+        """Only the binary member is extracted; other members are skipped."""
+        content = b"fake-binary-content"
+        tarball = _make_tarball(
+            [
+                ("README.txt", b"ignore me", "file"),
+                ("azlin", content, "file"),
+                ("LICENSE", b"also ignore", "file"),
+            ]
+        )
+        try:
+            _extract_release_binary(tarball, tmp_path)
+            assert (tmp_path / "azlin").exists()
+            assert not (tmp_path / "README.txt").exists()
+            assert not (tmp_path / "LICENSE").exists()
+        finally:
+            tarball.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# SEC-R-06 / _download_from_release: temp file cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestTempFileCleanup:
+    """Verify that temp files are always cleaned up, even on extraction failure."""
+
+    def test_temp_file_cleaned_up_on_security_error(self, tmp_path, monkeypatch):
+        """If SecurityError is raised during extraction, the temp file is removed."""
+        import azlin.rust_bridge as rb
+
+        captured_tmp: list[Path] = []
+
+        original_mktemp = tempfile.NamedTemporaryFile
+
+        def tracking_mktemp(*args, **kwargs):
+            f = original_mktemp(*args, **kwargs)
+            captured_tmp.append(Path(f.name))
+            return f
+
+        monkeypatch.setattr(tempfile, "NamedTemporaryFile", tracking_mktemp)
+
+        # Simulate a SecurityError during extraction
+        def bad_extract(tmp_path, destination):
+            raise SecurityError("simulated traversal attack")
+
+        monkeypatch.setattr(rb, "_extract_release_binary", bad_extract)
+        monkeypatch.setattr(rb, "MANAGED_BIN_DIR", tmp_path)
+        monkeypatch.setattr(rb, "MANAGED_BIN", tmp_path / "azlin")
+
+        # Provide a fake release list and download URL
+        fake_releases = [
+            {
+                "tag_name": "v0.1.0-rust",
+                "assets": [
+                    {
+                        "name": f"azlin-{rb._platform_suffix() or 'linux-x86_64'}.tar.gz",
+                        "browser_download_url": "http://example.com/azlin.tar.gz",
+                    }
+                ],
+            }
+        ]
+
+        with patch("azlin.rust_bridge.urllib.request.urlopen") as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_resp.read.return_value = (
+                __import__("json").dumps(fake_releases).encode()
+            )
+            mock_urlopen.return_value = mock_resp
+
+            with patch("azlin.rust_bridge.urllib.request.urlretrieve"):
+                # SecurityError should propagate (not be caught)
+                with pytest.raises(SecurityError):
+                    rb._download_from_release()
+
+        # The temp file must have been deleted despite the SecurityError
+        for tmp in captured_tmp:
+            assert not tmp.exists(), (
+                f"Temp file {tmp} was not cleaned up after SecurityError"
+            )
+
+
+# ---------------------------------------------------------------------------
+# SEC-R-07: SecurityError NOT swallowed by the download handler
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityErrorPropagation:
+    """SecurityError must propagate out of _download_from_release() uncaught."""
+
+    def test_security_error_propagates_from_download_handler(
+        self, tmp_path, monkeypatch
+    ):
+        """_download_from_release() must NOT catch SecurityError."""
+        import azlin.rust_bridge as rb
+
+        monkeypatch.setattr(rb, "MANAGED_BIN_DIR", tmp_path)
+        monkeypatch.setattr(rb, "MANAGED_BIN", tmp_path / "azlin")
+
+        def evil_extract(tmp_path, destination):
+            raise SecurityError("path traversal detected")
+
+        monkeypatch.setattr(rb, "_extract_release_binary", evil_extract)
+
+        fake_releases = [
+            {
+                "tag_name": "v0.1.0-rust",
+                "assets": [
+                    {
+                        "name": f"azlin-{rb._platform_suffix() or 'linux-x86_64'}.tar.gz",
+                        "browser_download_url": "http://example.com/azlin.tar.gz",
+                    }
+                ],
+            }
+        ]
+
+        with patch("azlin.rust_bridge.urllib.request.urlopen") as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_resp.read.return_value = (
+                __import__("json").dumps(fake_releases).encode()
+            )
+            mock_urlopen.return_value = mock_resp
+
+            with patch("azlin.rust_bridge.urllib.request.urlretrieve"):
+                with pytest.raises(SecurityError, match="path traversal detected"):
+                    rb._download_from_release()

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,149 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "azlin"
-version = "2.6.21"
+version = "2.6.22"
 source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "click" },
+    { name = "pytest" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "click" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pyyaml" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]


### PR DESCRIPTION
## Summary
"Take the currently validated local fixes for GitHub issues #876, #878, #879, and #880 in /home/azureuser/src/azlin and turn them into actual GitHub pull requests that are ready for review. Use the repository's workflow properly so the work results in PRs, not just local staged changes. Preserve the user's separate staged empty-env.json change and do not include it. Group changes sensibly by code area if multiple PRs are warranted, but keep scope tight to the filed issues. Run required validation, create branches/commits, push, and open PRs. Note that issue #877 was determined not to need a code change; if that conclusion still holds after review, document it clearly in the appropriate PR/issue context rather than forcing a fake fix."

## Issue
Closes #887

## Changes
"{"components":[{"action":"create","name":"SecurityError","purpose":"Domain exception for tar extraction failures; module-level so tests can import it directly"},{"action":"create","name":"_PY312_PLUS","purpose":"Module-level constant computed once at import time to avoid repeated sys.version_info checks"},{"action":"create","name":"_is_release_binary_member","purpose":"Pure predicate — returns True if the archive member name corresponds to the azlin binary; no I/O"},{"action":"create","name":"_validate_release_member","purpose":"Stateless guard — raises SecurityError on absolute paths, '..' traversal, or non-regular-file members (Python < 3.12)"},{"action":"create","name":"_extract_release_binary","purpose":"Orchestrator — iterates members, skips non-binary, validates, normalises name via copy.copy, extracts with filter='data' on 3.12+"},{"action":"modify","name":"_download_from_release","purpose":"Refactored to use _extract_release_binary; temp file cleanup moved to finally block; SecurityError NOT caught here"},{"action":"create","name":"DocumentationError","purpose":"Typed exception boundary for all I/O and parse failures in the cli_documentation subsystem; lives in models.py to avoid circular imports"},{"action":"modify","name":"ExampleManager","purpose":"Propagate ValueError from _sanitize_command_name (fix #878); enforce encoding='utf-8' (fix #879); validate required 'command' field (fix #880)"},{"action":"modify","name":"Hasher","purpose":"Add encoding='utf-8' to all open() calls; distinguish FileNotFoundError (return {}) from JSONDecodeError (raise DocumentationError)"},{"action":"modify","name":"SyncManager","purpose":"Narrow except Exception clauses to except DocumentationError; add encoding='utf-8' to write_text calls"},{"action":"modify","name":"Extractor","purpose":"Raise DocumentationError on parse failure instead of returning None; maintain module import whitelist unchanged"},{"action":"create","name":"scripts/__init__.py","purpose":"Package marker enabling test imports from scripts/ directory"},{"action":"modify","name":"pyproject.toml dev group","purpose":"Add pytest >=9.0.2 to dev dependency group; add scripts/ to pythonpath for test discovery"},{"action":"create","name":"TestExtractReleaseBinary","purpose":"4 targeted unit tests covering filter='data' on 3.12+, path traversal rejection, symlink rejection, and execvp passthrough documentation"},{"action":"create","name":"TestCLIDocumentation","purpose":"41 unit tests covering corrupt JSON, UTF-8 roundtrip, missing required field, exception propagation, and YAML safety"}],"files_to_change":["src/azlin/rust_bridge.py","scripts/cli_documentation/models.py","scripts/cli_documentation/example_manager.py","scripts/cli_documentation/hasher.py","scripts/cli_documentation/sync_manager.py","scripts/cli_documentation/extractor.py","pyproject.toml"],"implementation_order":["1. Modify src/azlin/rust_bridge.py — add SecurityError, _PY312_PLUS, _is_release_binary_member, _validate_release_member, _extract_release_binary; refactor _download_from_release to use new helpers with finally-block temp cleanup","2. Write tests/unit/test_rust_bridge.py — 4 tests: filter='data' on 3.12+, path traversal rejection, symlink rejection (<3.12), SecurityError raised when no binary in archive","3. Modify scripts/cli_documentation/models.py — add DocumentationError(Exception) class at module level","4. Modify scripts/cli_documentation/hasher.py — add encoding='utf-8' to all open() calls; narrow exception handling to FileNotFoundError/JSONDecodeError/OSError; raise DocumentationError on corrupt/unreadable files","5. Modify scripts/cli_documentation/example_manager.py — remove bare except ValueError catch (propagate it); add encoding='utf-8' to all open() calls; add 'command' field presence check raising DocumentationError before CommandExample construction","6. Modify scripts/cli_documentation/sync_manager.py — narrow except Exception to except DocumentationError; add encoding='utf-8' to write_text calls","7. Modify scripts/cli_documentation/extractor.py — raise DocumentationError on parse failure; verify yaml.safe_load() usage; confirm module import whitelist is untouched","8. Create scripts/__init__.py — empty package marker","9. Modify pyproject.toml — add pytest to dev dependencies; add scripts/ to pythonpath","10. Write tests/unit/test_cli_documentation.py — 41 tests covering: corrupt JSON raises DocumentationError, missing file returns empty dict, unwritable file raises DocumentationError, UTF-8 roundtrip for hasher and example_manager, missing 'command' field raises DocumentationError, present 'command' field succeeds, ValueError propagates from sanitize, yaml.safe_load rejects !!python/object, except narrowed to DocumentationError"],"new_files":["scripts/__init__.py"],"risks":["copy.copy(TarInfo) performs a shallow copy — verify nested attributes (e.g., pax_headers) are not needed post-copy; mitigate by testing with a real tarfile fixture","filter='data' on Python 3.12 may strip execute bits from the azlin binary — mitigate by chmod 0o755 on the destination file after extraction","_VALID_NAME_RE may be too restrictive if subcommands use dot-separated names (e.g., 'az.vm') — verify ExampleManager receives leaf names only, not full dotted paths","Existing YAML files that lack a 'command' field will now raise DocumentationError on load — run a one-time audit of all existing *.yaml example files before merging PR-2 to avoid breaking the sync script on first run","DocumentationError masking real bugs if except clauses in sync_manager.py are too broad — mitigate by only catching DocumentationError at the per-command level, letting unexpected exceptions propagate to the top-level handler","scripts/__init__.py creation may interfere with existing import paths if scripts/ is already on sys.path without being a package — verify no import collisions with existing test setup"],"security_considerations":["SEC-R-01 (CRITICAL): _validate_release_member must check PurePosixPath('..' in parts) — not a naive string contains — to avoid false positives on names like 'foo..bar'","SEC-R-02 (HIGH): _PY312_PLUS gate must use sys.version_info >= (3, 12) tuple comparison, not string comparison, to ensure correct behaviour on 3.12.x patch releases","SEC-R-03 (HIGH): copy.copy(member) before setting member.name = 'azlin' is mandatory — mutating the original TarInfo pollutes the tarfile's internal member list","SEC-R-04 (HIGH): extractall() must not appear anywhere in rust_bridge.py — enforce via grep in CI or pre-commit hook","SEC-R-05 (MEDIUM, future): Document in a follow-up issue that binary SHA256 verification against a SUMS file is the next hardening step; add a TODO comment in _download_from_release","SEC-R-06 (LOW): Temp file unlink must be in finally, not except — ensures cleanup even when SecurityError is raised mid-extraction","SEC-R-07 (LOW): The except clause in _download_from_release must be typed as (urllib.error.URLError, OSError) — SecurityError must propagate to abort installation loudly","SEC-R-08 (HIGH): ValueError from _sanitize_command_name propagating (not swallowed) is the direct fix for issue #878 — this is both a correctness fix and a security boundary","SEC-R-09 (HIGH): yaml.safe_load() is already correct — add a CI grep check (grep -r 'yaml.load(' scripts/) to prevent regression","SEC-R-10 (MEDIUM): encoding='utf-8' on every open() and write_text() call — on Windows with cp1252, omitting this causes silent data corruption that invalidates hashes and corrupts YAML","SEC-R-11 (MEDIUM): 'command' field validation must use 'command' not in ex (dict key check), not ex.get('command') falsy check — an empty string '' is a distinct invalid state that should also be caught","SEC-R-12 (MEDIUM): except DocumentationError is the correct scope; AttributeError, TypeError, and KeyError indicate bugs and must not be silently swallowed","SEC-R-13 (HIGH): ALLOWED_MODULES whitelist in extractor.py must not be modified — any new azlin modules requiring documentation must be explicitly added after review","SEC-R-14 (LOW): json.JSONDecodeError must be re-raised as DocumentationError (with chained 'from e') to preserve the original traceback for debugging while presenting a clean typed boundary to callers"],"test_files":["tests/unit/test_rust_bridge.py","tests/unit/test_cli_documentation.py"]}"

## Testing
- Unit tests added
- Local testing completed
- Pre-commit hooks pass

## Checklist
- [x] Tests pass
- [x] Documentation updated
- [x] No stubs or TODOs
- [ ] Code review completed
- [ ] Philosophy check passed

---
*This PR was created as a draft for review before merging.*