### PR TITLE
fix: correct credential forwarding docs and test naming

### DIFF
--- a/docs/features/credential-forwarding.md
+++ b/docs/features/credential-forwarding.md
@@ -50,7 +50,7 @@ Credential forwarding follows a strict security model:
   - `config` — CLI configuration
   - `msal_token_cache.json` — login tokens
   - `msal_token_cache.bin` — binary token cache
-  - `az.sess` — session state
+  - `clouds.config` — cloud endpoint definitions
   - Service principal credentials (`servicePrincipalProfile`, `accessTokens.json`) are **never** copied.
 
 - **No shell injection**: All SSH/SCP commands use `Command::new()` with argument arrays — never shell interpolation.

--- a/docs/reference/credential-forwarding.md
+++ b/docs/reference/credential-forwarding.md
@@ -20,7 +20,7 @@ Before forwarding, azlin waits for the VM's SSH service to become reachable:
 |-----------|-------|
 | Timeout | Configurable (default: 120 seconds) |
 | Poll interval | Configurable (default: 5 seconds) |
-| TCP connect timeout | Configurable (default: 5 seconds) |
+| TCP connect timeout | 3 seconds per attempt |
 | Verification | TCP connect + SSH auth handshake |
 
 The check performs two steps per attempt:
@@ -72,7 +72,7 @@ Each credential source is detected independently. Only sources that exist locall
 - `config`
 - `msal_token_cache.json`
 - `msal_token_cache.bin`
-- `az.sess`
+- `clouds.config`
 
 Files **excluded** from forwarding:
 
@@ -132,8 +132,9 @@ No forwarding failure ever causes `azlin new` to return a non-zero exit code.
 
 `TcpStream::connect_timeout` requires a `SocketAddr`. IP parsing:
 
-1. Attempt to parse `ip:22` as `SocketAddr`
-2. If that fails (e.g., bare IPv6 without brackets), fall back to `127.0.0.1:22`
+1. If the host contains `:` (IPv6 heuristic), bracket it: `[host]:port`
+2. Otherwise parse as `host:port`
+3. If parsing fails, fall back to `127.0.0.1:<port>` (preserves the actual port)
 
 In practice, Azure VMs use IPv4 addresses. The fallback exists as a safety net for unexpected address formats.
 

--- a/rust/crates/azlin/src/auth_forward.rs
+++ b/rust/crates/azlin/src/auth_forward.rs
@@ -732,12 +732,11 @@ mod tests {
     // =======================================================================
 
     #[test]
-    fn test_az_forward_only_copies_allowed_files() {
-        // Verify forward_az uses the same allow-list as az_config_dir.
-        // Both functions define their lists independently — this test catches drift.
-        // We test indirectly: create .azure with all 5 allowed files + 1 extra,
-        // confirm detection works (uses the detection list), and that
-        // the file set in az_config_dir is a subset of forward_az's allowed list.
+    fn test_az_detection_allow_list_accepts_all_five_files() {
+        // Verify az_config_dir detects presence when all 5 allowed files exist,
+        // even alongside files that should NOT be forwarded.
+        // NOTE: This tests detection only — actual SCP forwarding requires a
+        // live SSH connection and is covered by integration tests.
         let tmp = TempDir::new().unwrap();
         let az = tmp.path().join(".azure");
         std::fs::create_dir_all(&az).unwrap();


### PR DESCRIPTION
## Summary

Post-merge review of credential forwarding changes (commits 432d62cf, 73958d0c) found doc/code mismatches and a misleading test name.

## Changes

| File | Fix |
|------|-----|
| docs/features/credential-forwarding.md | Remove `az.sess` (not in code), add `clouds.config` (was in code) |
| docs/reference/credential-forwarding.md | Same allow-list fix + TCP timeout 5s→3s + IPv6 fallback preserves port |
| rust/.../auth_forward.rs | Rename test to reflect what it actually verifies (detection, not SCP) |

## Verification

- `cargo clippy --workspace` — clean
- `cargo test -- auth_forward::tests` — 36/36 pass
- `cargo doc -p azlin --no-deps` — builds
- Full suite: 2123 pass, 2 pre-existing TTY failures (unrelated)