### PR TITLE
chore: address PR #905 review feedback

### DIFF
--- a/rust/crates/azlin/src/cmd_sync_ops.rs
+++ b/rust/crates/azlin/src/cmd_sync_ops.rs
@@ -182,13 +182,13 @@ pub(crate) async fn handle_cp(
                 let port_str = tunnel.local_port.to_string();
 
                 let scp_source = if crate::cp_helpers::is_remote_path(source) {
-                    let remote_path = source.split_once(':').unwrap().1;
+                    let remote_path = source.split_once(':').expect("remote path must contain ':'").1;
                     format!("{}@127.0.0.1:{}", target.user, remote_path)
                 } else {
                     source.clone()
                 };
                 let scp_dest = if crate::cp_helpers::is_remote_path(dest) {
-                    let remote_path = dest.split_once(':').unwrap().1;
+                    let remote_path = dest.split_once(':').expect("remote path must contain ':'").1;
                     format!("{}@127.0.0.1:{}", target.user, remote_path)
                 } else {
                     dest.clone()

--- a/rust/crates/azlin/src/sync_helpers.rs
+++ b/rust/crates/azlin/src/sync_helpers.rs
@@ -159,6 +159,4 @@ mod tests {
         assert!(cmd.contains("500"));
         assert!(cmd.contains("/var/log/auth.log"));
     }
-
-
 }


### PR DESCRIPTION
## Summary

Addresses non-blocking suggestions from PR #905 reviews (code, security, philosophy).

### Changes

| # | Feedback | Action |
|---|----------|--------|
| 1 | Two `unwrap()` calls should use `expect()` (philosophy review) | Replaced with `expect("remote path must contain ':'")` in `cmd_sync_ops.rs` |
| 2 | Trailing blank line after dead code removal (code review) | Removed extra blank line in `sync_helpers.rs` |
| 3 | `--type all` shows last N per file (code review) | No action — correct `tail` semantics, documented |
| 4 | `--follow` + `--type all` interleaving (code review) | No action — documented with warning |

### Testing

- All 66 parity tests pass
- All sync_helpers tests pass
- Pre-existing unrelated test failure in `test_dispatch_session_set_get_clear` (not affected by this change)