### PR TITLE
docs: remove uv and python from prerequisites (Fixes #919)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,6 @@ Before using azlin, ensure these tools are installed:
 - `git`
 - `ssh`
 - `tmux`
-- `uv`
-- `python`
 
 **macOS**: `brew install azure-cli gh git tmux`
 **Linux**: See platform-specific installation in Prerequisites module


### PR DESCRIPTION
Fixes #919: The README incorrectly listed  and  as prerequisites for the Rust CLI, which are not required. This PR removes those entries from the Prerequisites section.