### PR TITLE
Fix outdated prerequisites in README (Resolves #919)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Before using azlin, ensure these tools are installed:
 - `git`
 - `ssh`
 - `tmux`
+
+**Note**: If you plan to install via `uvx` (Option 3 below), you'll also need:
 - `uv`
 - `python`
 


### PR DESCRIPTION
Fix outdated prerequisites in README

- Removed uv and python from general prerequisites list
- Added note that these are only required for uvx installation method (Option 3)
- Clarifies that Rust binary installation doesn't require Python/uv

Resolves #919