### PR TITLE
docs: remove uv/python from general prerequisites (Fixes #919)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,11 +199,11 @@ Before using azlin, ensure these tools are installed:
 - `git`
 - `ssh`
 - `tmux`
-- `uv`
-- `python`
 
 **macOS**: `brew install azure-cli gh git tmux`
 **Linux**: See platform-specific installation in Prerequisites module
+
+> **Note**: `uv` and `python` are only required for **Option 3** (Run via uvx). They are not needed for the Rust binary (Option 1 and Option 2).
 
 ### Copy Files to/from VMs
 


### PR DESCRIPTION
## Summary

Fixes outdated prerequisites in README.md that list `uv` and `python` as required tools.

## Changes

- Removed `uv` and `python` from the general prerequisites list
- Added a note clarifying that `uv`/`python` are only needed for **Option 3** (Run via uvx)
- Clarified that the Rust binary (Option 1 & 2) does not require Python

## Context

Since v2.3.0-rust (March 2026), azlin ships as a self-contained Rust binary. The `uv` and `python` prerequisites were required by the old Python CLI (`azlin-py`) but are **not needed** to run the Rust binary.

This fix addresses issue #919 reported by the Documentation Freshness Checker.

## Testing

- [ ] Verified README renders correctly
- [ ] Confirmed uv/python still mentioned in Option 3 section