### PR TITLE
Fix GUI setup command packaging

### DIFF
--- a/docs-site/advanced/gui-forwarding.md
+++ b/docs-site/advanced/gui-forwarding.md
@@ -31,16 +31,14 @@ Both approaches work transparently through Azure Bastion tunnels when your VM ha
 - Enable "Allow connections from network clients" in XQuartz Preferences > Security.
 
 **VNC Viewer** (for `azlin gui` only):
-- Any VNC client works. Recommendations:
-  - [TigerVNC](https://tigervnc.org/) (cross-platform, free)
-  - [RealVNC Viewer](https://www.realvnc.com/en/connect/download/viewer/) (cross-platform, free for personal use)
-  - Remmina (Linux, free)
+- `azlin gui` launches a local `vncviewer` command.
+- [TigerVNC](https://tigervnc.org/) is the tested viewer and provides that binary on Linux, macOS, and Windows/WSL setups.
 
 ### Remote VM
 
-No manual setup required. azlin automatically installs any missing packages on
-the VM when you use `azlin gui` or `azlin connect --x11`. The setup SSH pass
-uses the same `--user` and `--key` values that `azlin gui` uses for the tunnel.
+`azlin gui` automatically installs any missing VNC/desktop packages on first
+use. `azlin connect --x11` does **not** install remote GUI applications or X11
+packages for you; it only enables X11 forwarding on the SSH connection.
 
 ## VNC Desktop
 
@@ -99,7 +97,7 @@ azlin gui my-vm --user azureuser --key ~/.ssh/azlin_key
 | `--key` | `~/.ssh/azlin_key` | Path to SSH private key |
 | `--minimal` | false | Use openbox window manager instead of full XFCE desktop |
 | `--app` | none | Run a single application (e.g. `--app "chromium-browser"`) |
-| `-y, --yes` | false | Skip dependency installation prompts |
+| `-y, --yes` | false | Compatibility flag; GUI dependency setup is already non-interactive |
 
 ### Dependency Management
 
@@ -113,7 +111,8 @@ azlin automatically detects and installs missing packages on first use:
 | `dbus-x11` | D-Bus session bus (required by XFCE) |
 
 Installation happens once per VM and takes 2-3 minutes. Subsequent connections
-skip this step. The package setup is non-interactive; if it cannot finish
+skip this step. The package setup is non-interactive; `--yes` is accepted for
+CLI compatibility but does not change the behavior. If setup cannot finish
 cleanly, `azlin gui` exits with the setup error instead of waiting indefinitely.
 
 ### Security
@@ -188,6 +187,22 @@ The tunnel may not be ready yet. Retry the connection:
 
 ```bash
 azlin gui my-vm
+```
+
+### VNC: `GUI dependency/setup phase failed (exit 1): exit code 1`
+
+This empty setup error usually means the local azlin client is too old and is
+packaging the remote GUI dependency check incorrectly, especially on private
+VMs that route through Azure Bastion. Upgrade or rebuild azlin, then retry:
+
+```bash
+azlin gui my-vm
+```
+
+If the error persists after upgrading, verify that basic SSH still works first:
+
+```bash
+azlin connect my-vm --no-tmux -- whoami
 ```
 
 ### VNC: Black screen or no desktop

--- a/docs/GUI_FORWARDING.md
+++ b/docs/GUI_FORWARDING.md
@@ -31,16 +31,14 @@ Both approaches work transparently through Azure Bastion tunnels when your VM ha
 - Enable "Allow connections from network clients" in XQuartz Preferences > Security.
 
 **VNC Viewer** (for `azlin gui` only):
-- Any VNC client works. Recommendations:
-  - [TigerVNC](https://tigervnc.org/) (cross-platform, free)
-  - [RealVNC Viewer](https://www.realvnc.com/en/connect/download/viewer/) (cross-platform, free for personal use)
-  - Remmina (Linux, free)
+- `azlin gui` launches a local `vncviewer` command.
+- [TigerVNC](https://tigervnc.org/) is the tested viewer and provides that binary on Linux, macOS, and Windows/WSL setups.
 
 ### Remote VM
 
-No manual setup required. azlin automatically installs any missing packages on
-the VM when you use `azlin gui` or `azlin connect --x11`. The setup SSH pass
-uses the same `--user` and `--key` values that `azlin gui` uses for the tunnel.
+`azlin gui` automatically installs any missing VNC/desktop packages on first
+use. `azlin connect --x11` does **not** install remote GUI applications or X11
+packages for you; it only enables X11 forwarding on the SSH connection.
 
 ## VNC Desktop
 
@@ -98,7 +96,7 @@ azlin gui my-vm --user azureuser --key ~/.ssh/azlin_key
 | `--key` | `~/.ssh/azlin_key` | Path to SSH private key |
 | `--minimal` | false | Use openbox window manager instead of full XFCE desktop |
 | `--app` | none | Run a single application (e.g. `--app "chromium-browser"`) |
-| `-y, --yes` | false | Skip dependency installation prompts |
+| `-y, --yes` | false | Compatibility flag; GUI dependency setup is already non-interactive |
 
 ### Dependency Management
 
@@ -112,7 +110,8 @@ azlin automatically detects and installs missing packages on first use. The foll
 | `dbus-x11` | D-Bus session bus (required by XFCE) |
 
 Installation happens once per VM and takes 2-3 minutes. Subsequent connections
-skip this step. The package setup is non-interactive; if it cannot finish
+skip this step. The package setup is non-interactive; `--yes` is accepted for
+CLI compatibility but does not change the behavior. If setup cannot finish
 cleanly, `azlin gui` exits with the setup error instead of waiting indefinitely.
 
 ### Security
@@ -133,10 +132,22 @@ The tunnel may not be ready yet. azlin waits for the tunnel to be established be
 ```bash
 # Retry the connection
 azlin gui my-vm
+```
 
-# Or start without auto-viewer and connect manually
-azlin gui my-vm --no-viewer
-# Then open your VNC viewer and connect to localhost:<port> shown in output
+**`GUI dependency/setup phase failed (exit 1): exit code 1`**
+
+This empty setup error usually means the local azlin client is too old and is
+packaging the remote GUI dependency check incorrectly, especially on private
+VMs that route through Azure Bastion. Upgrade or rebuild azlin, then retry:
+
+```bash
+azlin gui my-vm
+```
+
+If the error persists after upgrading, verify that basic SSH still works first:
+
+```bash
+azlin connect my-vm --no-tmux -- whoami
 ```
 
 **Black screen or no desktop**
@@ -252,7 +263,7 @@ xauth generate $DISPLAY . trusted
 
 **`Warning: No xauth data`**
 
-The xauth package may be missing on the VM. azlin installs it automatically, but if you connected without `--x11` first:
+The `xauth` package may be missing on the VM:
 
 ```bash
 # On the VM
@@ -263,7 +274,7 @@ sudo apt-get install -y xauth
 **Apps are slow or laggy**
 
 X11 forwarding sends individual draw commands over the network, which can be slow for complex UIs. Options:
-- Use `ssh -C` (compression) for lower-bandwidth connections -- azlin enables this automatically.
+- Use `ssh -C` (compression) if you need it on a manual SSH command.
 - For heavy GUI usage, switch to VNC (`azlin gui`) which sends compressed screen updates instead.
 
 ## General Troubleshooting

--- a/rust/crates/azlin-cli/src/lib.rs
+++ b/rust/crates/azlin-cli/src/lib.rs
@@ -509,7 +509,7 @@ pub enum Commands {
         #[arg(long, default_value = "24")]
         depth: u8,
 
-        /// Skip dependency installation prompts
+        /// Compatibility flag; GUI dependency setup is already non-interactive
         #[arg(short, long)]
         yes: bool,
 

--- a/rust/crates/azlin/src/cmd_gui.rs
+++ b/rust/crates/azlin/src/cmd_gui.rs
@@ -234,8 +234,8 @@ fn build_dependency_setup_script(mode: &VncMode) -> String {
 
     let script = format!(
         "if {check_cmd}; then exit 0; fi; \
-         if ! sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq; then exit $?; fi; \
-         if ! sudo DEBIAN_FRONTEND=noninteractive apt-get install -y {install_packages}; then exit $?; fi; \
+         sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq || exit $?; \
+         sudo DEBIAN_FRONTEND=noninteractive apt-get install -y {install_packages} || exit $?; \
          if ! ({check_cmd}); then \
            echo 'Remote GUI dependencies are still missing after installation.' >&2; \
            exit 1; \
@@ -710,6 +710,17 @@ mod tests {
         assert!(!script.contains('\n'));
         assert!(script.contains("if ! (command -v vncserver"));
         assert!(!script.contains("set -e"));
+    }
+
+    #[test]
+    fn test_build_dependency_setup_script_propagates_apt_failures() {
+        let script = build_dependency_setup_script(&VncMode::Desktop);
+        assert!(script.contains("apt-get update -qq || exit $?"));
+        assert!(
+            script.contains(
+                "apt-get install -y tigervnc-standalone-server xfce4 xfce4-goodies dbus-x11 || exit $?"
+            )
+        );
     }
 
     #[test]

--- a/tests/agentic-scenarios/pr-945-gui-setup-regression.yaml
+++ b/tests/agentic-scenarios/pr-945-gui-setup-regression.yaml
@@ -1,0 +1,76 @@
+name: "azlin gui Simard setup regression"
+description: |
+  Verifies that `azlin gui Simard` no longer fails with the empty
+  `GUI dependency/setup phase failed (exit 1): exit code 1` error and
+  instead reaches a live VNC viewer connection on the real Simard VM.
+version: "1.0.0"
+
+config:
+  timeout: 180000
+
+agents:
+  - name: "cli-agent"
+    type: "system"
+    config:
+      workingDirectory: "."
+      shell: "bash"
+      timeout: 120000
+
+steps:
+  - name: "Build azlin GUI candidate"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: "cd rust && cargo build -q -p azlin --bin azlin"
+    expect:
+      exit_code: 0
+    timeout: 120000
+
+  - name: "azlin gui Simard reaches VNC viewer connection"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: |
+        AZLIN_BIN=${AZLIN_BIN:-rust/target/debug/azlin}
+        LOG=$(mktemp)
+        status=0
+        timeout 90 "$AZLIN_BIN" gui Simard >"$LOG" 2>&1 || status=$?
+        cat "$LOG"
+        if [ "$status" -ne 0 ] && [ "$status" -ne 124 ]; then
+          rm -f "$LOG"
+          exit "$status"
+        fi
+        grep -q "Launching VNC viewer (127.0.0.1:5901)..." "$LOG" || {
+          rm -f "$LOG"
+          exit 1
+        }
+        grep -q "Connected to host 127.0.0.1 port 5901" "$LOG" || {
+          rm -f "$LOG"
+          exit 1
+        }
+        if grep -q "GUI dependency/setup phase failed" "$LOG"; then
+          echo "LEGACY_SETUP_FAILURE_PRESENT"
+          rm -f "$LOG"
+          exit 1
+        fi
+        rm -f "$LOG"
+        echo "GUI_SIMARD_CONNECTION_OK"
+    expect:
+      exit_code: 0
+      stdout_contains: "GUI_SIMARD_CONNECTION_OK"
+    timeout: 180000
+
+assertions:
+  - name: "Simard GUI session comes up without legacy setup failure"
+    type: "command_success"
+    agent: "cli-agent"
+    params:
+      step: "azlin gui Simard reaches VNC viewer connection"
+
+metadata:
+  tags:
+    - "gui"
+    - "vnc"
+    - "regression"
+    - "real-vm"
+  priority: "critical"


### PR DESCRIPTION
## Summary
- fix `azlin gui` remote dependency setup so apt failures propagate correctly instead of collapsing into the empty `GUI dependency/setup phase failed (exit 1): exit code 1` path
- add a real-VM gadugi regression scenario for `azlin gui Simard` and make its VNC connection checks fatal
- align GUI docs and CLI help text with the actual implementation (`vncviewer` requirement, `connect --x11` behavior, `--yes` compatibility semantics)

Fixes #944.

## Scope
- `rust/crates/azlin/src/cmd_gui.rs`
- `rust/crates/azlin-cli/src/lib.rs`
- `tests/agentic-scenarios/pr-945-gui-setup-regression.yaml`
- `docs/GUI_FORWARDING.md`
- `docs-site/advanced/gui-forwarding.md`

## Real-VM QA evidence
- Target VM: `Simard`
- Scenario: `tests/agentic-scenarios/pr-945-gui-setup-regression.yaml`
- Validate: `gadugi-test validate -f tests/agentic-scenarios/pr-945-gui-setup-regression.yaml`
- Run: `gadugi-test run -s pr-945-gui-setup-regression -d tests/agentic-scenarios --timeout 240000`
- Evidence artifact: `outputs/sessions/session_9319adb3-a625-4fce-949a-dc1dae4a2311_2026-04-04T17-53-16-771Z.json`
- Key output:
  - `Launching VNC viewer (127.0.0.1:5901)...`
  - `CConn:       Connected to host 127.0.0.1 port 5901`
  - `GUI_SIMARD_CONNECTION_OK`

## Rust / CLI validation
- `cargo test -q -p azlin --bin azlin test_build_dependency_setup_script_is_noninteractive`
- `cargo test -q -p azlin --bin azlin test_build_dependency_setup_script_propagates_apt_failures`
- `cargo test -q -p azlin --bin azlin test_dependency_setup_runner_uses_outer_timeout`
- `cargo test -q -p azlin --bin azlin test_dependency_setup_nonzero_exit_is_explicit_failure`
- `cargo test -q -p azlin-cli --lib`

## Quality audit
- Cycle 1 found real blockers and they were fixed:
  - apt failure propagation in `cmd_gui.rs`
  - non-fatal grep checks in the gadugi scenario
  - stale GUI docs/help claims (`connect --x11` auto-install, `--no-viewer`, automatic `xauth` / compression claims, generic VNC viewer support, misleading `--yes` wording)
- Post-fix review status:
  - `qaudit-postfix-cycle2`: clean
  - `qaudit-final-code-review`: no remaining merge blockers in PR scope
  - `qaudit-final-reviewer`: no remaining merge blockers in PR scope
- Note: one earlier code-review pass reported the pre-fix staged shell bug; that finding is superseded by the later pushed fix and final clean reviews above.

## CI
- Latest push: `e3b13768`
- Fresh GitHub Actions reran after this push
- At the time of this update, all non-Rust checks are green, `OSSF Scorecard` is skipped, and only the two `Rust CI/build-and-test` jobs are still running