### PR TITLE
docs: correct prerequisites and uvx install note for Rust binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ cargo install --git https://github.com/rysweet/azlin
 ```bash
 uvx --from git+https://github.com/rysweet/azlin azlin list
 ```
+> **Note:** This option requires uv to be installed separately.
 
 ### Self-Update
 
@@ -199,8 +200,6 @@ Before using azlin, ensure these tools are installed:
 - `git`
 - `ssh`
 - `tmux`
-- `uv`
-- `python`
 
 **macOS**: `brew install azure-cli gh git tmux`
 **Linux**: See platform-specific installation in Prerequisites module


### PR DESCRIPTION
Closes #919

The Rust binary does not require Python or uv to run. Removed them from the prerequisites list.

Added a note under Option 3 (uvx) clarifying that uv is required only for that installation method.