### PR TITLE
Fix broken internal links in docs directory

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -539,4 +539,4 @@ azlin monitor dashboard
 
 - [Azure Monitor Metrics](https://docs.microsoft.com/azure/azure-monitor/platform/data-platform-metrics)
 - [azlin distributed top](./distributed_top.md) - Live process monitoring
-- [azlin cost tracking](./cost_tracking.md) - Cost estimation and tracking
+- [azlin cost tracking](.cost-optimization-intelligence.md) - Cost estimation and tracking

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -538,5 +538,5 @@ azlin monitor dashboard
 ## See Also
 
 - [Azure Monitor Metrics](https://docs.microsoft.com/azure/azure-monitor/platform/data-platform-metrics)
-- [azlin distributed top](./distributed_top.md) - Live process monitoring
+- azlin distributed top *(documentation not available)* - Live process monitoring
 - [azlin cost tracking](./cost-optimization-intelligence.md) - Cost estimation and tracking

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -539,4 +539,4 @@ azlin monitor dashboard
 
 - [Azure Monitor Metrics](https://docs.microsoft.com/azure/azure-monitor/platform/data-platform-metrics)
 - [azlin distributed top](./distributed_top.md) - Live process monitoring
-- [azlin cost tracking](.cost-optimization-intelligence.md) - Cost estimation and tracking
+- [azlin cost tracking](./cost-optimization-intelligence.md) - Cost estimation and tracking

--- a/docs/storage-management-improvements.md
+++ b/docs/storage-management-improvements.md
@@ -926,7 +926,9 @@ azlin defaults to safer options. Use `async` only fer specific write-heavy workl
 - [Storage Management Basics](./storage-basics.md) - Core storage concepts and commands
 - [VM Management](./vm-management.md) - VM creation and configuration
 - [Snapshot Management](./snapshot-management.md) - Automated backup and retention
-- [Cost Optimization Guide](https://github.com/rysweet/azlin/blob/36534a38ec7e558d046f87a245cc3cdc5b8d015e/docs/cost-optimization-intelligence.md) - Comprehensive cost management strategies
+- [Cost Optimization Guide](./cost-optimization-intelligence.md) - Comprehensive cost management strategies
+
+docs/cost-optimization-intelligence.md
 
 ## Support
 

--- a/docs/storage-management-improvements.md
+++ b/docs/storage-management-improvements.md
@@ -926,7 +926,7 @@ azlin defaults to safer options. Use `async` only fer specific write-heavy workl
 - [Storage Management Basics](./storage-basics.md) - Core storage concepts and commands
 - [VM Management](./vm-management.md) - VM creation and configuration
 - [Snapshot Management](./snapshot-management.md) - Automated backup and retention
-- [Cost Optimization Guide](./docs/cost-optimization-intelligence.md) - Comprehensive cost management strategies
+- [Cost Optimization Guide](docs/cost-optimization-intelligence.md) - Comprehensive cost management strategies
 
 ## Support
 

--- a/docs/storage-management-improvements.md
+++ b/docs/storage-management-improvements.md
@@ -923,9 +923,9 @@ azlin defaults to safer options. Use `async` only fer specific write-heavy workl
 
 ## Related Documentation
 
-- [Storage Management Basics](./storage-basics.md) - Core storage concepts and commands
-- [VM Management](./vm-management.md) - VM creation and configuration
-- [Snapshot Management](./snapshot-management.md) - Automated backup and retention
+- Storage Management Basics *(missing documentation)* - Core storage concepts and commands
+- VM Management *(missing documentation)* - VM creation and configuration
+- Snapshot Management *(missing documentation)* - Automated backup and retention
 - [Cost Optimization Guide](./cost-optimization-intelligence.md) - Comprehensive cost management strategies
 
 docs/cost-optimization-intelligence.md

--- a/docs/storage-management-improvements.md
+++ b/docs/storage-management-improvements.md
@@ -926,7 +926,7 @@ azlin defaults to safer options. Use `async` only fer specific write-heavy workl
 - [Storage Management Basics](./storage-basics.md) - Core storage concepts and commands
 - [VM Management](./vm-management.md) - VM creation and configuration
 - [Snapshot Management](./snapshot-management.md) - Automated backup and retention
-- [Cost Optimization Guide](docs/cost-optimization-intelligence.md) - Comprehensive cost management strategies
+- [Cost Optimization Guide](https://github.com/monapdx/azlin/blob/36534a38ec7e558d046f87a245cc3cdc5b8d015e/docs/cost-optimization-intelligence.md) - Comprehensive cost management strategies
 
 ## Support
 

--- a/docs/storage-management-improvements.md
+++ b/docs/storage-management-improvements.md
@@ -926,7 +926,7 @@ azlin defaults to safer options. Use `async` only fer specific write-heavy workl
 - [Storage Management Basics](./storage-basics.md) - Core storage concepts and commands
 - [VM Management](./vm-management.md) - VM creation and configuration
 - [Snapshot Management](./snapshot-management.md) - Automated backup and retention
-- [Cost Optimization Guide](./cost-optimization.md) - Comprehensive cost management strategies
+- [Cost Optimization Guide](./docs/cost-optimization-intelligence.md) - Comprehensive cost management strategies
 
 ## Support
 

--- a/docs/storage-management-improvements.md
+++ b/docs/storage-management-improvements.md
@@ -926,7 +926,7 @@ azlin defaults to safer options. Use `async` only fer specific write-heavy workl
 - [Storage Management Basics](./storage-basics.md) - Core storage concepts and commands
 - [VM Management](./vm-management.md) - VM creation and configuration
 - [Snapshot Management](./snapshot-management.md) - Automated backup and retention
-- [Cost Optimization Guide](https://github.com/monapdx/azlin/blob/36534a38ec7e558d046f87a245cc3cdc5b8d015e/docs/cost-optimization-intelligence.md) - Comprehensive cost management strategies
+- [Cost Optimization Guide](https://github.com/rysweet/azlin/blob/36534a38ec7e558d046f87a245cc3cdc5b8d015e/docs/cost-optimization-intelligence.md) - Comprehensive cost management strategies
 
 ## Support
 


### PR DESCRIPTION
Closes #974

This PR fixes broken internal links across multiple files in the `/docs` directory.

### Changes
- Updated links where valid target files exist (e.g., cost optimization documentation)
- Removed or converted links pointing to non-existent files to avoid dead links
  - Service Principal security documentation references
  - Bastion reconnect behavior documentation
- Preserved existing links that were already correct relative paths
- Fixed minor Markdown formatting (nested list indentation)

### Notes
- Did not create new documentation files for missing links to avoid introducing incomplete or incorrect content
- Avoided linking into `/docs-site` since it appears to be a separate documentation system
- Some entries flagged by the automated checker were verified as false positives and left unchanged

This improves overall documentation reliability by eliminating dead links while keeping references accurate and intentional.