### PR TITLE
feat: add Ubuntu 26.04 LTS shorthand support to --os flag

### DIFF
--- a/docs/features/vm-os-image-selection.md
+++ b/docs/features/vm-os-image-selection.md
@@ -33,6 +33,8 @@ Convenient aliases for common Ubuntu versions:
 
 | Shorthand | Resolved Image URN |
 |-----------|-------------------|
+| `26.04-lts` | `Canonical:ubuntu-26_04-lts:server:latest` |
+| `26.04` | `Canonical:ubuntu-26_04-lts:server:latest` |
 | `25.10` | `Canonical:ubuntu-25_10:server:latest` |
 | `24.10` | `Canonical:ubuntu-24_10:server:latest` |
 | `24.04-lts` | `Canonical:ubuntu-24_04-lts:server:latest` |

--- a/rust/crates/azlin-cli/src/lib.rs
+++ b/rust/crates/azlin-cli/src/lib.rs
@@ -260,7 +260,7 @@ pub enum Commands {
         #[arg(long)]
         tmp_disk_size: Option<u32>,
 
-        /// OS image (e.g., 25.10, 24.04-lts, Ubuntu2510, or full URN like Canonical:ubuntu-25_10:server:latest; default: Ubuntu 25.10)
+        /// OS image (e.g., 26.04-lts, 25.10, 24.04-lts, Ubuntu2604, or full URN like Canonical:ubuntu-26_04-lts:server:latest; default: Ubuntu 25.10)
         #[arg(long)]
         os: Option<String>,
     },

--- a/rust/crates/azlin-core/src/models.rs
+++ b/rust/crates/azlin-core/src/models.rs
@@ -343,6 +343,7 @@ impl VmImage {
         // Accepts dotted (25.10) and dotless (2510) forms; bare versions
         // (24.04, 2204) resolve to LTS when available.
         let offer = match version_part {
+            "26.04-lts" | "26.04" | "2604" => "ubuntu-26_04-lts",
             "25.10" | "2510" => "ubuntu-25_10",
             "24.10" | "2410" => "ubuntu-24_10",
             "24.04-lts" | "24.04" | "2404" => "ubuntu-24_04-lts",
@@ -351,7 +352,7 @@ impl VmImage {
             _ => {
                 return Err(format!(
                     "Unknown image shorthand {:?}. Supported shorthands: \
-                     25.10, 24.10, 24.04-lts, 24.04, 22.04-lts, 22.04, 20.04-lts, 20.04. \
+                     26.04-lts, 26.04, 25.10, 24.10, 24.04-lts, 24.04, 22.04-lts, 22.04, 20.04-lts, 20.04. \
                      Or use a full URN like 'Canonical:ubuntu-25_10:server:latest'",
                     spec
                 ));
@@ -623,6 +624,33 @@ mod tests {
     fn test_from_image_spec_shorthand_dotless_2404() {
         let img = VmImage::from_image_spec("2404").unwrap();
         assert_eq!(img.offer, "ubuntu-24_04-lts");
+    }
+
+    #[test]
+    fn test_from_image_spec_shorthand_26_04_lts() {
+        let img = VmImage::from_image_spec("26.04-lts").unwrap();
+        assert_eq!(img.publisher, "Canonical");
+        assert_eq!(img.offer, "ubuntu-26_04-lts");
+        assert_eq!(img.sku, "server");
+        assert_eq!(img.version, "latest");
+    }
+
+    #[test]
+    fn test_from_image_spec_shorthand_26_04_bare() {
+        let img = VmImage::from_image_spec("26.04").unwrap();
+        assert_eq!(img.offer, "ubuntu-26_04-lts");
+    }
+
+    #[test]
+    fn test_from_image_spec_shorthand_dotless_2604() {
+        let img = VmImage::from_image_spec("2604").unwrap();
+        assert_eq!(img.offer, "ubuntu-26_04-lts");
+    }
+
+    #[test]
+    fn test_from_image_spec_shorthand_ubuntu_2604() {
+        let img = VmImage::from_image_spec("Ubuntu2604").unwrap();
+        assert_eq!(img.offer, "ubuntu-26_04-lts");
     }
 
     #[test]

--- a/tests/agentic-scenarios/pr-1006-ubuntu-26.04-shorthand.yaml
+++ b/tests/agentic-scenarios/pr-1006-ubuntu-26.04-shorthand.yaml
@@ -1,0 +1,39 @@
+name: "Ubuntu 26.04 LTS shorthand support"
+description: |
+  Verifies that the --os flag correctly resolves Ubuntu 26.04 LTS
+  shorthands (26.04, 26.04-lts, 2604, Ubuntu2604) to the expected
+  Canonical:ubuntu-26_04-lts:server:latest URN. Uses unit tests as
+  the verification mechanism since image resolution is a pure function.
+version: "1.0.0"
+
+config:
+  timeout: 120000
+
+agents:
+  - name: "test-agent"
+    type: "system"
+    config:
+      workingDirectory: "./rust"
+      shell: "bash"
+      timeout: 60000
+
+steps:
+  - name: "Verify 26.04 shorthand tests pass"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: "cd rust && cargo test -q -p azlin-core --lib -- test_from_image_spec_shorthand_26_04"
+    expect:
+      exit_code: 0
+      stdout_contains: "4 passed"
+    timeout: 60000
+
+  - name: "Verify all existing image spec tests still pass"
+    agent: "test-agent"
+    action: "execute_command"
+    params:
+      command: "cd rust && cargo test -q -p azlin-core --lib -- image_spec"
+    expect:
+      exit_code: 0
+      stdout_contains: "23 passed"
+    timeout: 60000

--- a/tests/agentic-scenarios/pr-1006-ubuntu-26.04-shorthand.yaml
+++ b/tests/agentic-scenarios/pr-1006-ubuntu-26.04-shorthand.yaml
@@ -13,7 +13,7 @@ agents:
   - name: "test-agent"
     type: "system"
     config:
-      workingDirectory: "./rust"
+      workingDirectory: "."
       shell: "bash"
       timeout: 60000
 

--- a/tests/agentic-scenarios/pr-1006-ubuntu-26.04-shorthand.yaml
+++ b/tests/agentic-scenarios/pr-1006-ubuntu-26.04-shorthand.yaml
@@ -25,7 +25,7 @@ steps:
       command: "cd rust && cargo test -q -p azlin-core --lib -- test_from_image_spec_shorthand_26_04"
     expect:
       exit_code: 0
-      stdout_contains: "4 passed"
+      stdout_contains: "2 passed"
     timeout: 60000
 
   - name: "Verify all existing image spec tests still pass"


### PR DESCRIPTION
## Summary

Add Ubuntu 26.04 LTS shorthand support to `azlin new --os` so users can use convenient shorthands instead of full URNs now that Ubuntu 26.04 LTS images are available in Azure Marketplace.

## Changes

### `rust/crates/azlin-core/src/models.rs`
- Added `26.04-lts | 26.04 | 2604` match arm to `VmImage::resolve_shorthand()`
- Updated error message to list 26.04 in supported shorthands
- Added 4 new tests covering all shorthand variants

### `rust/crates/azlin-cli/src/lib.rs`
- Updated `--os` help text to show 26.04 examples

### `docs/features/vm-os-image-selection.md`
- Added `26.04-lts` and `26.04` rows to shorthand table

### `tests/agentic-scenarios/pr-1006-ubuntu-26.04-shorthand.yaml`
- New gadugi scenario verifying shorthand resolution

## Usage

```bash
azlin new --os 26.04          # shorthand
azlin new --os 26.04-lts      # explicit LTS
azlin new --os 2604            # dotless
azlin new --os Ubuntu2604      # case-insensitive
# All resolve to: Canonical:ubuntu-26_04-lts:server:latest
```

## Step 13: Local Testing Results

**Test Environment**: feat/add-ubuntu-26.04-lts-shorthand branch

1. Simple: `cargo test -p azlin-core --lib -- image_spec` → 23/23 passed ✅
2. Full suite: `cargo test -p azlin-core --lib` → 132/132 passed ✅
3. Clippy: `cargo clippy -p azlin-core -p azlin-cli -- -D warnings` → clean ✅

**Regressions**: All existing shorthand tests still pass ✅

---

## Merge Readiness

### QA-team evidence
- Scenario: `tests/agentic-scenarios/pr-1006-ubuntu-26.04-shorthand.yaml`
- Validation: `gadugi-test validate` → passed
- Run: `gadugi-test run` → 1 passed, 0 failed
- Target: local (unit tests via cargo)

### Documentation
- Updated: `docs/features/vm-os-image-selection.md` shorthand table, CLI help text

### Quality-audit
- Cycle 1: 1 critical + 2 medium → fixed
- Cycle 2: 1 medium → fixed
- Cycle 3: **CLEAN** (zero critical/high/medium)
- Convergence: 3 cycles, final cycle clean

### CI
- `gh pr checks 1006` → all green, 0 failures
- Skipped: OSSF Scorecard (conditional workflow)

### Scope
- 4 files changed, all directly related
- Unrelated changes: none

### Verdict
- **Merge-ready: yes**
- Remaining blockers: none