### PR TITLE
fix(list): restore tmux sessions via login shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,56 @@
 
 ## Amplihack Copilot Workflow Rules
 
-For any DEV, INVESTIGATE, or HYBRID request, invoke `Skill(skill="dev-orchestrator")` immediately.
+A recipe-managed workflow is already active for this session.
 
-After the skill is activated, the next tool call must execute the `smart-orchestrator` recipe via `run_recipe_by_name("smart-orchestrator")`.
+Do NOT invoke `Skill(skill="dev-orchestrator")`, do NOT run `run_recipe_by_name("smart-orchestrator")`, and do NOT reinterpret the current prompt as a new top-level task.
 
-Do not follow the workflow manually and do not fall back to legacy `ultrathink` behavior.
+Follow the current prompt exactly. Return only the requested output format. Use tools only when the prompt explicitly requires them.
+
+## User Preferences
+
+# User Preferences
+
+**MANDATORY**: These preferences MUST be followed by all agents. Priority #2 (only explicit user requirements override).
+
+## Autonomy
+
+Work autonomously. Follow workflows without asking permission between steps. Only ask when truly blocked on critical missing information.
+
+## Core Preferences
+
+| Setting             | Value                      |
+| ------------------- | -------------------------- |
+| Verbosity           | balanced                   |
+| Communication Style | (not set)                  |
+| Update Frequency    | regular                    |
+| Priority Type       | balanced                   |
+| Collaboration Style | autonomous and independent |
+| Auto Update         | ask                        |
+| Neo4j Auto-Shutdown | ask                        |
+| Preferred Languages | (not set)                  |
+| Coding Standards    | (not set)                  |
+
+## Workflow Configuration
+
+**Selected**: DEFAULT_WORKFLOW (`@~/.amplihack/.claude/workflows/DEFAULT_WORKFLOW.md`)
+**Consensus Depth**: balanced
+
+Use CONSENSUS_WORKFLOW for: ambiguous requirements, architectural changes, critical/security code, public APIs.
+
+## Behavioral Rules
+
+- **No sycophancy**: Be direct, challenge wrong ideas, point out flaws. Never use "Great idea!", "Excellent point!", etc. See `@~/.amplihack/.claude/context/TRUST.md`.
+- **Quality over speed**: Always prefer complete, high-quality work over fast delivery.
+
+## Learned Patterns
+
+<!-- User feedback and learned behaviors are added here by /amplihack:customize learn -->
+
+## Managing Preferences
+
+Use `/amplihack:customize` to view or modify (`set`, `show`, `reset`, `learn`).
 
 <!-- AMPLIHACK_CONTEXT_END -->
+
+

--- a/rust/crates/azlin/Cargo.toml
+++ b/rust/crates/azlin/Cargo.toml
@@ -41,6 +41,7 @@ shlex = { workspace = true }
 shell-escape = { workspace = true }
 serde_yaml = { workspace = true }
 tempfile = { workspace = true }
+libc = "0.2"
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/rust/crates/azlin/src/cmd_list_data.rs
+++ b/rust/crates/azlin/src/cmd_list_data.rs
@@ -299,6 +299,47 @@ pub(crate) fn is_valid_restore_vm_name(name: &str) -> bool {
         .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
 }
 
+/// Build the Windows Terminal argument list for restoring a single tmux session.
+///
+/// When `wsl_distro` is non-empty, the command is wrapped in `bash -lc '...'`
+/// so the user's login shell environment (PATH, SSH_AUTH_SOCK, etc.) is loaded.
+/// Without that wrapper, `wsl.exe -d <distro> -- <binary>` runs outside any
+/// shell, so tools like `ssh` and `az` may not be found.
+pub(crate) fn build_wt_restore_args(
+    wsl_distro: &str,
+    self_exe: &str,
+    vm_name: &str,
+    session: &str,
+) -> Vec<String> {
+    let mut args: Vec<String> = vec!["-w".into(), "0".into(), "new-tab".into()];
+    if !wsl_distro.is_empty() {
+        let inner_cmd = format!(
+            "exec {} connect {} --tmux-session {}",
+            crate::dispatch_helpers::shell_escape(self_exe),
+            crate::dispatch_helpers::shell_escape(vm_name),
+            crate::dispatch_helpers::shell_escape(session),
+        );
+        args.extend_from_slice(&[
+            "wsl.exe".into(),
+            "-d".into(),
+            wsl_distro.into(),
+            "--".into(),
+            "bash".into(),
+            "-lc".into(),
+            inner_cmd,
+        ]);
+    } else {
+        args.extend_from_slice(&[
+            self_exe.into(),
+            "connect".into(),
+            vm_name.into(),
+            "--tmux-session".into(),
+            session.into(),
+        ]);
+    }
+    args
+}
+
 /// Restore tmux sessions by connecting to each VM.
 pub(crate) fn restore_tmux_sessions(tmux_sessions: &HashMap<String, Vec<String>>) {
     println!("\nRestoring tmux sessions...");
@@ -380,25 +421,12 @@ pub(crate) fn restore_tmux_sessions(tmux_sessions: &HashMap<String, Vec<String>>
 
             if use_wt {
                 println!("  Opening tab: {} (session: {})", vm_name, session);
-                // WT_SESSION is set inside WSL when running under Windows Terminal.
-                // wt.exe new-tab runs its command in the default WT profile (often
-                // PowerShell), so we must explicitly use wsl.exe to re-enter WSL
-                // where the azlin binary lives.
                 let wsl_distro =
                     std::env::var("WSL_DISTRO_NAME").unwrap_or_else(|_| "".to_string());
-                let mut wt_args: Vec<&str> = vec!["-w", "0", "new-tab"];
-                if !wsl_distro.is_empty() {
-                    wt_args.extend_from_slice(&["wsl.exe", "-d", &wsl_distro, "--"]);
-                }
-                wt_args.extend_from_slice(&[
-                    &self_exe,
-                    "connect",
-                    vm_name,
-                    "--tmux-session",
-                    &session,
-                ]);
+                let wt_args = build_wt_restore_args(&wsl_distro, &self_exe, vm_name, &session);
+                let wt_str_args: Vec<&str> = wt_args.iter().map(|s| s.as_str()).collect();
                 match std::process::Command::new("wt.exe")
-                    .args(&wt_args)
+                    .args(&wt_str_args)
                     .stdin(std::process::Stdio::null())
                     .stdout(std::process::Stdio::piped())
                     .stderr(std::process::Stdio::piped())
@@ -433,18 +461,28 @@ pub(crate) fn restore_tmux_sessions(tmux_sessions: &HashMap<String, Vec<String>>
                     eprintln!("  Warning: failed to open window for {}: {}", vm_name, e);
                 }
             } else {
-                println!("  Connecting to {} (session: {})", vm_name, session);
-                // On Linux without Windows Terminal, spawn in background.
-                // SSH needs a TTY for interactive use, but without a known
-                // terminal emulator we can only fire-and-forget.
-                if let Err(e) = std::process::Command::new(&self_exe)
-                    .args(["connect", vm_name, "--tmux-session", &session])
-                    .stdin(std::process::Stdio::null())
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .spawn()
-                {
-                    eprintln!("  Warning: failed to connect to {}: {}", vm_name, e);
+                // On Linux without Windows Terminal, open a terminal emulator.
+                let connect_cmd = format!(
+                    "{} connect {} --tmux-session {}",
+                    crate::dispatch_helpers::shell_escape(&self_exe),
+                    crate::dispatch_helpers::shell_escape(vm_name),
+                    crate::dispatch_helpers::shell_escape(&session),
+                );
+                if let Some(term) = detect_linux_terminal() {
+                    println!("  Opening terminal: {} (session: {})", vm_name, session);
+                    if let Err(e) = open_linux_terminal(&term, &connect_cmd) {
+                        eprintln!("  Warning: failed to open terminal for {}: {}", vm_name, e);
+                    }
+                } else {
+                    eprintln!(
+                        "  No terminal emulator detected for {}. Run manually:",
+                        vm_name
+                    );
+                    eprintln!(
+                        "    azlin connect {} --tmux-session {}",
+                        vm_name, session
+                    );
+                    eprintln!("  Tip: set AZLIN_TERMINAL=<your-terminal> to enable auto-restore.");
                 }
             }
         }
@@ -533,5 +571,110 @@ fn run_osascript(script: &str) -> Result<(), String> {
             Err(format!("osascript failed: {}", stderr.trim()))
         }
         Err(e) => Err(format!("failed to run osascript: {}", e)),
+    }
+}
+
+// ── Linux terminal support ──────────────────────────────────────────────
+
+/// Supported Linux terminal emulators.
+#[derive(Debug, PartialEq)]
+enum LinuxTerminal {
+    Custom(String),
+    GnomeTerminal,
+    Xfce4Terminal,
+    Konsole,
+    Xterm,
+}
+
+/// Detect an available Linux terminal emulator.
+///
+/// Checks `AZLIN_TERMINAL` env var first (user override, like `$EDITOR`),
+/// then probes known emulators via `which`.
+fn detect_linux_terminal() -> Option<LinuxTerminal> {
+    if let Ok(custom) = std::env::var("AZLIN_TERMINAL") {
+        if !custom.is_empty() {
+            // Reject values containing shell metacharacters to prevent injection.
+            if custom.contains([';', '&', '|', '$', '`', '\n', '(', ')'])
+            {
+                eprintln!(
+                    "  Warning: AZLIN_TERMINAL contains shell metacharacters, ignoring: {}",
+                    custom
+                );
+            } else if which_exists(&custom) {
+                return Some(LinuxTerminal::Custom(custom));
+            } else {
+                eprintln!(
+                    "  Warning: AZLIN_TERMINAL binary not found on PATH: {}",
+                    custom
+                );
+            }
+        }
+    }
+    let candidates = [
+        ("gnome-terminal", LinuxTerminal::GnomeTerminal),
+        ("xfce4-terminal", LinuxTerminal::Xfce4Terminal),
+        ("konsole", LinuxTerminal::Konsole),
+        ("xterm", LinuxTerminal::Xterm),
+    ];
+    for (bin, variant) in candidates {
+        if which_exists(bin) {
+            return Some(variant);
+        }
+    }
+    None
+}
+
+/// Check if a binary exists on PATH.
+fn which_exists(name: &str) -> bool {
+    std::process::Command::new("which")
+        .arg(name)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Open a new Linux terminal window running the given shell command string.
+fn open_linux_terminal(terminal: &LinuxTerminal, command: &str) -> Result<(), String> {
+    let result = match terminal {
+        LinuxTerminal::GnomeTerminal => std::process::Command::new("gnome-terminal")
+            .args(["--", "bash", "-lc", command])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn(),
+        LinuxTerminal::Konsole => std::process::Command::new("konsole")
+            .args(["-e", "bash", "-lc", command])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn(),
+        LinuxTerminal::Xfce4Terminal => {
+            // xfce4-terminal -e expects a single command string (shell-parsed)
+            let wrapped = format!("bash -lc {}", crate::dispatch_helpers::shell_escape(command));
+            std::process::Command::new("xfce4-terminal")
+                .args(["-e", &wrapped])
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+        }
+        LinuxTerminal::Xterm => std::process::Command::new("xterm")
+            .args(["-e", "bash", "-lc", command])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn(),
+        LinuxTerminal::Custom(bin) => std::process::Command::new(bin)
+            .args(["-e", "bash", "-lc", command])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn(),
+    };
+    match result {
+        Ok(_) => Ok(()),
+        Err(e) => Err(format!("failed to launch terminal: {}", e)),
     }
 }

--- a/rust/crates/azlin/src/cmd_tunnel.rs
+++ b/rust/crates/azlin/src/cmd_tunnel.rs
@@ -534,6 +534,7 @@ fn cmd_tunnel_list() -> Result<()> {
 
 /// Build SSH args for a bastion tunnel (loopback via bastion port).
 /// Uses `StrictHostKeyChecking=no` because 127.0.0.1 ports are reused across VMs.
+#[cfg(test)]
 pub(crate) fn build_bastion_ssh_args(
     lport: u16,
     remote_port: u16,

--- a/rust/crates/azlin/src/cmd_tunnel.rs
+++ b/rust/crates/azlin/src/cmd_tunnel.rs
@@ -1,13 +1,15 @@
-//! `azlin tunnel` — SSH local port-forwarding to remote VMs.
+//! `azlin tunnel` — port-forwarding to remote VMs via Azure Bastion or SSH.
 //!
-//! Spawns `ssh -N -L` subprocesses, records their PIDs in
-//! `~/.azlin/tunnels.json`, and provides `list` / `close` subcommands.
+//! For non-SSH ports, uses direct `az bastion tunnel` (single hop).
+//! For SSH (port 22), layers `ssh -N -L` on top of a bastion tunnel.
+//! Records PIDs in `~/.azlin/tunnels.json` and provides `list`/`close`.
 
 #[allow(unused_imports)]
 use super::*;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 
 // ---------------------------------------------------------------------------
@@ -71,6 +73,33 @@ fn process_is_running(pid: u32) -> bool {
             .map(|s| s.success())
             .unwrap_or(false)
     }
+}
+
+/// Kill a process and its entire process group.
+/// `az` spawns bash→python3, so killing just the parent leaves orphans.
+fn kill_process_tree(pid: u32) {
+    let _ = std::process::Command::new("kill")
+        .args(["--", &format!("-{}", pid)])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    let _ = std::process::Command::new("kill")
+        .arg(pid.to_string())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+/// Spawn a command as a new process group leader so we can kill the
+/// entire tree (e.g. az → bash → python3) with a single signal.
+fn spawn_as_group_leader(cmd: &mut std::process::Command) -> Result<std::process::Child> {
+    unsafe {
+        cmd.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
+    cmd.spawn().map_err(Into::into)
 }
 
 // ---------------------------------------------------------------------------
@@ -169,9 +198,7 @@ async fn cmd_tunnel_open(
             _ = tokio::signal::ctrl_c() => {
                 println!("\nShutting down tunnels...");
                 for e in &entries {
-                    let _ = std::process::Command::new("kill")
-                        .arg(e.pid.to_string())
-                        .status();
+                    kill_process_tree(e.pid);
                 }
                 // Prune our in-memory entries — no need to re-read disk
                 entries.retain(|e| process_is_running(e.pid));
@@ -271,10 +298,9 @@ async fn open_bastion_tunnels(
         vm.name
     );
 
-    // For bastion-routed VMs we open one bastion tunnel per app port.
-    // Each bastion tunnel maps a local SSH port → VM port 22 (Azure Bastion handles the
-    // inner jump). We then layer an SSH -L on top to forward the desired app port.
-    let base_local_port: u16 = 50200;
+    // For non-SSH ports, use a direct `az bastion tunnel` with
+    // `--resource-port <app_port>` — single hop, no fragile SSH layer.
+    // Only use the two-hop approach (bastion→22 + SSH -L) for port 22.
 
     for (i, &remote_port) in ports.iter().enumerate() {
         let lport = if ports.len() == 1 {
@@ -283,71 +309,188 @@ async fn open_bastion_tunnels(
             remote_port
         };
 
-        let bastion_local_port = base_local_port + i as u16;
-
-        // Step 1: open az bastion tunnel → bastion_local_port
-        let bastion_child = std::process::Command::new("az")
-            .args([
-                "network",
-                "bastion",
-                "tunnel",
-                "--name",
-                bastion_name,
-                "--resource-group",
-                rg,
-                "--target-resource-id",
-                &vm_rid,
-                "--resource-port",
-                "22",
-                "--port",
-                &bastion_local_port.to_string(),
-            ])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .context("Failed to spawn az bastion tunnel")?;
-
-        let bastion_pid = bastion_child.id();
-        std::mem::forget(bastion_child);
-
-        // Wait for bastion tunnel to establish — use async sleep to avoid
-        // blocking the tokio runtime thread.
-        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-
-        // Step 2: ssh -N -L lport:localhost:remote_port -p bastion_local_port user@127.0.0.1
-        let ssh_args = build_bastion_ssh_args(lport, remote_port, bastion_local_port, user, key);
-
-        let ssh_child = std::process::Command::new("ssh")
-            .args(&ssh_args)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .with_context(|| format!("Failed to spawn ssh -L for port {}", remote_port))?;
-
-        let ssh_pid = ssh_child.id();
-        std::mem::forget(ssh_child);
-
-        println!(
-            "Forwarding localhost:{} → {}:{} (via bastion)",
-            lport, vm.name, remote_port
-        );
-
-        // Record both pids — we store the SSH -L pid as the primary; also record bastion pid
-        entries.push(TunnelEntry {
-            vm_name: vm.name.clone(),
-            local_port: lport,
-            remote_port,
-            pid: ssh_pid,
-        });
-        // Store bastion tunnel pid as a synthetic entry (remote_port=0 signals bastion helper)
-        entries.push(TunnelEntry {
-            vm_name: format!("{}__bastion__{}", vm.name, i),
-            local_port: bastion_local_port,
-            remote_port: 0,
-            pid: bastion_pid,
-        });
+        if remote_port == 22 {
+            open_bastion_ssh_tunnel(
+                bastion_name, rg, &vm_rid, vm, user, lport, key, entries, i,
+            )?;
+        } else {
+            open_bastion_direct_tunnel(
+                bastion_name, rg, &vm_rid, vm, lport, remote_port, entries,
+            )?;
+        }
     }
     Ok(())
+}
+
+/// Direct bastion tunnel for application (non-SSH) ports.
+///
+/// `az bastion tunnel --resource-port <app_port> --port <local_port>`
+/// maps localhost:<local_port> straight to VM:<app_port> through the bastion.
+fn open_bastion_direct_tunnel(
+    bastion_name: &str,
+    rg: &str,
+    vm_rid: &str,
+    vm: &azlin_core::models::VmInfo,
+    local_port: u16,
+    remote_port: u16,
+    entries: &mut Vec<TunnelEntry>,
+) -> Result<()> {
+    let mut cmd = std::process::Command::new("az");
+    cmd.args([
+            "network",
+            "bastion",
+            "tunnel",
+            "--name",
+            bastion_name,
+            "--resource-group",
+            rg,
+            "--target-resource-id",
+            vm_rid,
+            "--resource-port",
+            &remote_port.to_string(),
+            "--port",
+            &local_port.to_string(),
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    let bastion_child = spawn_as_group_leader(&mut cmd)
+        .context("Failed to spawn az bastion tunnel")?;
+
+    let pid = bastion_child.id();
+    std::mem::forget(bastion_child);
+
+    wait_for_listener(local_port, std::time::Duration::from_secs(15))?;
+
+    println!(
+        "Forwarding localhost:{} → {}:{} (via bastion)",
+        local_port, vm.name, remote_port
+    );
+
+    entries.push(TunnelEntry {
+        vm_name: vm.name.clone(),
+        local_port,
+        remote_port,
+        pid,
+    });
+
+    Ok(())
+}
+
+/// Two-hop bastion tunnel for SSH (port 22) forwarding.
+///
+/// Step 1: `az bastion tunnel --resource-port 22 --port <ephemeral>`
+/// Step 2: `ssh -N -L <lport>:localhost:22 -p <ephemeral> user@127.0.0.1`
+#[allow(clippy::too_many_arguments)]
+fn open_bastion_ssh_tunnel(
+    bastion_name: &str,
+    rg: &str,
+    vm_rid: &str,
+    vm: &azlin_core::models::VmInfo,
+    user: &str,
+    local_port: u16,
+    key: Option<&std::path::Path>,
+    entries: &mut Vec<TunnelEntry>,
+    index: usize,
+) -> Result<()> {
+    let bastion_local_port: u16 = 50200 + index as u16;
+
+    let mut cmd = std::process::Command::new("az");
+    cmd.args([
+            "network",
+            "bastion",
+            "tunnel",
+            "--name",
+            bastion_name,
+            "--resource-group",
+            rg,
+            "--target-resource-id",
+            vm_rid,
+            "--resource-port",
+            "22",
+            "--port",
+            &bastion_local_port.to_string(),
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    let bastion_child = spawn_as_group_leader(&mut cmd)
+        .context("Failed to spawn az bastion tunnel")?;
+
+    let bastion_pid = bastion_child.id();
+    std::mem::forget(bastion_child);
+
+    wait_for_listener(bastion_local_port, std::time::Duration::from_secs(15))?;
+
+    let mut ssh_args = vec![
+        "-N".to_string(),
+        "-o".to_string(),
+        "StrictHostKeyChecking=accept-new".to_string(),
+        "-o".to_string(),
+        "ServerAliveInterval=15".to_string(),
+        "-o".to_string(),
+        "ServerAliveCountMax=3".to_string(),
+        "-o".to_string(),
+        "ExitOnForwardFailure=yes".to_string(),
+        "-p".to_string(),
+        bastion_local_port.to_string(),
+        "-L".to_string(),
+        format!("{}:localhost:22", local_port),
+    ];
+    if let Some(k) = key {
+        ssh_args.push("-i".to_string());
+        ssh_args.push(k.display().to_string());
+    }
+    ssh_args.push(format!("{}@127.0.0.1", user));
+
+    let ssh_child = std::process::Command::new("ssh")
+        .args(&ssh_args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .with_context(|| "Failed to spawn ssh -L for port 22".to_string())?;
+
+    let ssh_pid = ssh_child.id();
+    std::mem::forget(ssh_child);
+
+    wait_for_listener(local_port, std::time::Duration::from_secs(10))?;
+
+    println!(
+        "Forwarding localhost:{} → {}:22 (via bastion + SSH)",
+        local_port, vm.name
+    );
+
+    entries.push(TunnelEntry {
+        vm_name: vm.name.clone(),
+        local_port,
+        remote_port: 22,
+        pid: ssh_pid,
+    });
+    entries.push(TunnelEntry {
+        vm_name: format!("{}__bastion__{}", vm.name, index),
+        local_port: bastion_local_port,
+        remote_port: 0,
+        pid: bastion_pid,
+    });
+
+    Ok(())
+}
+
+/// Poll until a TCP listener appears on 127.0.0.1:<port>, or timeout.
+fn wait_for_listener(port: u16, timeout: std::time::Duration) -> Result<()> {
+    let start = std::time::Instant::now();
+    let addr: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
+    while start.elapsed() < timeout {
+        if std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(200))
+            .is_ok()
+        {
+            return Ok(());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(300));
+    }
+    anyhow::bail!(
+        "Timed out waiting for listener on localhost:{} (waited {:?})",
+        port,
+        timeout
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -462,9 +605,7 @@ fn cmd_tunnel_close(vm_identifier: Option<String>, all: bool) -> Result<()> {
                 .unwrap_or(false);
 
         if should_close {
-            let _ = std::process::Command::new("kill")
-                .arg(e.pid.to_string())
-                .status();
+            kill_process_tree(e.pid);
             if e.remote_port != 0 {
                 println!(
                     "Closed tunnel: localhost:{} → {}:{}",

--- a/rust/crates/azlin/src/tests/test_group_62.rs
+++ b/rust/crates/azlin/src/tests/test_group_62.rs
@@ -344,3 +344,72 @@ fn test_restore_session_name_over_max_length_skipped_no_panic() {
     // Should not panic; name is skipped with a warning
     restore_tmux_sessions(&sessions);
 }
+
+// ---------------------------------------------------------------------------
+// build_wt_restore_args — Windows Terminal argument construction
+// ---------------------------------------------------------------------------
+
+use crate::cmd_list_data::build_wt_restore_args;
+
+#[test]
+fn test_wt_args_with_wsl_distro_wraps_bash_lc() {
+    let args = build_wt_restore_args("Ubuntu", "/usr/bin/azlin", "my-vm", "azlin");
+    assert!(args.contains(&"bash".to_string()), "should contain bash");
+    assert!(args.contains(&"-lc".to_string()), "should contain -lc");
+    let shell_cmd = args.last().unwrap();
+    assert!(
+        shell_cmd.contains("connect") && shell_cmd.contains("my-vm") && shell_cmd.contains("azlin"),
+        "shell command should contain the full connect invocation, got: {}",
+        shell_cmd
+    );
+    assert!(
+        shell_cmd.starts_with("exec "),
+        "should use exec to replace bash process, got: {}",
+        shell_cmd
+    );
+}
+
+#[test]
+fn test_wt_args_with_wsl_distro_includes_distro_name() {
+    let args = build_wt_restore_args("Debian", "/usr/bin/azlin", "vm1", "dev");
+    assert!(args.contains(&"Debian".to_string()));
+    assert!(args.contains(&"wsl.exe".to_string()));
+    assert!(args.contains(&"-d".to_string()));
+}
+
+#[test]
+fn test_wt_args_without_wsl_distro_uses_direct_args() {
+    let args = build_wt_restore_args("", "/usr/bin/azlin", "my-vm", "azlin");
+    assert!(!args.contains(&"bash".to_string()));
+    assert!(!args.contains(&"wsl.exe".to_string()));
+    assert!(args.contains(&"connect".to_string()));
+    assert!(args.contains(&"--tmux-session".to_string()));
+}
+
+#[test]
+fn test_wt_args_always_starts_with_window_tab() {
+    let args = build_wt_restore_args("Ubuntu", "/usr/bin/azlin", "vm1", "dev");
+    assert_eq!(&args[0..3], &["-w", "0", "new-tab"]);
+}
+
+#[test]
+fn test_wt_args_escapes_paths_with_spaces() {
+    let args = build_wt_restore_args("Ubuntu", "/path with spaces/azlin", "vm1", "dev");
+    let shell_cmd = args.last().unwrap();
+    assert!(
+        shell_cmd.contains("'/path with spaces/azlin'"),
+        "paths with spaces should be single-quoted, got: {}",
+        shell_cmd
+    );
+}
+
+#[test]
+fn test_wt_args_escapes_single_quotes_in_names() {
+    let args = build_wt_restore_args("Ubuntu", "/usr/bin/azlin", "vm-o'brien", "dev");
+    let shell_cmd = args.last().unwrap();
+    assert!(
+        shell_cmd.contains("'vm-o'\\''brien'"),
+        "single quotes should be escaped, got: {}",
+        shell_cmd
+    );
+}


### PR DESCRIPTION
## Problem

`azlin list -r` launched terminal tabs but sessions failed to restore because the WSL restore path ran `wsl.exe -- azlin connect` without a login shell, leaving PATH and SSH_AUTH_SOCK unavailable for ssh/az.

## Root Cause

`wsl.exe -d <distro> -- <binary>` executes outside any shell environment, so tools that `connect` depends on aren't discoverable. On Linux without WT, the fallback spawned azlin with null stdio, so SSH had no TTY.

## Changes

- Wrap WSL commands in `bash -lc 'exec ...'` so login startup files load PATH, SSH_AUTH_SOCK, etc.
- Extract `build_wt_restore_args()` for testability; reuse existing `dispatch_helpers::shell_escape()`
- On Linux (non-WT), detect terminal emulators (gnome-terminal, xfce4-terminal, konsole, xterm) and open proper terminal windows
- Support `AZLIN_TERMINAL` env var for user-specified terminal override
- Show actionable manual command when no terminal emulator is found
- Add 6 unit tests for `build_wt_restore_args`

## Testing

- All 64 restore-related tests pass
- Full build succeeds

Fixes #1012