### PR TITLE
feat: add restore_mode config (auto/tab/window) for azlin list -r

### DIFF
--- a/rust/crates/azlin-core/src/config.rs
+++ b/rust/crates/azlin-core/src/config.rs
@@ -52,6 +52,30 @@ const VALID_AZURE_REGIONS: &[&str] = &[
     "italynorth",
 ];
 
+/// How `azlin list -r` opens restored tmux sessions in Windows Terminal.
+///
+/// - `Auto`: detect WT_SESSION env var; fall back to Linux terminal emulators.
+/// - `Tab`: force `wt.exe -w 0 new-tab` (reuse existing window).
+/// - `Window`: force `wt.exe new-tab` (open a new window per session).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum RestoreMode {
+    #[default]
+    Auto,
+    Tab,
+    Window,
+}
+
+impl std::fmt::Display for RestoreMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Auto => write!(f, "auto"),
+            Self::Tab => write!(f, "tab"),
+            Self::Window => write!(f, "window"),
+        }
+    }
+}
+
 /// SSH key synchronization method.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -106,6 +130,8 @@ pub struct AzlinConfig {
     /// Timeout in seconds for `az` CLI subprocess calls.
     /// Default: 120 seconds. Increase on Windows/WSL where Azure CLI is slower.
     pub az_cli_timeout: u64,
+    /// How `azlin list -r` opens restored sessions: "auto", "tab", or "window".
+    pub restore_mode: RestoreMode,
 }
 
 impl Default for AzlinConfig {
@@ -133,6 +159,7 @@ impl Default for AzlinConfig {
             ssh_connect_timeout: 30,
             scp_transfer_timeout: 120,
             az_cli_timeout: 120,
+            restore_mode: RestoreMode::Auto,
         }
     }
 }
@@ -403,6 +430,20 @@ impl AzlinConfig {
             }
         }
 
+        if key == "restore_mode" {
+            match value.to_lowercase().as_str() {
+                "auto" | "tab" | "window" => {
+                    return Ok(serde_json::Value::String(value.to_lowercase()));
+                }
+                _ => {
+                    return Err(crate::AzlinError::Config(format!(
+                        "restore_mode must be 'auto', 'tab', or 'window', got '{}'",
+                        value
+                    )));
+                }
+            }
+        }
+
         if Self::BOOL_FIELDS.contains(&key) {
             match value {
                 "true" => return Ok(serde_json::Value::Bool(true)),
@@ -436,6 +477,7 @@ impl AzlinConfig {
             "notification_command",
             "default_nfs_storage",
             "ssh_sync_method",
+            "restore_mode",
         ];
         if !KNOWN_STRING_FIELDS.contains(&key)
             && !Self::BOOL_FIELDS.contains(&key)

--- a/rust/crates/azlin-core/src/lib.rs
+++ b/rust/crates/azlin-core/src/lib.rs
@@ -5,5 +5,5 @@ pub mod error;
 pub mod models;
 pub mod sanitizer;
 
-pub use config::{AzlinConfig, SshSyncMethod};
+pub use config::{AzlinConfig, RestoreMode, SshSyncMethod};
 pub use error::{AzlinError, Result};

--- a/rust/crates/azlin/src/cmd_list_data.rs
+++ b/rust/crates/azlin/src/cmd_list_data.rs
@@ -305,13 +305,22 @@ pub(crate) fn is_valid_restore_vm_name(name: &str) -> bool {
 /// so the user's login shell environment (PATH, SSH_AUTH_SOCK, etc.) is loaded.
 /// Without that wrapper, `wsl.exe -d <distro> -- <binary>` runs outside any
 /// shell, so tools like `ssh` and `az` may not be found.
+///
+/// `restore_mode` controls window placement:
+/// - `Tab` → `wt.exe -w 0 new-tab ...` (reuse existing window)
+/// - `Window` → `wt.exe -w new new-tab ...` (new window per session)
+/// - `Auto` is resolved by the caller before reaching here; treated as `Tab`.
 pub(crate) fn build_wt_restore_args(
     wsl_distro: &str,
     self_exe: &str,
     vm_name: &str,
     session: &str,
+    restore_mode: &azlin_core::RestoreMode,
 ) -> Vec<String> {
-    let mut args: Vec<String> = vec!["-w".into(), "0".into(), "new-tab".into()];
+    let mut args: Vec<String> = match restore_mode {
+        azlin_core::RestoreMode::Window => vec!["-w".into(), "new".into(), "new-tab".into()],
+        _ => vec!["-w".into(), "0".into(), "new-tab".into()],
+    };
     if !wsl_distro.is_empty() {
         let inner_cmd = format!(
             "exec {} connect {} --tmux-session {}",
@@ -375,7 +384,21 @@ pub(crate) fn restore_tmux_sessions(tmux_sessions: &HashMap<String, Vec<String>>
         return;
     }
 
-    let use_wt = std::env::var("WT_SESSION").is_ok();
+    let detected_wt = std::env::var("WT_SESSION").is_ok();
+
+    // Load config for restore_mode preference.
+    let config = azlin_core::AzlinConfig::load().unwrap_or_default();
+    let restore_mode = &config.restore_mode;
+
+    // If restore_mode is explicitly set to tab or window, force wt.exe usage
+    // — but only when we're in WSL where wt.exe is actually available.
+    let in_wsl = std::env::var("WSL_DISTRO_NAME").is_ok_and(|v| !v.is_empty());
+    let force_wt = in_wsl
+        && matches!(
+            restore_mode,
+            azlin_core::RestoreMode::Tab | azlin_core::RestoreMode::Window
+        );
+    let use_wt = detected_wt || force_wt;
     let use_macos = cfg!(target_os = "macos") && !use_wt;
 
     // Resolve the current executable path so we can re-invoke ourselves
@@ -423,7 +446,7 @@ pub(crate) fn restore_tmux_sessions(tmux_sessions: &HashMap<String, Vec<String>>
                 println!("  Opening tab: {} (session: {})", vm_name, session);
                 let wsl_distro =
                     std::env::var("WSL_DISTRO_NAME").unwrap_or_else(|_| "".to_string());
-                let wt_args = build_wt_restore_args(&wsl_distro, &self_exe, vm_name, &session);
+                let wt_args = build_wt_restore_args(&wsl_distro, &self_exe, vm_name, &session, restore_mode);
                 let wt_str_args: Vec<&str> = wt_args.iter().map(|s| s.as_str()).collect();
                 match std::process::Command::new("wt.exe")
                     .args(&wt_str_args)

--- a/rust/crates/azlin/src/tests/test_group_62.rs
+++ b/rust/crates/azlin/src/tests/test_group_62.rs
@@ -353,7 +353,8 @@ use crate::cmd_list_data::build_wt_restore_args;
 
 #[test]
 fn test_wt_args_with_wsl_distro_wraps_bash_lc() {
-    let args = build_wt_restore_args("Ubuntu", "/usr/bin/azlin", "my-vm", "azlin");
+    let mode = azlin_core::RestoreMode::Tab;
+    let args = build_wt_restore_args("Ubuntu", "/usr/bin/azlin", "my-vm", "azlin", &mode);
     assert!(args.contains(&"bash".to_string()), "should contain bash");
     assert!(args.contains(&"-lc".to_string()), "should contain -lc");
     let shell_cmd = args.last().unwrap();
@@ -371,7 +372,8 @@ fn test_wt_args_with_wsl_distro_wraps_bash_lc() {
 
 #[test]
 fn test_wt_args_with_wsl_distro_includes_distro_name() {
-    let args = build_wt_restore_args("Debian", "/usr/bin/azlin", "vm1", "dev");
+    let mode = azlin_core::RestoreMode::Tab;
+    let args = build_wt_restore_args("Debian", "/usr/bin/azlin", "vm1", "dev", &mode);
     assert!(args.contains(&"Debian".to_string()));
     assert!(args.contains(&"wsl.exe".to_string()));
     assert!(args.contains(&"-d".to_string()));
@@ -379,7 +381,8 @@ fn test_wt_args_with_wsl_distro_includes_distro_name() {
 
 #[test]
 fn test_wt_args_without_wsl_distro_uses_direct_args() {
-    let args = build_wt_restore_args("", "/usr/bin/azlin", "my-vm", "azlin");
+    let mode = azlin_core::RestoreMode::Tab;
+    let args = build_wt_restore_args("", "/usr/bin/azlin", "my-vm", "azlin", &mode);
     assert!(!args.contains(&"bash".to_string()));
     assert!(!args.contains(&"wsl.exe".to_string()));
     assert!(args.contains(&"connect".to_string()));
@@ -387,14 +390,30 @@ fn test_wt_args_without_wsl_distro_uses_direct_args() {
 }
 
 #[test]
-fn test_wt_args_always_starts_with_window_tab() {
-    let args = build_wt_restore_args("Ubuntu", "/usr/bin/azlin", "vm1", "dev");
+fn test_wt_args_tab_mode_starts_with_window_tab() {
+    let mode = azlin_core::RestoreMode::Tab;
+    let args = build_wt_restore_args("Ubuntu", "/usr/bin/azlin", "vm1", "dev", &mode);
+    assert_eq!(&args[0..3], &["-w", "0", "new-tab"]);
+}
+
+#[test]
+fn test_wt_args_window_mode_uses_new_window() {
+    let mode = azlin_core::RestoreMode::Window;
+    let args = build_wt_restore_args("Ubuntu", "/usr/bin/azlin", "vm1", "dev", &mode);
+    assert_eq!(&args[0..3], &["-w", "new", "new-tab"]);
+}
+
+#[test]
+fn test_wt_args_auto_mode_defaults_to_tab_prefix() {
+    let mode = azlin_core::RestoreMode::Auto;
+    let args = build_wt_restore_args("Ubuntu", "/usr/bin/azlin", "vm1", "dev", &mode);
     assert_eq!(&args[0..3], &["-w", "0", "new-tab"]);
 }
 
 #[test]
 fn test_wt_args_escapes_paths_with_spaces() {
-    let args = build_wt_restore_args("Ubuntu", "/path with spaces/azlin", "vm1", "dev");
+    let mode = azlin_core::RestoreMode::Tab;
+    let args = build_wt_restore_args("Ubuntu", "/path with spaces/azlin", "vm1", "dev", &mode);
     let shell_cmd = args.last().unwrap();
     assert!(
         shell_cmd.contains("'/path with spaces/azlin'"),
@@ -405,7 +424,8 @@ fn test_wt_args_escapes_paths_with_spaces() {
 
 #[test]
 fn test_wt_args_escapes_single_quotes_in_names() {
-    let args = build_wt_restore_args("Ubuntu", "/usr/bin/azlin", "vm-o'brien", "dev");
+    let mode = azlin_core::RestoreMode::Tab;
+    let args = build_wt_restore_args("Ubuntu", "/usr/bin/azlin", "vm-o'brien", "dev", &mode);
     let shell_cmd = args.last().unwrap();
     assert!(
         shell_cmd.contains("'vm-o'\\''brien'"),


### PR DESCRIPTION
## Summary

Adds a `restore_mode` config preference controlling how `azlin list -r` opens restored tmux sessions:

- **auto** (default): uses WT if `WT_SESSION` is set, else Linux terminal detection
- **tab**: forces `wt.exe -w 0 new-tab` (reuse existing WT window)  
- **window**: forces `wt.exe new-tab` (new window per session)

When `restore_mode` is `tab` or `window`, wt.exe is used regardless of whether `WT_SESSION` is set — fixes the xterm fallback issue.

## Usage

```bash
azlin config set restore_mode tab    # new tabs in existing WT window
azlin config set restore_mode window # new WT window per session
azlin config set restore_mode auto   # original behavior (default)
```

## Changes

- `azlin-core/config.rs`: `RestoreMode` enum, field on `AzlinConfig`, validation
- `azlin-core/lib.rs`: re-export `RestoreMode`
- `cmd_list_data.rs`: `build_wt_restore_args` accepts `RestoreMode`; `restore_tmux_sessions` loads config and forces WT when mode is explicit
- `test_group_62.rs`: 8 tests covering all three modes + edge cases

## Testing

All 56 tests in test_group_62 pass. Clippy clean.