### PR TITLE
Update default Ubuntu VM image to 26.04 LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Default VM OS image updated to Ubuntu 26.04 LTS.
+
 ### Added
 - **GUI Forwarding**: Run remote Linux GUI applications locally (#828)
   - `azlin connect --x11` / `-X` — X11 forwarding for lightweight GUI apps (gitk, meld, xeyes)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ the later auth-forward, home seeding, and first auto-connect phases too.
 azlin automates the tedious process of setting up Azure Ubuntu VMs for development. In one command, it:
 
 1. Authenticates with Azure
-2. Provisions an Ubuntu 24.04 VM
+2. Provisions an Ubuntu 26.04 LTS VM
 3. Installs 12 essential development tools
 4. Creates a separate 100GB Premium SSD for /home (persistent storage), with optional /tmp disk
 5. Sets up SSH with key-based authentication
@@ -125,7 +125,7 @@ azlin logs my-vm --lines 50           # View last 50 lines
 ### Ubuntu Version Selection
 Specify Ubuntu version when creating VMs:
 ```bash
-azlin new --os 25.10         # Ubuntu 25.10
+azlin new --os 24.04-lts     # Ubuntu 24.04 LTS
 ```
 
 ### Separate /tmp Disk Support

--- a/docs-site/commands/vm/new.md
+++ b/docs-site/commands/vm/new.md
@@ -292,7 +292,7 @@ When you run `azlin new`, the following happens automatically:
 
 1. **Authentication** - Verifies Azure CLI authentication
 2. **Prerequisites** - Checks SSH keys and required tools
-3. **VM Creation** - Provisions Ubuntu 24.04 VM with your chosen size
+3. **VM Creation** - Provisions Ubuntu 26.04 LTS VM with your chosen size
 4. **Cloud-Init** - Installs all development tools (4-5 minutes)
 5. **SSH Key Storage** - Automatically stores private key in Azure Key Vault for cross-system access
 6. **NFS Storage** (optional) - Mounts shared persistent home directory

--- a/docs-site/getting-started/concepts.md
+++ b/docs-site/getting-started/concepts.md
@@ -7,7 +7,7 @@ Understand the core concepts behind azlin to use it effectively.
 
 ### Virtual Machines (VMs)
 
-azlin creates **Ubuntu 24.04 LTS** virtual machines in Azure with development tools pre-installed.
+azlin creates **Ubuntu 26.04 LTS** virtual machines in Azure with development tools pre-installed.
 
 **Key characteristics:**
 

--- a/docs-site/getting-started/first-vm.md
+++ b/docs-site/getting-started/first-vm.md
@@ -7,7 +7,7 @@ This guide walks you through creating your first Azure VM with azlin in detail.
 
 By the end of this tutorial, you'll have:
 
-- A running Ubuntu 24.04 VM in Azure
+- A running Ubuntu 26.04 LTS VM in Azure
 - 12 development tools pre-installed
 - SSH access configured
 - A persistent tmux session
@@ -90,7 +90,7 @@ You'll see:
 ✓ SSH configured
 → Connecting to my-first-vm...
 
-Welcome to Ubuntu 24.04 LTS
+Welcome to Ubuntu 26.04 LTS
 
 azureuser@my-first-vm:~$
 ```

--- a/docs-site/getting-started/quickstart.md
+++ b/docs-site/getting-started/quickstart.md
@@ -37,7 +37,7 @@ azlin new --name myproject
 
 azlin will:
 
-1. Create an Ubuntu 24.04 VM
+1. Create an Ubuntu 26.04 LTS VM
 2. Install 12 development tools
 3. Configure SSH access
 4. Start tmux session

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -43,7 +43,7 @@
 azlin automates the tedious process of setting up Azure Ubuntu VMs for development. Written in Rust for blazing-fast startup (75-85x faster than the original Python implementation), it provisions a fully configured VM in one command:
 
 1. Authenticates with Azure
-2. Provisions an Ubuntu 24.04 VM
+2. Provisions an Ubuntu 26.04 LTS VM
 3. Installs 12 essential development tools
 4. Sets up SSH with key-based authentication
 5. Starts a persistent tmux session

--- a/docs/AMPLIFIER_CHEATSHEET.md
+++ b/docs/AMPLIFIER_CHEATSHEET.md
@@ -55,7 +55,7 @@ azlin new --vm-size Standard_D4s_v3 --repo https://github.com/microsoft/amplifie
 ```
 
 **What happens:**
-- Provisions Ubuntu 24.04 VM on Azure
+- Provisions Ubuntu 26.04 LTS VM on Azure
 - Installs 12 dev tools (Docker, Node.js, Python, Go, Rust, etc.)
 - Clones amplifier repo to `~/amplifier`
 - Auto-connects via SSH with tmux

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -82,7 +82,7 @@ azlin <command> --help             # Command-specific help
 --size m                           # Size tier: xs/s/m/l/xl/xxl
 --vm-size Standard_D8s_v5          # Exact Azure VM SKU (overrides --size)
 --vm-family e                      # VM family: d (general) or e (memory-optimized)
---os 24.04-lts                     # OS image (shorthand or full URN)
+--os 26.04-lts                     # OS image (shorthand or full URN)
 --region westus2                   # Azure region
 --region-fit                       # Auto-find region with available quota/SKU
 ```

--- a/docs/features/vm-os-image-selection.md
+++ b/docs/features/vm-os-image-selection.md
@@ -4,7 +4,7 @@ Choose the operating system image for new VMs via the `--os` flag or persistent 
 
 ## Overview
 
-By default, `azlin new` provisions VMs with Ubuntu 25.10. You can override this per-command with `--os` or set a persistent default with `azlin config set default_vm_image`.
+By default, `azlin new` provisions VMs with Ubuntu 26.04 LTS. You can override this per-command with `--os` or set a persistent default with `azlin config set default_vm_image`.
 
 ## Quick Start
 
@@ -33,6 +33,8 @@ Convenient aliases for common Ubuntu versions:
 
 | Shorthand | Resolved Image URN |
 |-----------|-------------------|
+| `26.04-lts` | `Canonical:ubuntu-26_04-lts:server:latest` |
+| `26.04` | `Canonical:ubuntu-26_04-lts:server:latest` |
 | `25.10` | `Canonical:ubuntu-25_10:server:latest` |
 | `24.10` | `Canonical:ubuntu-24_10:server:latest` |
 | `24.04-lts` | `Canonical:ubuntu-24_04-lts:server:latest` |
@@ -68,7 +70,7 @@ azlin config set default_vm_image "Canonical:ubuntu-24_04-lts:server:latest"
 # View current default
 azlin config get default_vm_image
 
-# Remove default (revert to built-in Ubuntu 25.10)
+# Remove default (revert to built-in Ubuntu 26.04 LTS)
 azlin config unset default_vm_image
 ```
 
@@ -94,7 +96,7 @@ When creating a VM, the OS image is resolved in this order (highest priority fir
 
 1. **`--os` flag** — per-command override
 2. **`default_vm_image` config** — persistent default in `~/.azlin/config.toml`
-3. **Built-in default** — Ubuntu 25.10 (`Canonical:ubuntu-25_10:server:latest`)
+3. **Built-in default** — Ubuntu 26.04 LTS (`Canonical:ubuntu-26_04-lts:server:latest`)
 
 ```bash
 # Uses --os flag (highest priority)
@@ -103,7 +105,7 @@ azlin new --os 22.04-lts
 # Uses config default_vm_image (if set)
 azlin new
 
-# Uses built-in Ubuntu 25.10 (if no config set and no --os)
+# Uses built-in Ubuntu 26.04 LTS (if no config set and no --os)
 azlin new
 ```
 
@@ -159,12 +161,13 @@ Invalid input produces a clear error:
 ```
 $ azlin new --os "NotAPublisher:image:sku:latest"
 Error: Only Canonical publisher is supported for VM images, got "NotAPublisher".
-  Use a URN like 'Canonical:ubuntu-25_10:server:latest'
+  Use a URN like 'Canonical:ubuntu-26_04-lts:server:latest'
 
 $ azlin new --os "not-a-version"
 Error: Unknown image shorthand "not-a-version". Supported shorthands:
-  25.10, 24.10, 24.04-lts, 24.04, 22.04-lts, 22.04, 20.04-lts, 20.04.
-  Or use a full URN like 'Canonical:ubuntu-25_10:server:latest'
+  26.04-lts, 26.04, 25.10, 24.10, 24.04-lts, 24.04, 22.04-lts,
+  22.04, 20.04-lts, 20.04.
+  Or use a full URN like 'Canonical:ubuntu-26_04-lts:server:latest'
 ```
 
 ## Troubleshooting

--- a/docs/reference/config-default-behaviors.md
+++ b/docs/reference/config-default-behaviors.md
@@ -37,9 +37,9 @@ default_vm_size = "Standard_E16as_v5"
 
 # Default OS image for new VMs (shorthand or full URN)
 # Type: string (optional)
-# Default: None (falls back to Ubuntu 25.10)
+# Default: None (falls back to Ubuntu 26.04 LTS)
 # CLI Override: --os <IMAGE_SPEC>
-# Valid shorthands: 25.10, 24.10, 24.04-lts, 24.04, 22.04-lts, 22.04, 20.04-lts, 20.04
+# Valid shorthands: 26.04-lts, 26.04, 25.10, 24.10, 24.04-lts, 24.04, 22.04-lts, 22.04, 20.04-lts, 20.04
 # Valid URN format: Canonical:<offer>:<sku>:<version>
 default_vm_image = "Canonical:ubuntu-24_04-lts:server:latest"
 

--- a/rust/crates/azlin-cli/src/lib.rs
+++ b/rust/crates/azlin-cli/src/lib.rs
@@ -260,7 +260,7 @@ pub enum Commands {
         #[arg(long)]
         tmp_disk_size: Option<u32>,
 
-        /// OS image (e.g., 25.10, 24.04-lts, Ubuntu2510, or full URN like Canonical:ubuntu-25_10:server:latest; default: Ubuntu 25.10)
+        /// OS image (e.g., 26.04, 24.04-lts, Ubuntu2604, or full URN like Canonical:ubuntu-26_04-lts:server:latest; default: Ubuntu 26.04 LTS)
         #[arg(long)]
         os: Option<String>,
     },

--- a/rust/crates/azlin-core/src/config.rs
+++ b/rust/crates/azlin-core/src/config.rs
@@ -109,7 +109,7 @@ pub struct AzlinConfig {
     pub vm_storage: Option<HashMap<String, String>>,
     pub default_nfs_storage: Option<String>,
     pub github_runner_fleets: Option<HashMap<String, serde_json::Value>>,
-    /// Default VM OS image URN (e.g. "Canonical:ubuntu-25_10:server:latest").
+    /// Default VM OS image URN (e.g. "Canonical:ubuntu-26_04-lts:server:latest").
     /// When None, falls back to VmImage::default().
     pub default_vm_image: Option<String>,
     pub ssh_auto_sync_keys: bool,
@@ -1060,23 +1060,25 @@ mod tests {
 
     #[test]
     fn test_validate_field_default_vm_image_full_urn() {
-        let result =
-            AzlinConfig::validate_field("default_vm_image", "Canonical:ubuntu-25_10:server:latest");
+        let result = AzlinConfig::validate_field(
+            "default_vm_image",
+            "Canonical:ubuntu-26_04-lts:server:latest",
+        );
         assert!(result.is_ok(), "should accept valid URN");
         assert_eq!(
             result.unwrap(),
-            serde_json::Value::String("Canonical:ubuntu-25_10:server:latest".to_string())
+            serde_json::Value::String("Canonical:ubuntu-26_04-lts:server:latest".to_string())
         );
     }
 
     #[test]
     fn test_validate_field_default_vm_image_shorthand() {
-        let result = AzlinConfig::validate_field("default_vm_image", "24.04-lts");
+        let result = AzlinConfig::validate_field("default_vm_image", "26.04-lts");
         assert!(result.is_ok(), "should accept valid shorthand");
         // Should store the resolved full URN
         assert_eq!(
             result.unwrap(),
-            serde_json::Value::String("Canonical:ubuntu-24_04-lts:server:latest".to_string())
+            serde_json::Value::String("Canonical:ubuntu-26_04-lts:server:latest".to_string())
         );
     }
 

--- a/rust/crates/azlin-core/src/models.rs
+++ b/rust/crates/azlin-core/src/models.rs
@@ -41,7 +41,7 @@ pub struct VmInfo {
     pub power_state: PowerState,
     pub provisioning_state: ProvisioningState,
     pub os_type: OsType,
-    /// Image offer string from Azure (e.g., "ubuntu-25_10", "WindowsServer").
+    /// Image offer string from Azure (e.g., "ubuntu-26_04-lts", "WindowsServer").
     /// Used for OS distro display in list output.
     pub os_offer: Option<String>,
     pub public_ip: Option<String>,
@@ -228,7 +228,7 @@ impl Default for VmImage {
     fn default() -> Self {
         Self {
             publisher: "Canonical".into(),
-            offer: "ubuntu-25_10".into(),
+            offer: "ubuntu-26_04-lts".into(),
             sku: "server".into(),
             version: "latest".into(),
         }
@@ -249,8 +249,8 @@ impl VmImage {
     /// Parse an image specification into a `VmImage`.
     ///
     /// Accepts:
-    /// - Full URN: `Canonical:ubuntu-25_10:server:latest` (must be Canonical publisher)
-    /// - Shorthands: `25.10`, `24.04-lts`, `ubuntu-25.10`, `ubuntu-24.04-lts`
+    /// - Full URN: `Canonical:ubuntu-26_04-lts:server:latest` (must be Canonical publisher)
+    /// - Shorthands: `26.04`, `26.04-lts`, `25.10`, `24.04-lts`, `ubuntu-26.04-lts`
     ///
     /// Returns an error for empty/whitespace input, shell metacharacters, non-Canonical
     /// publishers, malformed URNs, or unrecognized shorthands.
@@ -266,7 +266,7 @@ impl VmImage {
         if spec.as_bytes().iter().any(|b| FORBIDDEN.contains(b)) {
             return Err(format!(
                 "Image spec contains invalid characters: {:?}. Use a URN like \
-                 'Canonical:ubuntu-25_10:server:latest' or shorthand like '25.10'",
+                 'Canonical:ubuntu-26_04-lts:server:latest' or shorthand like '26.04'",
                 spec
             ));
         }
@@ -317,7 +317,7 @@ impl VmImage {
         if parts[0] != "Canonical" {
             return Err(format!(
                 "Only Canonical publisher is supported for VM images, got {:?}. \
-                 Use a URN like 'Canonical:ubuntu-25_10:server:latest'",
+                 Use a URN like 'Canonical:ubuntu-26_04-lts:server:latest'",
                 parts[0]
             ));
         }
@@ -330,7 +330,7 @@ impl VmImage {
         })
     }
 
-    /// Resolve a shorthand like "25.10" or "ubuntu-24.04-lts" to a full VmImage.
+    /// Resolve a shorthand like "26.04" or "ubuntu-24.04-lts" to a full VmImage.
     fn resolve_shorthand(spec: &str) -> Result<Self, String> {
         // Normalize to lowercase for case-insensitive prefix matching
         let lower = spec.to_ascii_lowercase();
@@ -340,9 +340,10 @@ impl VmImage {
             .unwrap_or(&lower);
 
         // Map version shorthands to offer names.
-        // Accepts dotted (25.10) and dotless (2510) forms; bare versions
+        // Accepts dotted (26.04) and dotless (2604) forms; bare versions
         // (24.04, 2204) resolve to LTS when available.
         let offer = match version_part {
+            "26.04-lts" | "26.04" | "2604" => "ubuntu-26_04-lts",
             "25.10" | "2510" => "ubuntu-25_10",
             "24.10" | "2410" => "ubuntu-24_10",
             "24.04-lts" | "24.04" | "2404" => "ubuntu-24_04-lts",
@@ -351,8 +352,9 @@ impl VmImage {
             _ => {
                 return Err(format!(
                     "Unknown image shorthand {:?}. Supported shorthands: \
-                     25.10, 24.10, 24.04-lts, 24.04, 22.04-lts, 22.04, 20.04-lts, 20.04. \
-                     Or use a full URN like 'Canonical:ubuntu-25_10:server:latest'",
+                     26.04-lts, 26.04, 25.10, 24.10, 24.04-lts, 24.04, 22.04-lts, 22.04, \
+                     20.04-lts, 20.04. Or use a full URN like \
+                     'Canonical:ubuntu-26_04-lts:server:latest'",
                     spec
                 ));
             }
@@ -564,7 +566,7 @@ mod tests {
     fn test_vm_image_default() {
         let img = VmImage::default();
         assert_eq!(img.publisher, "Canonical");
-        assert_eq!(img.offer, "ubuntu-25_10");
+        assert_eq!(img.offer, "ubuntu-26_04-lts");
         assert_eq!(img.sku, "server");
         assert_eq!(img.version, "latest");
     }
@@ -572,7 +574,7 @@ mod tests {
     #[test]
     fn test_vm_image_display() {
         let img = VmImage::default();
-        assert_eq!(img.to_string(), "Canonical:ubuntu-25_10:server:latest");
+        assert_eq!(img.to_string(), "Canonical:ubuntu-26_04-lts:server:latest");
     }
 
     // ── from_image_spec tests (TDD — will fail until implementation) ──
@@ -596,6 +598,15 @@ mod tests {
     }
 
     #[test]
+    fn test_from_image_spec_shorthand_26_04_lts() {
+        let img = VmImage::from_image_spec("26.04").unwrap();
+        assert_eq!(img.publisher, "Canonical");
+        assert_eq!(img.offer, "ubuntu-26_04-lts");
+        assert_eq!(img.sku, "server");
+        assert_eq!(img.version, "latest");
+    }
+
+    #[test]
     fn test_from_image_spec_shorthand_24_04_lts() {
         let img = VmImage::from_image_spec("24.04-lts").unwrap();
         assert_eq!(img.publisher, "Canonical");
@@ -614,9 +625,15 @@ mod tests {
 
     #[test]
     fn test_from_image_spec_shorthand_dotless_ubuntu2510() {
-        // "Ubuntu2510" as documented in --os help text
+        // Existing dotless shorthands continue to work.
         let img = VmImage::from_image_spec("Ubuntu2510").unwrap();
         assert_eq!(img.offer, "ubuntu-25_10");
+    }
+
+    #[test]
+    fn test_from_image_spec_shorthand_dotless_ubuntu2604() {
+        let img = VmImage::from_image_spec("Ubuntu2604").unwrap();
+        assert_eq!(img.offer, "ubuntu-26_04-lts");
     }
 
     #[test]

--- a/rust/crates/azlin/src/display_helpers.rs
+++ b/rust/crates/azlin/src/display_helpers.rs
@@ -88,6 +88,7 @@ pub fn format_os_display(os_offer: Option<&str>, os_type: &azlin_core::models::O
 
 /// Parse Ubuntu offer strings into human-readable format.
 /// Handles multiple Azure offer formats:
+///   "ubuntu-26_04-lts" -> "Ubuntu 26.04 LTS"
 ///   "ubuntu-24_04-lts" -> "Ubuntu 24.04 LTS"
 ///   "ubuntu-25_10" -> "Ubuntu 25.10"
 ///   "0001-com-ubuntu-server-jammy" -> "Ubuntu 22.04 LTS"

--- a/rust/crates/azlin/src/display_helpers_tests.rs
+++ b/rust/crates/azlin/src/display_helpers_tests.rs
@@ -105,6 +105,14 @@ fn test_format_os_display_ubuntu_version() {
 }
 
 #[test]
+fn test_format_os_display_ubuntu_26_04_lts() {
+    assert_eq!(
+        format_os_display(Some("ubuntu-26_04-lts"), &azlin_core::models::OsType::Linux),
+        "Ubuntu 26.04 LTS"
+    );
+}
+
+#[test]
 fn test_format_os_display_ubuntu_non_lts() {
     assert_eq!(
         format_os_display(Some("ubuntu-25_10"), &azlin_core::models::OsType::Linux),

--- a/rust/crates/azlin/src/tests/test_group_46.rs
+++ b/rust/crates/azlin/src/tests/test_group_46.rs
@@ -10,6 +10,15 @@ fn test_format_os_display_ubuntu_version_lts() {
 }
 
 #[test]
+fn test_format_os_display_ubuntu_26_04_lts() {
+    let result = crate::display_helpers::format_os_display(
+        Some("ubuntu-26_04-lts"),
+        &azlin_core::models::OsType::Linux,
+    );
+    assert_eq!(result, "Ubuntu 26.04 LTS");
+}
+
+#[test]
 fn test_format_os_display_ubuntu_version_no_lts() {
     let result = crate::display_helpers::format_os_display(
         Some("ubuntu-25_10"),

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -92,7 +92,7 @@ azlin new --name myproject
 
 azlin will:
 
-1. ✓ Create an Ubuntu 24.04 VM
+1. ✓ Create an Ubuntu 26.04 LTS VM
 2. ✓ Install 12 development tools
 3. ✓ Configure SSH access
 4. ✓ Start tmux session
@@ -196,7 +196,7 @@ This guide walks you through creating your first Azure VM with azlin in detail.
 
 By the end of this tutorial, you'll have:
 
-- A running Ubuntu 24.04 VM in Azure
+- A running Ubuntu 26.04 LTS VM in Azure
 - 12 development tools pre-installed
 - SSH access configured
 - A persistent tmux session
@@ -279,7 +279,7 @@ You'll see:
 ✓ SSH configured
 → Connecting to my-first-vm...
 
-Welcome to Ubuntu 24.04 LTS
+Welcome to Ubuntu 26.04 LTS
 
 azureuser@my-first-vm:~$
 ```
@@ -493,7 +493,7 @@ Understand the core concepts behind azlin to use it effectively.
 
 ### Virtual Machines (VMs)
 
-azlin creates **Ubuntu 24.04 LTS** virtual machines in Azure with development tools pre-installed.
+azlin creates **Ubuntu 26.04 LTS** virtual machines in Azure with development tools pre-installed.
 
 **Key characteristics:**
 


### PR DESCRIPTION
## Summary
- change the built-in VM image fallback to Ubuntu 26.04 LTS
- add 26.04/26.04-lts shorthand support and matching tests
- update docs that describe the default VM OS image

## Validation
- cd rust && cargo test -p azlin-core vm_image --quiet
- cd rust && cargo test -p azlin-core default_vm_image --quiet
- cd rust && cargo test -p azlin-cli --quiet
- cd rust && cargo run -p azlin --bin azlin --quiet -- new --help