### PR TITLE
feat: update default dev-tool/OS versions to latest releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,14 @@ git clone https://github.com/rysweet/azlin && cd azlin/rust && cargo install --p
 
 ### Self-Update
 
+Update the azlin binary itself to the latest release:
+
 ```bash
-azlin update
+azlin update          # alias: azlin self-update
 ```
+
+> Note: `azlin update <vm>` (with a VM argument) instead updates the development
+> tools *on that VM* — see [VM Maintenance](#vm-maintenance).
 
 ### Verify
 
@@ -60,15 +65,11 @@ azlin new --repo https://github.com/owner/repo
 azlin health
 ```
 
-`azlin new` selects the first available public key from
-`~/.ssh/azlin_key.pub`, `~/.ssh/id_ed25519_azlin.pub`,
-`~/.ssh/id_ed25519.pub`, then `~/.ssh/id_rsa.pub`. When create-time home
-seeding, repo clone, or first auto-connect shell run, azlin reuses the
-matching private key for those phases too. If one of those post-create SSH
-phases is enabled and the matching private key is missing, `azlin new` now
-errors instead of silently falling back to a different identity. If the create
-flow routes through bastion, `azlin new --bastion-name <name>` is reused for
-the later auth-forward, home seeding, and first auto-connect phases too.
+By default, `azlin new` picks up your existing SSH public key (trying
+`~/.ssh/azlin_key.pub`, `~/.ssh/id_ed25519_azlin.pub`, `~/.ssh/id_ed25519.pub`,
+then `~/.ssh/id_rsa.pub`) and reuses the matching private key for home seeding,
+repo clone, and the first auto-connect. See [Connection](#connection) for
+details and bastion behavior.
 
 ## What is azlin?
 
@@ -212,74 +213,8 @@ Before using azlin, ensure these tools are installed:
 - `uv`
 - `python`
 
-**macOS**: `brew install azure-cli gh git tmux`
-**Linux**: See platform-specific installation in Prerequisites module
-
-### Copy Files to/from VMs
-
-```bash
-azlin cp myfile.txt vm1:~/
-azlin cp vm1:~/data.txt ./
-```
-
-### Home Directory Sync
-
-Automatically sync your configuration files from `~/.azlin/home/` to all VMs:
-
-```bash
-# Setup: Place your dotfiles in ~/.azlin/home/
-mkdir -p ~/.azlin/home
-cp ~/.bashrc ~/.vimrc ~/.gitconfig ~/.azlin/home/
-
-# Auto-syncs on VM creation and login
-azlin new # Dotfiles automatically synced after provisioning
-
-# Manual sync to specific VM
-azlin sync --vm-name my-vm
-
-# Preview what would be synced
-azlin sync --dry-run
-```
-
-**Security**: Automatically blocks SSH keys, cloud credentials, .env files, and other secrets.
-
-### Bidirectional File Transfer
-
-Copy files between your local machine and VMs:
-
-```bash
-# Copy local file to VM
-azlin cp report.pdf vm1:~/documents/
-
-# Copy from VM to local
-azlin cp vm1:~/results.tar.gz ./
-
-# Preview transfer
-azlin cp --dry-run large-dataset.zip vm1:~/
-```
-
-### Azure Bastion (Secure Access)
-
-Connect to VMs securely without public IPs using Azure Bastion:
-
-```bash
-# List available Bastion hosts
-azlin bastion list
-
-# Connect to VM through Bastion (auto-detected when available)
-azlin connect my-vm
-
-# Configure VM to use specific Bastion
-azlin bastion configure my-vm --bastion-name my-bastion --resource-group my-rg
-```
-
-**Security Benefits**: Bastion eliminates internet-facing access to VMs, providing enhanced security through centralized access control, audit logging, and compliance with security policies requiring private-only VMs.
-
-**Cost**: ~$289/month per Bastion host (Standard SKU, shared across all VMs in the VNet).
-
-**Note**: azlin requires Standard SKU to enable CLI tunneling via `az network bastion tunnel`. Basic SKU only supports browser-based access.
-
-For complete documentation, see the [Azure Bastion](#azure-bastion-secure-vm-access) section.
+**macOS**: `brew install azure-cli gh git tmux uv python`
+**Linux**: Install the Azure CLI and GitHub CLI from their official apt/dnf repositories; `git`, `ssh`, `tmux`, and `python` are available from your distro's package manager.
 
 ## Authentication
 
@@ -815,22 +750,6 @@ azlin killall --force
 **Defaults:**
 - `--prefix`: "azlin" (only deletes azlin-created VMs)
 
-### Deletion Commands Comparison
-
-| Feature | `kill` | `destroy` | `killall` |
-|---------|--------|-----------|-----------|
-| Delete single VM | ✓ | ✓ | ✗ |
-| Delete multiple VMs | ✗ | ✗ | ✓ |
-| Dry-run mode | ✗ | ✓ | ✗ |
-| Delete resource group | ✗ | ✓ | ✗ |
-| Confirmation | ✓ | ✓ | ✓ |
-| Force flag | ✓ | ✓ | ✓ |
-
-**When to use:**
-- `kill` - Simple, quick VM deletion
-- `destroy` - Advanced with dry-run and RG deletion
-- `killall` - Bulk cleanup of multiple VMs
-
 ### `azlin prune` - Automated VM cleanup
 
 Intelligently identify and delete idle or unused VMs based on age and activity.
@@ -1190,12 +1109,16 @@ See [GUI Forwarding Guide](docs/GUI_FORWARDING.md) for prerequisites, options, a
 
 ## Monitoring
 
+All monitoring commands (`azlin top`, `azlin w`, `azlin ps`) automatically
+discover your VMs via tag-based discovery — including custom-named VMs and
+compound `hostname:session` formats — so you never need to list them manually.
+
 ### `azlin top` - Distributed real-time monitoring
 
-Monitor CPU, memory, and processes across all VMs in a unified dashboard. Automatically discovers all azlin VMs using tag-based discovery, including VMs with custom names.
+Monitor CPU, memory, and processes across all VMs in a unified dashboard.
 
 ```bash
-# Default: 10 second refresh (discovers all azlin VMs including custom-named)
+# Default: 10 second refresh
 azlin top
 
 # Custom refresh rate (5 second refresh)
@@ -1217,16 +1140,12 @@ azlin top -i 15 -t 10
 - `--interval, -i SECONDS` - Refresh rate (default: 10 seconds)
 - `--timeout, -t SECONDS` - SSH timeout per VM (default: 5 seconds)
 
-**Output:** Real-time dashboard showing all VMs (including custom-named):
-- CPU usage per VM
-- Memory utilization
-- System load averages
-- Top processes
+**Output:** Real-time dashboard showing per-VM CPU usage, memory utilization,
+system load averages, and top processes.
 
 **Use cases:**
-- Monitor distributed workloads across custom-named VMs
+- Monitor distributed workloads across the fleet
 - Identify resource bottlenecks
-- Track performance across fleet (regardless of naming convention)
 - Real-time capacity planning
 
 Press Ctrl+C to exit.
@@ -1235,17 +1154,15 @@ Press Ctrl+C to exit.
 
 Run the `w` command on all VMs to see active users and their processes.
 
-**All monitoring commands (`azlin w`, `azlin ps`, `azlin top`) automatically discover VMs using tag-based discovery, supporting custom VM names including compound formats like "hostname:session".**
-
 ```bash
-# Run 'w' on all VMs (discovers all azlin VMs including custom-named)
+# Run 'w' on all VMs
 azlin w
 
 # Run on specific resource group
 azlin w --resource-group my-rg
 ```
 
-**Output** (showing custom-named VMs):
+**Output:**
 ```
 === VM: myhost:dev (20.12.34.56) ===
  12:34:56 up  2:15,  1 user,  load average: 0.52, 0.58, 0.59
@@ -1255,15 +1172,15 @@ azureuser pts/0   192.168.1.1      10:30    0.00s  0.04s  0.00s w
 
 **Use cases**:
 - Check if anyone is using a VM
-- Monitor system load across all VMs (including custom-named)
+- Monitor system load across all VMs
 - See active sessions
 
 ### `azlin ps` - Show running processes
 
-Run `ps aux` on all VMs to see all processes. Automatically discovers all azlin VMs using tag-based discovery.
+Run `ps aux` on all VMs to see all processes.
 
 ```bash
-# Show all processes on all VMs (discovers all azlin VMs including custom-named)
+# Show all processes on all VMs
 azlin ps
 
 # Show on specific resource group
@@ -1271,8 +1188,8 @@ azlin ps --resource-group my-rg
 ```
 
 **Use cases**:
-- Find runaway processes across fleet
-- Monitor resource usage (including custom-named VMs)
+- Find runaway processes across the fleet
+- Monitor resource usage
 - Debug performance issues
 
 ---

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ the later auth-forward, home seeding, and first auto-connect phases too.
 azlin automates the tedious process of setting up Azure Ubuntu VMs for development. In one command, it:
 
 1. Authenticates with Azure
-2. Provisions an Ubuntu 24.04 VM
+2. Provisions an Ubuntu 26.04 LTS VM
 3. Installs 12 essential development tools
 4. Creates a separate 100GB Premium SSD for /home (persistent storage), with optional /tmp disk
 5. Sets up SSH with key-based authentication
@@ -123,9 +123,11 @@ azlin logs my-vm --lines 50           # View last 50 lines
 ```
 
 ### Ubuntu Version Selection
-Specify Ubuntu version when creating VMs:
+VMs default to **Ubuntu 26.04 LTS**. Specify a different Ubuntu version when creating VMs:
 ```bash
+azlin new --os 26.04         # Ubuntu 26.04 LTS (default)
 azlin new --os 25.10         # Ubuntu 25.10
+azlin new --os 24.04-lts     # Ubuntu 24.04 LTS
 ```
 
 ### Separate /tmp Disk Support
@@ -154,11 +156,11 @@ Every azlin VM comes pre-configured with:
 2. **Azure CLI (az)** - Azure management
 3. **GitHub CLI (gh)** - GitHub integration
 4. **Git** - Version control
-5. **Node.js** - JavaScript runtime with user-local npm configuration
-6. **Python 3.13+** - Python runtime + pip (latest stable version from deadsnakes PPA)
+5. **Node.js** - JavaScript runtime (24.x LTS via NodeSource) with user-local npm configuration
+6. **Python 3.14+** - Python runtime + pip (latest stable version from deadsnakes PPA)
 7. **Rust** - Systems programming language
 8. **Golang** - Go programming language
-9. **.NET 10 RC** - .NET development framework
+9. **.NET 10** - .NET development framework
 10. **GitHub Copilot CLI** - AI-powered coding assistant
 11. **OpenAI Codex CLI** - AI code generation
 12. **Claude Code CLI** - AI coding assistant
@@ -194,7 +196,7 @@ grep '[AZLIN_VERSION]' /var/log/cloud-init-output.log
 # [AZLIN_VERSION] rg: 14.1.0
 ```
 
-**Note**: The versions shown are examples. Actual versions depend on Ubuntu repository state at provision time. npm is bundled with Node.js 20.x LTS (installed via apt), not installed separately.
+**Note**: The versions shown are examples. Actual versions depend on Ubuntu repository state at provision time. npm is bundled with Node.js 24.x LTS (installed via NodeSource), not installed separately.
 
 This provides an audit trail of exactly which tool versions were installed, useful for troubleshooting and compliance.
 

--- a/docs-site/commands/vm/new.md
+++ b/docs-site/commands/vm/new.md
@@ -9,7 +9,7 @@ The `azlin new` command is the core of azlin - it provisions a fully-equipped Az
 **What gets installed on every VM:**
 - Docker, Azure CLI, GitHub CLI, Git
 - Node.js with user-local npm configuration
-- Python 3.13+, Rust, Golang, .NET 10 RC
+- Python 3.14+, Rust, Golang, .NET 10
 - ripgrep (rg) for fast code search
 - AI tools: GitHub Copilot CLI, OpenAI Codex CLI, Claude Code CLI
 - Persistent tmux session management
@@ -292,7 +292,7 @@ When you run `azlin new`, the following happens automatically:
 
 1. **Authentication** - Verifies Azure CLI authentication
 2. **Prerequisites** - Checks SSH keys and required tools
-3. **VM Creation** - Provisions Ubuntu 24.04 VM with your chosen size
+3. **VM Creation** - Provisions Ubuntu 26.04 LTS VM with your chosen size
 4. **Cloud-Init** - Installs all development tools (4-5 minutes)
 5. **SSH Key Storage** - Automatically stores private key in Azure Key Vault for cross-system access
 6. **NFS Storage** (optional) - Mounts shared persistent home directory
@@ -345,10 +345,10 @@ Every VM runs a comprehensive cloud-init script that:
 3. Configures non-root Docker access
 4. Installs Azure CLI, GitHub CLI, Git
 5. Sets up Node.js with user-local npm (no sudo needed)
-6. Installs Python 3.13+ from deadsnakes PPA
+6. Installs Python 3.14+ from deadsnakes PPA
 7. Installs Rust via rustup
 8. Installs Golang
-9. Installs .NET 10 RC
+9. Installs .NET 10
 10. Installs ripgrep (rg) for fast search
 11. Installs AI CLI tools (Copilot, Codex, Claude)
 12. Configures tmux for persistent sessions

--- a/docs-site/faq.md
+++ b/docs-site/faq.md
@@ -53,7 +53,7 @@ Typically 4-7 minutes. The breakdown:
 
 ### What tools are pre-installed on VMs?
 
-Every VM gets: Docker, Azure CLI, GitHub CLI, Git, Node.js, Python 3.13+, Rust, Go, .NET, GitHub Copilot CLI, OpenAI Codex CLI, and Claude Code CLI.
+Every VM gets: Docker, Azure CLI, GitHub CLI, Git, Node.js, Python 3.14+, Rust, Go, .NET, GitHub Copilot CLI, OpenAI Codex CLI, and Claude Code CLI.
 
 ### Can I customize what gets installed?
 

--- a/docs-site/getting-started/concepts.md
+++ b/docs-site/getting-started/concepts.md
@@ -7,7 +7,7 @@ Understand the core concepts behind azlin to use it effectively.
 
 ### Virtual Machines (VMs)
 
-azlin creates **Ubuntu 24.04 LTS** virtual machines in Azure with development tools pre-installed.
+azlin creates **Ubuntu 26.04 LTS** virtual machines in Azure with development tools pre-installed.
 
 **Key characteristics:**
 

--- a/docs-site/getting-started/first-vm.md
+++ b/docs-site/getting-started/first-vm.md
@@ -7,7 +7,7 @@ This guide walks you through creating your first Azure VM with azlin in detail.
 
 By the end of this tutorial, you'll have:
 
-- A running Ubuntu 24.04 VM in Azure
+- A running Ubuntu 26.04 LTS VM in Azure
 - 12 development tools pre-installed
 - SSH access configured
 - A persistent tmux session
@@ -90,7 +90,7 @@ You'll see:
 ✓ SSH configured
 → Connecting to my-first-vm...
 
-Welcome to Ubuntu 24.04 LTS
+Welcome to Ubuntu 26.04 LTS
 
 azureuser@my-first-vm:~$
 ```
@@ -183,10 +183,10 @@ The VM came with these tools pre-installed:
 
 **Programming Languages:**
 - Node.js with npm
-- Python 3.13 with pip
+- Python 3.14 with pip
 - Rust with cargo
 - Go
-- .NET 10 RC
+- .NET 10
 
 **AI Coding Assistants:**
 - GitHub Copilot CLI

--- a/docs-site/getting-started/quickstart.md
+++ b/docs-site/getting-started/quickstart.md
@@ -37,7 +37,7 @@ azlin new --name myproject
 
 azlin will:
 
-1. Create an Ubuntu 24.04 VM
+1. Create an Ubuntu 26.04 LTS VM
 2. Install 12 development tools
 3. Configure SSH access
 4. Start tmux session

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -43,7 +43,7 @@
 azlin automates the tedious process of setting up Azure Ubuntu VMs for development. Written in Rust for blazing-fast startup (75-85x faster than the original Python implementation), it provisions a fully configured VM in one command:
 
 1. Authenticates with Azure
-2. Provisions an Ubuntu 24.04 VM
+2. Provisions an Ubuntu 26.04 LTS VM
 3. Installs 12 essential development tools
 4. Sets up SSH with key-based authentication
 5. Starts a persistent tmux session
@@ -124,7 +124,7 @@ Every azlin VM comes pre-configured with:
 === "Languages"
 
     - **Node.js** - JavaScript runtime with user-local npm
-    - **Python 3.13+** - Latest Python from deadsnakes PPA
+    - **Python 3.14+** - Latest Python from deadsnakes PPA
     - **Rust** - Systems programming language
     - **Golang** - Go programming language
     - **.NET** - .NET development framework

--- a/docs-site/vm-lifecycle/creating.md
+++ b/docs-site/vm-lifecycle/creating.md
@@ -253,7 +253,7 @@ Typical provisioning times:
 Every azlin VM comes with:
 
 **Development Tools:**
-- Python 3.13 (with uv package manager)
+- Python 3.14 (with uv package manager)
 - Docker & Docker Compose
 - Node.js & npm
 - Git & GitHub CLI (gh)

--- a/docs/AMPLIFIER_CHEATSHEET.md
+++ b/docs/AMPLIFIER_CHEATSHEET.md
@@ -55,7 +55,7 @@ azlin new --vm-size Standard_D4s_v3 --repo https://github.com/microsoft/amplifie
 ```
 
 **What happens:**
-- Provisions Ubuntu 24.04 VM on Azure
+- Provisions Ubuntu 26.04 LTS VM on Azure
 - Installs 12 dev tools (Docker, Node.js, Python, Go, Rust, etc.)
 - Clones amplifier repo to `~/amplifier`
 - Auto-connects via SSH with tmux

--- a/docs/AZLIN.md
+++ b/docs/AZLIN.md
@@ -176,7 +176,7 @@ azlin new --home-disk-size 200 --tmp-disk-size 128  # Both disks
 
 **What gets installed**:
 - Docker, Azure CLI, GitHub CLI, Git
-- Node.js, Python 3.13+, Rust, Golang, .NET 10
+- Node.js, Python 3.14+, Rust, Golang, .NET 10
 - GitHub Copilot CLI, OpenAI Codex CLI, Claude Code CLI
 - tmux, vim, and essential utilities
 

--- a/docs/features/vm-os-image-selection.md
+++ b/docs/features/vm-os-image-selection.md
@@ -4,7 +4,7 @@ Choose the operating system image for new VMs via the `--os` flag or persistent 
 
 ## Overview
 
-By default, `azlin new` provisions VMs with Ubuntu 25.10. You can override this per-command with `--os` or set a persistent default with `azlin config set default_vm_image`.
+By default, `azlin new` provisions VMs with Ubuntu 26.04 LTS. You can override this per-command with `--os` or set a persistent default with `azlin config set default_vm_image`.
 
 ## Quick Start
 
@@ -33,6 +33,8 @@ Convenient aliases for common Ubuntu versions:
 
 | Shorthand | Resolved Image URN |
 |-----------|-------------------|
+| `26.04-lts` | `Canonical:ubuntu-26_04-lts:server:latest` |
+| `26.04` | `Canonical:ubuntu-26_04-lts:server:latest` |
 | `25.10` | `Canonical:ubuntu-25_10:server:latest` |
 | `24.10` | `Canonical:ubuntu-24_10:server:latest` |
 | `24.04-lts` | `Canonical:ubuntu-24_04-lts:server:latest` |
@@ -68,7 +70,7 @@ azlin config set default_vm_image "Canonical:ubuntu-24_04-lts:server:latest"
 # View current default
 azlin config get default_vm_image
 
-# Remove default (revert to built-in Ubuntu 25.10)
+# Remove default (revert to built-in Ubuntu 26.04 LTS)
 azlin config unset default_vm_image
 ```
 
@@ -94,7 +96,7 @@ When creating a VM, the OS image is resolved in this order (highest priority fir
 
 1. **`--os` flag** — per-command override
 2. **`default_vm_image` config** — persistent default in `~/.azlin/config.toml`
-3. **Built-in default** — Ubuntu 25.10 (`Canonical:ubuntu-25_10:server:latest`)
+3. **Built-in default** — Ubuntu 26.04 LTS (`Canonical:ubuntu-26_04-lts:server:latest`)
 
 ```bash
 # Uses --os flag (highest priority)
@@ -103,7 +105,7 @@ azlin new --os 22.04-lts
 # Uses config default_vm_image (if set)
 azlin new
 
-# Uses built-in Ubuntu 25.10 (if no config set and no --os)
+# Uses built-in Ubuntu 26.04 LTS (if no config set and no --os)
 azlin new
 ```
 
@@ -159,12 +161,12 @@ Invalid input produces a clear error:
 ```
 $ azlin new --os "NotAPublisher:image:sku:latest"
 Error: Only Canonical publisher is supported for VM images, got "NotAPublisher".
-  Use a URN like 'Canonical:ubuntu-25_10:server:latest'
+  Use a URN like 'Canonical:ubuntu-26_04-lts:server:latest'
 
 $ azlin new --os "not-a-version"
 Error: Unknown image shorthand "not-a-version". Supported shorthands:
-  25.10, 24.10, 24.04-lts, 24.04, 22.04-lts, 22.04, 20.04-lts, 20.04.
-  Or use a full URN like 'Canonical:ubuntu-25_10:server:latest'
+  26.04-lts, 26.04, 25.10, 24.10, 24.04-lts, 24.04, 22.04-lts, 22.04, 20.04-lts, 20.04.
+  Or use a full URN like 'Canonical:ubuntu-26_04-lts:server:latest'
 ```
 
 ## Troubleshooting

--- a/docs/reference/config-default-behaviors.md
+++ b/docs/reference/config-default-behaviors.md
@@ -37,9 +37,9 @@ default_vm_size = "Standard_E16as_v5"
 
 # Default OS image for new VMs (shorthand or full URN)
 # Type: string (optional)
-# Default: None (falls back to Ubuntu 25.10)
+# Default: None (falls back to Ubuntu 26.04 LTS)
 # CLI Override: --os <IMAGE_SPEC>
-# Valid shorthands: 25.10, 24.10, 24.04-lts, 24.04, 22.04-lts, 22.04, 20.04-lts, 20.04
+# Valid shorthands: 26.04-lts, 26.04, 25.10, 24.10, 24.04-lts, 24.04, 22.04-lts, 22.04, 20.04-lts, 20.04
 # Valid URN format: Canonical:<offer>:<sku>:<version>
 default_vm_image = "Canonical:ubuntu-24_04-lts:server:latest"
 

--- a/rust/crates/azlin-azure/src/cloud_init.rs
+++ b/rust/crates/azlin-azure/src/cloud_init.rs
@@ -314,8 +314,8 @@ CHROMIUMALIAS
 chmod 755 /usr/local/bin/chromium"#.to_string(),
         // astral-uv (uv package manager)
         "snap install astral-uv --classic || true".to_string(),
-        // Node.js 22 LTS (via NodeSource)
-        "curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt install -y nodejs".to_string(),
+        // Node.js 24 LTS (via NodeSource)
+        "curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && apt install -y nodejs".to_string(),
         // npm user-local configuration
         format!("mkdir -p /home/{u}/.npm-packages && echo 'prefix=${{HOME}}/.npm-packages' > /home/{u}/.npmrc && chown {u}:{u} /home/{u}/.npmrc /home/{u}/.npm-packages", u = username),
         // Tmux configuration
@@ -344,7 +344,7 @@ chmod 755 /usr/local/bin/chromium"#.to_string(),
             chmod +x ~/.cargo/bin/azlin 2>/dev/null; \
             rm -rf /tmp/azlin-install' || echo 'WARNING: azlin installation failed'", u = username),
         // Go
-        "wget -q https://go.dev/dl/go1.26.1.linux-amd64.tar.gz -O /tmp/go.tar.gz && tar -C /usr/local -xzf /tmp/go.tar.gz && rm /tmp/go.tar.gz".to_string(),
+        "wget -q https://go.dev/dl/go1.26.4.linux-amd64.tar.gz -O /tmp/go.tar.gz && tar -C /usr/local -xzf /tmp/go.tar.gz && rm /tmp/go.tar.gz".to_string(),
         // .NET 10 SDK
         "curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh && chmod +x /tmp/dotnet-install.sh && (/tmp/dotnet-install.sh --channel 10.0 --install-dir /usr/share/dotnet || echo 'WARNING: .NET 10 SDK install failed') && ln -sf /usr/share/dotnet/dotnet /usr/local/bin/dotnet; rm -f /tmp/dotnet-install.sh".to_string(),
         // Docker post-install

--- a/rust/crates/azlin-cli/src/lib.rs
+++ b/rust/crates/azlin-cli/src/lib.rs
@@ -260,7 +260,7 @@ pub enum Commands {
         #[arg(long)]
         tmp_disk_size: Option<u32>,
 
-        /// OS image (e.g., 25.10, 24.04-lts, Ubuntu2510, or full URN like Canonical:ubuntu-25_10:server:latest; default: Ubuntu 25.10)
+        /// OS image (e.g., 26.04, 24.04-lts, Ubuntu2604, or full URN like Canonical:ubuntu-26_04-lts:server:latest; default: Ubuntu 26.04 LTS)
         #[arg(long)]
         os: Option<String>,
     },
@@ -4510,7 +4510,10 @@ mod tests {
         } = cli.command
         {
             assert!(!public, "VMs should default to private (no --public)");
-            assert!(!private, "--private is hidden compat flag, not set by default");
+            assert!(
+                !private,
+                "--private is hidden compat flag, not set by default"
+            );
         } else {
             panic!("Expected New command");
         }

--- a/rust/crates/azlin-core/src/config.rs
+++ b/rust/crates/azlin-core/src/config.rs
@@ -109,7 +109,7 @@ pub struct AzlinConfig {
     pub vm_storage: Option<HashMap<String, String>>,
     pub default_nfs_storage: Option<String>,
     pub github_runner_fleets: Option<HashMap<String, serde_json::Value>>,
-    /// Default VM OS image URN (e.g. "Canonical:ubuntu-25_10:server:latest").
+    /// Default VM OS image URN (e.g. "Canonical:ubuntu-26_04-lts:server:latest").
     /// When None, falls back to VmImage::default().
     pub default_vm_image: Option<String>,
     pub ssh_auto_sync_keys: bool,
@@ -1117,8 +1117,11 @@ mod tests {
     #[test]
     fn test_set_field_default_vm_image() {
         let config = AzlinConfig::default();
-        let (toml_str, _) =
-            simulate_set_field(&config, "default_vm_image", "Canonical:ubuntu-25_10:server:latest");
+        let (toml_str, _) = simulate_set_field(
+            &config,
+            "default_vm_image",
+            "Canonical:ubuntu-25_10:server:latest",
+        );
         assert!(
             toml_str.contains("default_vm_image"),
             "TOML should contain default_vm_image key after set_field"

--- a/rust/crates/azlin-core/src/models.rs
+++ b/rust/crates/azlin-core/src/models.rs
@@ -228,7 +228,7 @@ impl Default for VmImage {
     fn default() -> Self {
         Self {
             publisher: "Canonical".into(),
-            offer: "ubuntu-25_10".into(),
+            offer: "ubuntu-26_04-lts".into(),
             sku: "server".into(),
             version: "latest".into(),
         }
@@ -250,7 +250,7 @@ impl VmImage {
     ///
     /// Accepts:
     /// - Full URN: `Canonical:ubuntu-25_10:server:latest` (must be Canonical publisher)
-    /// - Shorthands: `25.10`, `24.04-lts`, `ubuntu-25.10`, `ubuntu-24.04-lts`
+    /// - Shorthands: `26.04`, `25.10`, `24.04-lts`, `ubuntu-26.04`, `ubuntu-24.04-lts`
     ///
     /// Returns an error for empty/whitespace input, shell metacharacters, non-Canonical
     /// publishers, malformed URNs, or unrecognized shorthands.
@@ -343,6 +343,7 @@ impl VmImage {
         // Accepts dotted (25.10) and dotless (2510) forms; bare versions
         // (24.04, 2204) resolve to LTS when available.
         let offer = match version_part {
+            "26.04-lts" | "26.04" | "2604" => "ubuntu-26_04-lts",
             "25.10" | "2510" => "ubuntu-25_10",
             "24.10" | "2410" => "ubuntu-24_10",
             "24.04-lts" | "24.04" | "2404" => "ubuntu-24_04-lts",
@@ -351,8 +352,8 @@ impl VmImage {
             _ => {
                 return Err(format!(
                     "Unknown image shorthand {:?}. Supported shorthands: \
-                     25.10, 24.10, 24.04-lts, 24.04, 22.04-lts, 22.04, 20.04-lts, 20.04. \
-                     Or use a full URN like 'Canonical:ubuntu-25_10:server:latest'",
+                     26.04-lts, 26.04, 25.10, 24.10, 24.04-lts, 24.04, 22.04-lts, 22.04, 20.04-lts, 20.04. \
+                     Or use a full URN like 'Canonical:ubuntu-26_04-lts:server:latest'",
                     spec
                 ));
             }
@@ -564,7 +565,7 @@ mod tests {
     fn test_vm_image_default() {
         let img = VmImage::default();
         assert_eq!(img.publisher, "Canonical");
-        assert_eq!(img.offer, "ubuntu-25_10");
+        assert_eq!(img.offer, "ubuntu-26_04-lts");
         assert_eq!(img.sku, "server");
         assert_eq!(img.version, "latest");
     }
@@ -572,7 +573,7 @@ mod tests {
     #[test]
     fn test_vm_image_display() {
         let img = VmImage::default();
-        assert_eq!(img.to_string(), "Canonical:ubuntu-25_10:server:latest");
+        assert_eq!(img.to_string(), "Canonical:ubuntu-26_04-lts:server:latest");
     }
 
     // ── from_image_spec tests (TDD — will fail until implementation) ──
@@ -584,6 +585,17 @@ mod tests {
         assert_eq!(img.offer, "ubuntu-25_10");
         assert_eq!(img.sku, "server");
         assert_eq!(img.version, "latest");
+    }
+
+    #[test]
+    fn test_from_image_spec_shorthand_26_04_lts() {
+        for spec in ["26.04", "26.04-lts", "2604", "ubuntu-26.04"] {
+            let img = VmImage::from_image_spec(spec).unwrap();
+            assert_eq!(img.publisher, "Canonical");
+            assert_eq!(img.offer, "ubuntu-26_04-lts");
+            assert_eq!(img.sku, "server");
+            assert_eq!(img.version, "latest");
+        }
     }
 
     #[test]
@@ -707,7 +719,8 @@ mod tests {
     #[test]
     fn test_from_image_spec_roundtrip_via_display() {
         // Parse a full URN, display it, re-parse — should be identical
-        let original = VmImage::from_image_spec("Canonical:ubuntu-24_04-lts:server:latest").unwrap();
+        let original =
+            VmImage::from_image_spec("Canonical:ubuntu-24_04-lts:server:latest").unwrap();
         let displayed = original.to_string();
         let reparsed = VmImage::from_image_spec(&displayed).unwrap();
         assert_eq!(original, reparsed);

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -92,7 +92,7 @@ azlin new --name myproject
 
 azlin will:
 
-1. ✓ Create an Ubuntu 24.04 VM
+1. ✓ Create an Ubuntu 26.04 LTS VM
 2. ✓ Install 12 development tools
 3. ✓ Configure SSH access
 4. ✓ Start tmux session
@@ -196,7 +196,7 @@ This guide walks you through creating your first Azure VM with azlin in detail.
 
 By the end of this tutorial, you'll have:
 
-- A running Ubuntu 24.04 VM in Azure
+- A running Ubuntu 26.04 LTS VM in Azure
 - 12 development tools pre-installed
 - SSH access configured
 - A persistent tmux session
@@ -279,7 +279,7 @@ You'll see:
 ✓ SSH configured
 → Connecting to my-first-vm...
 
-Welcome to Ubuntu 24.04 LTS
+Welcome to Ubuntu 26.04 LTS
 
 azureuser@my-first-vm:~$
 ```
@@ -372,10 +372,10 @@ The VM came with these tools pre-installed:
 
 **Programming Languages:**
 - Node.js with npm
-- Python 3.13 with pip
+- Python 3.14 with pip
 - Rust with cargo
 - Go
-- .NET 10 RC
+- .NET 10
 
 **AI Coding Assistants:**
 - GitHub Copilot CLI
@@ -493,7 +493,7 @@ Understand the core concepts behind azlin to use it effectively.
 
 ### Virtual Machines (VMs)
 
-azlin creates **Ubuntu 24.04 LTS** virtual machines in Azure with development tools pre-installed.
+azlin creates **Ubuntu 26.04 LTS** virtual machines in Azure with development tools pre-installed.
 
 **Key characteristics:**
 


### PR DESCRIPTION
## Summary

Updates azlin to provision the latest released OS and development-tool versions by default, and updates the README and docs to match.

### Changes
- **VM default OS**: Ubuntu 25.10 → **Ubuntu 26.04 LTS** (`Canonical:ubuntu-26_04-lts:server:latest`)
  - Added `26.04` / `26.04-lts` / `2604` shorthand mapping + new `test_from_image_spec_shorthand_26_04_lts`
  - Updated doc comments, error messages, and the `--os` CLI help text
- **Node.js** (NodeSource): `setup_22.x` → `setup_24.x` (24 LTS)
- **Go**: `go1.26.1` → `go1.26.4`
- **.NET**: install already uses `dotnet-install.sh --channel 10.0` (now .NET 10 GA); doc wording `.NET 10 RC` → `.NET 10`
- **Python**: docs `3.13+` → `3.14+`
- **Docs**: README, `docs/`, `docs-site/`, and `scripts/generate_docs.py` updated for consistency

Existing `24.04-lts` / `25.10` shorthands remain valid and are intentionally left in place as selectable options/examples.

## Verification
- `cargo build --workspace` ✅
- `cargo test --workspace --lib --bins` ✅ (3,136 unit/bin tests pass, incl. new shorthand test)
- `cargo fmt` clean on all changed files; `cargo clippy --workspace` exits clean (only pre-existing warnings in unrelated test files)
- Repo-wide grep confirms no stale default version strings remain; remaining `24.04`/`25.10` hits are valid shorthands, parser tests, and display-formatter codename maps

## Out of scope
- Pre-existing staged `.github/hooks/*` and `.claude` changes were intentionally left untouched
- Pre-existing fmt drift in unrelated files was not reformatted

🤖 Generated with GitHub Copilot CLI

---

## README editorial cleanup (added commit `751d997`)

General tightening of the README without dropping any command coverage (net -83 lines):
- Clarified **Self-Update**: `azlin update` (alias `self-update`) updates the binary; noted the distinct `azlin update <vm>` for updating tools on a VM.
- Replaced the verbose post-Quick-Start SSH-key implementation paragraph with a concise summary linking to the Connection section.
- Removed duplicated **Verify** content.
- De-duplicated the **Monitoring** section boilerplate ("(discovers all azlin VMs including custom-named)") — now stated once up front.
- Removed a duplicated **Deletion Commands Comparison** table.
- Removed feature-teaser subsections (cp/sync/bidirectional transfer/Bastion) that were mis-nested under **Prerequisites** and fully duplicated by their dedicated sections; fixed the vague Linux prerequisites note.

All commands and sections preserved; verified no internal anchor links broken.
