### PR TITLE
docs: drop SSH-key note from Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,6 @@ azlin new --repo https://github.com/owner/repo
 azlin health
 ```
 
-By default, `azlin new` picks up your existing SSH public key (trying
-`~/.ssh/azlin_key.pub`, `~/.ssh/id_ed25519_azlin.pub`, `~/.ssh/id_ed25519.pub`,
-then `~/.ssh/id_rsa.pub`) and reuses the matching private key for home seeding,
-repo clone, and the first auto-connect. See [Connection](#connection) for
-details and bastion behavior.
-
 ## What is azlin?
 
 azlin automates the tedious process of setting up Azure Ubuntu VMs for development. In one command, it:


### PR DESCRIPTION
## Summary
Removes the explanatory SSH-key paragraph that followed the Quick Start command block. It dumped all four candidate `.pub` filenames as an aside, which read as clutter in the intro.

The behavior it described (reuse an existing key with `azlin_key` → `id_ed25519_azlin` → `id_ed25519` → `id_rsa` precedence, generate otherwise) is already documented in the **Smart Connection Behaviors** and **Connection** sections, so nothing is lost.

Quick Start is now just the commands to get going.

## Changes
- `README.md`: remove the post-Quick-Start SSH-key paragraph (−6 lines)

Docs-only; no code or tests affected.