### PR TITLE
fix(release): point maturin readme to local rust/README.md (fix Rust Release on main)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "azlin"
-version = "2.6.75"
+version = "2.6.76"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-ai"
-version = "2.6.75"
+version = "2.6.76"
 dependencies = [
  "anyhow",
  "azlin-core",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-azure"
-version = "2.6.75"
+version = "2.6.76"
 dependencies = [
  "anyhow",
  "azlin-core",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-cli"
-version = "2.6.75"
+version = "2.6.76"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-core"
-version = "2.6.75"
+version = "2.6.76"
 dependencies = [
  "anyhow",
  "chrono",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-ssh"
-version = "2.6.75"
+version = "2.6.76"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/pyproject.toml
+++ b/rust/pyproject.toml
@@ -9,7 +9,7 @@ description = "Azure VM fleet management CLI (Rust) — provision, manage, and m
 requires-python = ">=3.8"
 license = {text = "MIT"}
 authors = [{name = "Ryan Sweet", email = "rysweet@microsoft.com"}]
-readme = "../README.md"
+readme = "README.md"
 keywords = ["azure", "vm", "cli", "rust", "devops", "cloud", "provisioning"]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary

Fixes the persistent failure of the **Rust Release** workflow on `main`.

`rust/pyproject.toml` declared `readme = "../README.md"` (the repo-root README). maturin (>=1.9) enforces that `project.readme` must resolve **inside** the metadata root. Because the maturin build runs with `working-directory: rust`, `../README.md` resolves outside `.../azlin/rust`, so maturin aborts **before** compilation on every wheel target:

```
💥 maturin failed
  Caused by: `project.readme` path `../README.md` resolves outside allowed metadata root `.../azlin/rust`
```

This broke **all** `wheels` matrix jobs (macos-aarch64 failed first; the rest were fail-fast-cancelled), making Rust Release red on `main` for 3 consecutive push runs (2026-06-24, -26, -29).

## Fix

Point `readme` at the already-present, rust-specific `rust/README.md` — a one-line change. This is also semantically more correct: it is the long-description for the `azlin-rs` package rather than the umbrella repo README.

```diff
-readme = "../README.md"
+readme = "README.md"
```

## Evidence

**Criteria 1 (validation) & 4 (CI green):**
- Reproduced the exact CI error locally with maturin 1.14.1:
  `maturin sdist` → `readme path '../README.md' resolves outside allowed metadata root` (matches CI).
- After the fix: `maturin sdist` exits 0, builds `azlin_rs-2.6.76.tar.gz`, and `PKG-INFO` contains a resolved `Description-Content-Type` (README embedded correctly).
- The readme-path check is metadata resolution (pre-compile, platform-independent), so the fix resolves the failure identically across all 4 wheel targets (linux/macos × x86_64/aarch64).
- `Rust CI` (runs on PRs touching `rust/**`) gates this PR.

**Criterion 2 (docs):** No user-facing surface change. Internal build-metadata config only; the published long-description now derives from `rust/README.md`.

**Criterion 3 (quality audit):** Change is a single-line, low-risk config correction with a reproduced-before / verified-after check. No logic/security surface touched.

**Criterion 6 (focused diff):** One line in `rust/pyproject.toml`. No unrelated edits (an incidental `Cargo.lock` version sync produced by the local sdist run was reverted).

## Scope note
Found via a grounded tier-0 CI sweep for the "steward CI GitHub Actions health across all governed repos" goal. Latest-run-per-workflow across all governed default branches was green **except** this azlin Rust Release regression, which the prior cycle's "all-green" premise had missed.

---

### Update: also fixes pre-existing Cargo.lock drift

Triggering `Rust CI` on this PR surfaced a separate pre-existing regression on `main`: the release `version-bump` had advanced `rust/Cargo.toml` to `2.6.76` but left `rust/Cargo.lock` crate versions at `2.6.75`, so `cargo build --locked` fails with *"cannot update the lock file because --locked was passed"*. Synced the 6 workspace member versions to `2.6.76` (dependencies unchanged). Verified locally: `cargo metadata --locked --offline` now returns 0. Diff is exactly 6 version lines.
