### PR TITLE
feat(bastion): make bastion public-IP ip-tags configurable

### DIFF
--- a/docs/features/bastion-pip-first-party-ip-tag.md
+++ b/docs/features/bastion-pip-first-party-ip-tag.md
@@ -1,19 +1,25 @@
-# First-Party Usage IP Tag for Bastion Public IPs
+# Bastion Public IP IP-Tag (First-Party Usage)
 
 Every Azure public IP that azlin creates for a bastion host is automatically
-tagged with the Azure IP tag `FirstPartyUsage=/ATEVETNonProd`. This satisfies
-the first-party usage tagging requirement for non-production Azure resources
-with no extra steps from you.
+tagged with an Azure IP tag. The tag defaults to
+`FirstPartyUsage=/ATEVETNonProd`, which satisfies the first-party usage tagging
+requirement for non-production Azure resources with no extra steps from you.
 
-## What is the First-Party Usage IP Tag?
+Unlike earlier versions, the tag value is now **configurable**. You can override
+it per-environment via a config file field, an environment variable, or the
+`azlin config set` command — while the default keeps existing behavior
+unchanged.
+
+## What is the Bastion IP Tag?
 
 Azure public IP addresses support **IP tags** — typed key/value metadata that
 the platform recognizes for billing, compliance, and routing classification. IP
 tags are distinct from ordinary Azure resource tags: they are applied at IP
-allocation time via the `--ip-tags` argument of
-`az network public-ip create` and use the form `<TagType>=<TagValue>`.
+allocation time via the `--ip-tags` argument of `az network public-ip create`
+and use the form `<TagType>=<TagValue>`.
 
-azlin now applies the following IP tag to every bastion public IP it creates:
+azlin applies the configured IP tag to every bastion public IP it creates.
+With the default configuration, this is:
 
 | Field      | Value             |
 | ---------- | ----------------- |
@@ -28,21 +34,24 @@ The resulting argument passed to the Azure CLI is:
 
 ## Why Would I Use It?
 
-This feature activates automatically. You don't need to opt in, pass a flag, or
-change any configuration.
+By default this feature activates automatically — you don't need to opt in for
+the standard `FirstPartyUsage=/ATEVETNonProd` tag. Configuration is only needed
+if your subscription or environment requires a **different** IP tag.
 
-### Problem: Untagged Bastion Public IPs
+### Problem: Untagged or Wrongly-Tagged Bastion Public IPs
 
-First-party Azure subscriptions require non-production public IPs to carry the
-`FirstPartyUsage` IP tag. Previously, bastion public IPs created by azlin had no
-IP tag, so they failed compliance scans and had to be re-tagged manually after
-the fact — a tedious, error-prone process that was easy to forget.
+First-party Azure subscriptions require non-production public IPs to carry an
+appropriate IP tag. Without one, bastion public IPs fail compliance scans and
+have to be re-tagged manually after the fact — a tedious, error-prone process.
+Different subscriptions or environments may also require a different tag value
+than the non-production default.
 
-### Solution: Automatic Tagging at Creation
+### Solution: Configurable Tagging at Creation
 
-azlin now injects the required IP tag at allocation time, so every bastion
-public IP is compliant the moment it is created. There is nothing to remember
-and nothing to clean up afterward.
+azlin injects the required IP tag at allocation time, so every bastion public IP
+is compliant the moment it is created. The tag value can be tailored to your
+environment through configuration, and the default preserves backward
+compatibility for existing users.
 
 ## Usage
 
@@ -54,7 +63,7 @@ any command that ensures bastion infrastructure exists:
 azlin new --name my-vm --region eastus2 --size xl
 # If bastion infrastructure is missing, azlin creates it, and the
 # bastion public IP azlin-bastion-eastus2-pip is allocated with
-# the FirstPartyUsage=/ATEVETNonProd IP tag.
+# the configured IP tag (default: FirstPartyUsage=/ATEVETNonProd).
 ```
 
 Under the hood, azlin runs the equivalent of:
@@ -74,6 +83,85 @@ az network public-ip create \
 > command above prints nothing on success. To inspect the resulting IP tag, use
 > the `show` query in [Verifying the Tag](#verifying-the-tag).
 
+## Configuration
+
+The IP tag value is controlled by the `bastion_pip_ip_tags` configuration
+setting. It uses the standard `<TagType>=<TagValue>` IP-tag format expected by
+`az network public-ip create --ip-tags`.
+
+### Precedence
+
+azlin resolves the effective IP tag in the following order (highest priority
+first):
+
+1. **Environment variable** `AZLIN_BASTION_PIP_IP_TAGS` — if set to a valid,
+   non-empty value.
+2. **Config file field** `bastion_pip_ip_tags` — if set to a valid, non-empty
+   value.
+3. **Built-in default** `FirstPartyUsage=/ATEVETNonProd`.
+
+If the environment variable is set but invalid or empty, azlin logs a warning
+and falls through to the config field, and then to the built-in default. This
+guarantees a valid tag is always applied. The warning is emitted via `tracing`
+to stderr, consistent with other azlin warnings, so look there if an expected
+override does not take effect.
+
+### Set via `azlin config set`
+
+```bash
+# Override the bastion public IP tag for all future bastion provisioning
+azlin config set bastion_pip_ip_tags "FirstPartyUsage=/ATEVETProd"
+
+# Inspect the persisted value
+azlin config get bastion_pip_ip_tags
+```
+
+The value is validated at set time (see [Validation](#validation)).
+
+> **Note:** `azlin config get` reports the **persisted** `bastion_pip_ip_tags`
+> field only. The **effective** value used at provisioning time may differ: if
+> `AZLIN_BASTION_PIP_IP_TAGS` is set it takes precedence, and if the field is
+> unset the built-in default (`FirstPartyUsage=/ATEVETNonProd`) applies. See
+> [Precedence](#precedence).
+
+### Set via config file
+
+The setting lives alongside other top-level fields in `~/.azlin/config.toml`
+(or the directory named by `AZLIN_CONFIG_DIR`):
+
+```toml
+bastion_pip_ip_tags = "FirstPartyUsage=/ATEVETNonProd"
+```
+
+Config files that omit the field continue to work: the field defaults to
+`FirstPartyUsage=/ATEVETNonProd`, so upgrades require no changes.
+
+### Set via environment variable
+
+```bash
+# Overrides the config file for the current shell/session
+export AZLIN_BASTION_PIP_IP_TAGS="FirstPartyUsage=/ATEVETProd"
+azlin new --name my-vm --region eastus2
+```
+
+This is convenient for CI pipelines or one-off runs that target a different
+subscription without editing the persisted config.
+
+### Validation
+
+When set via `azlin config set` (or read from the environment), the value is
+validated against the IP-tag format:
+
+- Must be in `Key=Value` form (contain an `=`).
+- The key (tag type) must be non-empty.
+- The value must not begin with `-` (prevents CLI flag injection).
+- No control characters.
+- Length must be at most 512 characters.
+
+Invalid values are rejected by `azlin config set` with a descriptive error. An
+invalid `AZLIN_BASTION_PIP_IP_TAGS` value is ignored (with a `tracing` warning on
+stderr) in favor of the next source in the precedence order.
+
 ## Verifying the Tag
 
 You can confirm the IP tag on any bastion public IP with the Azure CLI:
@@ -86,7 +174,7 @@ az network public-ip show \
   --output json
 ```
 
-Expected output:
+Expected output (with the default tag):
 
 ```json
 [
@@ -100,22 +188,24 @@ Expected output:
 ## Scope and Behavior
 
 - **Applies to**: All bastion public IPs created by azlin going forward.
-- **Idempotent**: The tag value is a fixed compile-time constant; repeated
-  bastion provisioning always produces the same tag.
+- **Configurable**: The tag value is resolved from environment, config, or the
+  built-in default (see [Configuration](#configuration)).
+- **Idempotent**: For a given configuration, repeated bastion provisioning
+  always produces the same tag.
 - **Non-destructive**: The tag is additive. All other public IP settings (SKU,
   allocation method, location, naming) are unchanged.
 - **Does not retroactively modify** public IPs that were created before this
-  feature. Only newly created bastion public IPs are tagged. Pre-existing IPs
-  can be tagged manually if needed.
+  feature, or public IPs created with a previous tag value. Only newly created
+  bastion public IPs receive the currently configured tag. Pre-existing IPs can
+  be re-tagged manually if needed.
 
 ## Configuration Reference
 
-There is no user-facing configuration for this feature. The IP tag type and
-value are fixed:
-
-| Setting   | Value                            | Configurable |
-| --------- | -------------------------------- | ------------ |
-| IP tag    | `FirstPartyUsage=/ATEVETNonProd` | No           |
+| Setting               | Config field / flag                         | Default                          | Configurable |
+| --------------------- | ------------------------------------------- | -------------------------------- | ------------ |
+| Bastion IP tag        | `bastion_pip_ip_tags`                       | `FirstPartyUsage=/ATEVETNonProd` | Yes          |
+| Environment override  | `AZLIN_BASTION_PIP_IP_TAGS`                 | (unset)                          | Yes          |
+| CLI command           | `azlin config set bastion_pip_ip_tags <v>`  | —                                | Yes          |
 
 The value is a non-sensitive compliance/billing identifier and is safe to appear
 in command output and logs. It is passed as a discrete `argv` element (not a

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "azlin"
-version = "2.6.76"
+version = "2.6.77"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-ai"
-version = "2.6.76"
+version = "2.6.77"
 dependencies = [
  "anyhow",
  "azlin-core",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-azure"
-version = "2.6.76"
+version = "2.6.77"
 dependencies = [
  "anyhow",
  "azlin-core",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-cli"
-version = "2.6.76"
+version = "2.6.77"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-core"
-version = "2.6.76"
+version = "2.6.77"
 dependencies = [
  "anyhow",
  "chrono",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-ssh"
-version = "2.6.76"
+version = "2.6.77"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/crates/azlin-core/src/config.rs
+++ b/rust/crates/azlin-core/src/config.rs
@@ -2,6 +2,18 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+/// Default Azure Public IP `--ip-tags` value applied to Bastion public IPs.
+///
+/// Historically this was hardcoded in `bastion_helpers::build_create_pip_args`.
+/// It is retained as the default so existing behavior is byte-identical when
+/// no override is configured.
+pub const DEFAULT_BASTION_PIP_IP_TAGS: &str = "FirstPartyUsage=/ATEVETNonProd";
+
+/// Environment variable that overrides the persisted `bastion_pip_ip_tags`
+/// config field at runtime. Must be a valid `Key=Value` IP tag; invalid values
+/// are ignored (with a warning) in favor of the persisted field / default.
+pub const ENV_BASTION_PIP_IP_TAGS: &str = "AZLIN_BASTION_PIP_IP_TAGS";
+
 /// Known valid Azure regions (subset — allows any alphanumeric lowercase string
 /// that matches the general Azure region pattern).
 const VALID_AZURE_REGIONS: &[&str] = &[
@@ -132,6 +144,12 @@ pub struct AzlinConfig {
     pub az_cli_timeout: u64,
     /// How `azlin list -r` opens restored sessions: "auto", "tab", or "window".
     pub restore_mode: RestoreMode,
+    /// Azure Public IP `--ip-tags` value applied to Bastion public IPs.
+    ///
+    /// Defaults to [`DEFAULT_BASTION_PIP_IP_TAGS`]. May be overridden at runtime
+    /// via the [`ENV_BASTION_PIP_IP_TAGS`] environment variable. Resolve the
+    /// effective value with [`AzlinConfig::bastion_pip_ip_tags`].
+    pub bastion_pip_ip_tags: String,
 }
 
 impl Default for AzlinConfig {
@@ -160,6 +178,7 @@ impl Default for AzlinConfig {
             scp_transfer_timeout: 120,
             az_cli_timeout: 120,
             restore_mode: RestoreMode::Auto,
+            bastion_pip_ip_tags: DEFAULT_BASTION_PIP_IP_TAGS.to_string(),
         }
     }
 }
@@ -328,6 +347,90 @@ impl AzlinConfig {
         Ok(())
     }
 
+    /// Resolve the effective Bastion public-IP `--ip-tags` value.
+    ///
+    /// Precedence:
+    /// 1. `AZLIN_BASTION_PIP_IP_TAGS` env var, if set to a valid, non-empty tag.
+    /// 2. The persisted `bastion_pip_ip_tags` field, if non-empty.
+    /// 3. [`DEFAULT_BASTION_PIP_IP_TAGS`].
+    ///
+    /// An env value that is empty or fails validation is ignored (a warning is
+    /// logged) and resolution falls through to the field, then the default.
+    /// The returned value is always non-empty and valid.
+    pub fn bastion_pip_ip_tags(&self) -> String {
+        if let Ok(env_val) = std::env::var(ENV_BASTION_PIP_IP_TAGS) {
+            let trimmed = env_val.trim();
+            if !trimmed.is_empty() {
+                match Self::validate_bastion_pip_ip_tags(trimmed) {
+                    Ok(()) => return trimmed.to_string(),
+                    Err(e) => {
+                        tracing::warn!(
+                            env = ENV_BASTION_PIP_IP_TAGS,
+                            error = %e,
+                            "Ignoring invalid AZLIN_BASTION_PIP_IP_TAGS; \
+                             falling back to configured value"
+                        );
+                    }
+                }
+            }
+        }
+
+        let field = self.bastion_pip_ip_tags.trim();
+        if field.is_empty() {
+            DEFAULT_BASTION_PIP_IP_TAGS.to_string()
+        } else {
+            field.to_string()
+        }
+    }
+
+    /// Validate a Bastion public-IP `--ip-tags` value.
+    ///
+    /// Enforces an Azure `IpTagType=Tag` shape and guards against argument
+    /// injection when the value is later passed to the `az` CLI:
+    /// - Must contain `=` with a non-empty key.
+    /// - Key must not start with `-` (flag-injection guard).
+    /// - No control characters (including newlines).
+    /// - Length must be <= 512.
+    pub fn validate_bastion_pip_ip_tags(value: &str) -> crate::Result<()> {
+        if value.is_empty() {
+            return Err(crate::AzlinError::Config(
+                "bastion_pip_ip_tags must not be empty (expected 'Key=Value', \
+                 e.g. 'FirstPartyUsage=/ATEVETNonProd')"
+                    .into(),
+            ));
+        }
+        if value.len() > 512 {
+            return Err(crate::AzlinError::Config(format!(
+                "bastion_pip_ip_tags is too long ({} chars, max 512)",
+                value.len()
+            )));
+        }
+        if value.chars().any(|c| c.is_control()) {
+            return Err(crate::AzlinError::Config(
+                "bastion_pip_ip_tags must not contain control characters".into(),
+            ));
+        }
+        let Some((key, _tag)) = value.split_once('=') else {
+            return Err(crate::AzlinError::Config(format!(
+                "bastion_pip_ip_tags must be 'Key=Value' (e.g. \
+                 'FirstPartyUsage=/ATEVETNonProd'), got '{}'",
+                value
+            )));
+        };
+        if key.is_empty() {
+            return Err(crate::AzlinError::Config(
+                "bastion_pip_ip_tags key (before '=') must not be empty".into(),
+            ));
+        }
+        if key.starts_with('-') {
+            return Err(crate::AzlinError::Config(format!(
+                "bastion_pip_ip_tags key must not start with '-' (got '{}')",
+                key
+            )));
+        }
+        Ok(())
+    }
+
     /// Boolean field names in the config.
     const BOOL_FIELDS: &[&str] = &[
         "ssh_auto_sync_keys",
@@ -444,6 +547,11 @@ impl AzlinConfig {
             }
         }
 
+        if key == "bastion_pip_ip_tags" {
+            Self::validate_bastion_pip_ip_tags(value)?;
+            return Ok(serde_json::Value::String(value.to_string()));
+        }
+
         if Self::BOOL_FIELDS.contains(&key) {
             match value {
                 "true" => return Ok(serde_json::Value::Bool(true)),
@@ -478,6 +586,7 @@ impl AzlinConfig {
             "default_nfs_storage",
             "ssh_sync_method",
             "restore_mode",
+            "bastion_pip_ip_tags",
         ];
         if !KNOWN_STRING_FIELDS.contains(&key)
             && !Self::BOOL_FIELDS.contains(&key)
@@ -499,6 +608,11 @@ impl AzlinConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes tests that mutate the process-global `AZLIN_BASTION_PIP_IP_TAGS`
+    /// env var, preventing races under the parallel test runner.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_default_config() {
@@ -1126,5 +1240,137 @@ mod tests {
             toml_str.contains("default_vm_image"),
             "TOML should contain default_vm_image key after set_field"
         );
+    }
+
+    // ── bastion_pip_ip_tags (configurable IP tag) tests ──────────────
+
+    #[test]
+    fn test_default_bastion_pip_ip_tags_constant() {
+        // The default must remain byte-identical to the historically hardcoded
+        // value for backward compatibility.
+        assert_eq!(
+            DEFAULT_BASTION_PIP_IP_TAGS,
+            "FirstPartyUsage=/ATEVETNonProd"
+        );
+    }
+
+    #[test]
+    fn test_default_config_bastion_pip_ip_tags_field() {
+        let config = AzlinConfig::default();
+        assert_eq!(config.bastion_pip_ip_tags, DEFAULT_BASTION_PIP_IP_TAGS);
+    }
+
+    #[test]
+    fn test_accessor_returns_field_value() {
+        // With no env override, the accessor returns the persisted field value.
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("AZLIN_BASTION_PIP_IP_TAGS");
+        let mut config = AzlinConfig::default();
+        config.bastion_pip_ip_tags = "FirstPartyUsage=/CustomTag".to_string();
+        assert_eq!(config.bastion_pip_ip_tags(), "FirstPartyUsage=/CustomTag");
+    }
+
+    #[test]
+    fn test_accessor_empty_field_falls_back_to_default() {
+        // An empty/whitespace persisted value normalizes to the default constant.
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("AZLIN_BASTION_PIP_IP_TAGS");
+        let mut config = AzlinConfig::default();
+        config.bastion_pip_ip_tags = "   ".to_string();
+        assert_eq!(config.bastion_pip_ip_tags(), DEFAULT_BASTION_PIP_IP_TAGS);
+    }
+
+    #[test]
+    fn test_accessor_env_override_takes_precedence() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let mut config = AzlinConfig::default();
+        config.bastion_pip_ip_tags = "FirstPartyUsage=/FieldValue".to_string();
+        std::env::set_var("AZLIN_BASTION_PIP_IP_TAGS", "FirstPartyUsage=/FromEnv");
+        let resolved = config.bastion_pip_ip_tags();
+        std::env::remove_var("AZLIN_BASTION_PIP_IP_TAGS");
+        assert_eq!(resolved, "FirstPartyUsage=/FromEnv");
+    }
+
+    #[test]
+    fn test_accessor_invalid_env_falls_back_to_field() {
+        // An invalid env value (fails the validator) is ignored; the accessor
+        // falls back to the field value rather than propagating garbage.
+        let _guard = ENV_LOCK.lock().unwrap();
+        let mut config = AzlinConfig::default();
+        config.bastion_pip_ip_tags = "FirstPartyUsage=/FieldValue".to_string();
+        std::env::set_var("AZLIN_BASTION_PIP_IP_TAGS", "-badkey=value");
+        let resolved = config.bastion_pip_ip_tags();
+        std::env::remove_var("AZLIN_BASTION_PIP_IP_TAGS");
+        assert_eq!(resolved, "FirstPartyUsage=/FieldValue");
+    }
+
+    #[test]
+    fn test_accessor_empty_env_falls_back_to_field() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let mut config = AzlinConfig::default();
+        config.bastion_pip_ip_tags = "FirstPartyUsage=/FieldValue".to_string();
+        std::env::set_var("AZLIN_BASTION_PIP_IP_TAGS", "");
+        let resolved = config.bastion_pip_ip_tags();
+        std::env::remove_var("AZLIN_BASTION_PIP_IP_TAGS");
+        assert_eq!(resolved, "FirstPartyUsage=/FieldValue");
+    }
+
+    #[test]
+    fn test_validate_bastion_pip_ip_tags_accepts_valid() {
+        assert!(
+            AzlinConfig::validate_bastion_pip_ip_tags("FirstPartyUsage=/ATEVETNonProd").is_ok()
+        );
+        assert!(AzlinConfig::validate_bastion_pip_ip_tags("FirstPartyUsage=/CustomTag").is_ok());
+    }
+
+    #[test]
+    fn test_validate_bastion_pip_ip_tags_rejects_invalid() {
+        // Missing '=' (no Key=Value form).
+        assert!(AzlinConfig::validate_bastion_pip_ip_tags("NoEqualsSign").is_err());
+        // Empty key.
+        assert!(AzlinConfig::validate_bastion_pip_ip_tags("=value").is_err());
+        // Empty string.
+        assert!(AzlinConfig::validate_bastion_pip_ip_tags("").is_err());
+        // Leading '-' on key (flag-injection guard).
+        assert!(AzlinConfig::validate_bastion_pip_ip_tags("-Key=value").is_err());
+        // Control characters.
+        assert!(AzlinConfig::validate_bastion_pip_ip_tags("Key=va\nlue").is_err());
+        // Over-length (>512).
+        let long = format!("Key=/{}", "a".repeat(600));
+        assert!(AzlinConfig::validate_bastion_pip_ip_tags(&long).is_err());
+    }
+
+    #[test]
+    fn test_validate_field_routes_bastion_pip_ip_tags() {
+        // The field must hit the dedicated validator, not the generic string
+        // pass-through: an invalid value must be rejected.
+        let ok = AzlinConfig::validate_field("bastion_pip_ip_tags", "FirstPartyUsage=/CustomTag");
+        assert_eq!(ok.unwrap(), serde_json::json!("FirstPartyUsage=/CustomTag"));
+
+        let bad = AzlinConfig::validate_field("bastion_pip_ip_tags", "NoEqualsSign");
+        assert!(
+            bad.is_err(),
+            "bastion_pip_ip_tags must be validated, not passed through as a generic string"
+        );
+    }
+
+    #[test]
+    fn test_set_field_bastion_pip_ip_tags_roundtrip() {
+        let config = AzlinConfig::default();
+        let (toml_str, parsed) =
+            simulate_set_field(&config, "bastion_pip_ip_tags", "FirstPartyUsage=/CustomTag");
+        assert!(
+            toml_str.contains("bastion_pip_ip_tags"),
+            "TOML should contain bastion_pip_ip_tags after set_field"
+        );
+        assert_eq!(parsed.bastion_pip_ip_tags, "FirstPartyUsage=/CustomTag");
+    }
+
+    #[test]
+    fn test_old_config_without_bastion_pip_ip_tags_deserializes_to_default() {
+        // Config files predating this field must deserialize with the default.
+        let toml_str = "default_region = \"westus2\"\ndefault_vm_size = \"Standard_E16as_v5\"\n";
+        let config: AzlinConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.bastion_pip_ip_tags, DEFAULT_BASTION_PIP_IP_TAGS);
     }
 }

--- a/rust/crates/azlin/src/bastion_helpers.rs
+++ b/rust/crates/azlin/src/bastion_helpers.rs
@@ -55,7 +55,12 @@ pub fn build_create_bastion_subnet_args(resource_group: &str, region: &str) -> V
 }
 
 /// Build `az network public-ip create` arguments for the bastion public IP.
-pub fn build_create_pip_args(resource_group: &str, region: &str) -> Vec<String> {
+///
+/// `ip_tags` is the already-resolved, validated Azure `--ip-tags` value
+/// (e.g. `FirstPartyUsage=/ATEVETNonProd`). It is emitted verbatim as a single
+/// argument — callers must resolve it via
+/// [`azlin_core::AzlinConfig::bastion_pip_ip_tags`].
+pub fn build_create_pip_args(resource_group: &str, region: &str, ip_tags: &str) -> Vec<String> {
     let pip = bastion_pip_name(region);
     vec![
         "network".into(), "public-ip".into(), "create".into(),
@@ -64,7 +69,7 @@ pub fn build_create_pip_args(resource_group: &str, region: &str) -> Vec<String> 
         "--location".into(), region.to_lowercase(),
         "--sku".into(), "Standard".into(),
         "--allocation-method".into(), "Static".into(),
-        "--ip-tags".into(), "FirstPartyUsage=/ATEVETNonProd".into(),
+        "--ip-tags".into(), ip_tags.into(),
         "--output".into(), "none".into(),
     ]
 }
@@ -138,11 +143,16 @@ fn run_az_or_bail(args: &[String], context: &str) -> anyhow::Result<()> {
 /// Ensure the bastion VNet, AzureBastionSubnet, public IP, and bastion host
 /// all exist in the target region. Creates only what is missing (idempotent).
 ///
+/// `ip_tags` is the already-resolved Azure `--ip-tags` value applied to the
+/// bastion public IP (resolve via
+/// [`azlin_core::AzlinConfig::bastion_pip_ip_tags`]).
+///
 /// Uses `penguin_spinner` (via the supplied callback) for user feedback during
 /// long-running operations.
 pub fn ensure_bastion_infrastructure(
     resource_group: &str,
     region: &str,
+    ip_tags: &str,
 ) -> anyhow::Result<()> {
     // Normalize region once to avoid repeated to_lowercase() in every helper call.
     let region = &region.to_lowercase();
@@ -190,7 +200,7 @@ pub fn ensure_bastion_infrastructure(
     //    create-or-update operation)
     eprintln!("Ensuring public IP '{pip}'...");
     run_az_or_bail(
-        &build_create_pip_args(resource_group, region),
+        &build_create_pip_args(resource_group, region, ip_tags),
         &format!("Failed to create bastion public IP in {region}"),
     )?;
     eprintln!("  ✓ Public IP ready");
@@ -333,18 +343,28 @@ mod tests {
 
     #[test]
     fn test_build_create_pip_args_uses_standard_sku() {
-        let args = build_create_pip_args("my-rg", "westus");
+        let args = build_create_pip_args("my-rg", "westus", "FirstPartyUsage=/ATEVETNonProd");
         assert!(args.contains(&"azlin-bastion-westus-pip".to_string()));
         assert!(args.contains(&"Standard".to_string()));
         assert!(args.contains(&"Static".to_string()));
     }
 
     #[test]
-    fn test_build_create_pip_args_applies_first_party_ip_tag() {
-        let args = build_create_pip_args("my-rg", "westus");
-        // Every bastion public IP must carry the FirstPartyUsage IP tag.
+    fn test_build_create_pip_args_applies_default_ip_tag() {
+        // When the caller passes the default tag value, the public IP must carry
+        // FirstPartyUsage=/ATEVETNonProd for backward compatibility.
+        let args = build_create_pip_args("my-rg", "westus", "FirstPartyUsage=/ATEVETNonProd");
         let tag_idx = args.iter().position(|a| a == "--ip-tags").unwrap();
         assert_eq!(args[tag_idx + 1], "FirstPartyUsage=/ATEVETNonProd");
+    }
+
+    #[test]
+    fn test_build_create_pip_args_applies_custom_ip_tag() {
+        // The IP tag is now configurable: whatever resolved value is passed in
+        // must be emitted verbatim as the --ip-tags argument.
+        let args = build_create_pip_args("my-rg", "westus", "FirstPartyUsage=/CustomTag");
+        let tag_idx = args.iter().position(|a| a == "--ip-tags").unwrap();
+        assert_eq!(args[tag_idx + 1], "FirstPartyUsage=/CustomTag");
     }
 
     #[test]

--- a/rust/crates/azlin/src/cmd_lifecycle.rs
+++ b/rust/crates/azlin/src/cmd_lifecycle.rs
@@ -203,7 +203,6 @@ pub(crate) async fn dispatch(
         azlin_cli::Commands::OsUpdate {
             vm_identifier,
             resource_group,
-            timeout: _,
             ..
         } => {
             let rg = resolve_resource_group(resource_group)?;

--- a/rust/crates/azlin/src/cmd_list_data.rs
+++ b/rust/crates/azlin/src/cmd_list_data.rs
@@ -478,7 +478,7 @@ pub(crate) fn restore_tmux_sessions(tmux_sessions: &HashMap<String, Vec<String>>
                 println!("  Opening window: {} (session: {})", vm_name, session);
                 let connect_cmd = escape_for_applescript(&format!(
                     "{} connect {} --tmux-session {}",
-                    &self_exe, vm_name, &session
+                    self_exe, vm_name, session
                 ));
                 if let Err(e) = open_macos_terminal(&macos_terminal, &connect_cmd) {
                     eprintln!("  Warning: failed to open window for {}: {}", vm_name, e);

--- a/rust/crates/azlin/src/cmd_vm.rs
+++ b/rust/crates/azlin/src/cmd_vm.rs
@@ -70,7 +70,6 @@ pub(crate) async fn dispatch(
             azlin_cli::VmAction::UpdateTools {
                 vm_identifier,
                 resource_group,
-                timeout: _,
                 ..
             } => {
                 crate::cmd_vm_ops2::handle_vm_update(&vm_identifier, resource_group).await?;

--- a/rust/crates/azlin/src/cmd_vm_ops.rs
+++ b/rust/crates/azlin/src/cmd_vm_ops.rs
@@ -603,8 +603,10 @@ pub(crate) async fn handle_vm_new(
                         "Provisioning bastion infrastructure in {}...",
                         final_loc
                     ));
-                    let result =
-                        crate::bastion_helpers::ensure_bastion_infrastructure(&rg, &final_loc);
+                    let ip_tags = config_defaults.bastion_pip_ip_tags();
+                    let result = crate::bastion_helpers::ensure_bastion_infrastructure(
+                        &rg, &final_loc, &ip_tags,
+                    );
                     pb.finish_and_clear();
                     result?;
                 }


### PR DESCRIPTION
## Summary
The Azure `--ip-tags` value applied to bastion public IPs was hardcoded as `FirstPartyUsage=/ATEVETNonProd` in `build_create_pip_args`. This makes it **configurable** while keeping that value as the default (fully backward compatible).

## Changes
- **New config field** `bastion_pip_ip_tags` on `AzlinConfig` (default `DEFAULT_BASTION_PIP_IP_TAGS = "FirstPartyUsage=/ATEVETNonProd"`).
- **Resolution accessor** `bastion_pip_ip_tags()` with precedence: `AZLIN_BASTION_PIP_IP_TAGS` env var → persisted field → default.
- **Validation** (`validate_bastion_pip_ip_tags`): enforces `Key=Value` shape, rejects control chars, leading-`-` keys (flag-injection guard), and values >512 chars. Wired into both `config set` and env-override paths.
- **Threaded** the resolved value through `ensure_bastion_infrastructure` → `build_create_pip_args`; resolved in `handle_vm_new`.
- **Docs** updated: `docs/features/bastion-pip-first-party-ip-tag.md`.
- **Tests**: config resolution/validation/roundtrip + old-config-deserializes-to-default + custom/default pip-arg tests.

## Configuration options
```bash
# Persisted config
azlin config set bastion_pip_ip_tags FirstPartyUsage=/MyTag
# Or per-run env override
export AZLIN_BASTION_PIP_IP_TAGS=FirstPartyUsage=/MyTag
```

## Validation
- `cargo build --workspace` ✓
- `cargo test -p azlin-core --lib config` → 63 passed ✓
- `cargo test -p azlin --bin azlin bastion_helpers` → 19 passed ✓
- `cargo clippy -p azlin-core -p azlin` → clean ✓

Fixes #1038