### PR TITLE
feat: azlin connect resolves bare identifier to tmux session name

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "azlin"
-version = "2.6.79"
+version = "2.6.80"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-ai"
-version = "2.6.79"
+version = "2.6.80"
 dependencies = [
  "anyhow",
  "azlin-core",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-azure"
-version = "2.6.79"
+version = "2.6.80"
 dependencies = [
  "anyhow",
  "azlin-core",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-cli"
-version = "2.6.79"
+version = "2.6.80"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-core"
-version = "2.6.79"
+version = "2.6.80"
 dependencies = [
  "anyhow",
  "chrono",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-ssh"
-version = "2.6.79"
+version = "2.6.80"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/crates/azlin/src/cmd_connect.rs
+++ b/rust/crates/azlin/src/cmd_connect.rs
@@ -78,9 +78,10 @@ pub(crate) async fn dispatch(
             let auth = create_auth()?;
             let vm_manager = azlin_azure::VmManager::new(&auth);
             let rg = resolve_resource_group(resource_group)?;
+            let identifier_was_explicit = vm_identifier.is_some();
 
             // Parse compound identifier: "vm:session" → (vm_name, Some(session))
-            let (raw_name, colon_session) = if let Some(ref id) = vm_identifier {
+            let (raw_name, mut colon_session) = if let Some(ref id) = vm_identifier {
                 if let Some((vm_part, sess_part)) = id.split_once(':') {
                     (Some(vm_part.to_string()), Some(sess_part.to_string()))
                 } else {
@@ -91,7 +92,7 @@ pub(crate) async fn dispatch(
             };
 
             // If no VM specified, show interactive picker of running VMs
-            let name = if let Some(n) = raw_name {
+            let mut name = if let Some(n) = raw_name {
                 n
             } else {
                 let vms = vm_manager.list_vms(&rg)?;
@@ -129,8 +130,70 @@ pub(crate) async fn dispatch(
             };
 
             let pb = penguin_spinner(&format!("Looking up {}...", name));
-            let vm = vm_manager.get_vm(&rg, &name)?;
-            pb.finish_and_clear();
+            let vm = match vm_manager.get_vm(&rg, &name) {
+                Ok(vm) => vm,
+                Err(get_vm_err) => {
+                    pb.finish_and_clear();
+                    // Fall back to tmux-session-name resolution only when the
+                    // user typed a bare identifier (no explicit "vm:session"
+                    // notation and no --tmux-session flag), since those forms
+                    // already unambiguously name the VM.
+                    if !identifier_was_explicit || colon_session.is_some() || tmux_session.is_some()
+                    {
+                        return Err(get_vm_err);
+                    }
+                    let pb2 = penguin_spinner(&format!(
+                        "'{}' is not a known VM; searching tmux sessions...",
+                        name
+                    ));
+                    let config = azlin_core::AzlinConfig::load().unwrap_or_default();
+                    let all_vms = vm_manager.list_vms(&rg).unwrap_or_default();
+                    let running: Vec<_> = all_vms
+                        .into_iter()
+                        .filter(|v| v.power_state == azlin_core::models::PowerState::Running)
+                        .collect();
+                    let lookup = crate::cmd_list_data::find_vm_by_tmux_session(
+                        &running,
+                        &rg,
+                        vm_manager.subscription_id(),
+                        config.ssh_connect_timeout,
+                        &name,
+                        verbose,
+                    );
+                    pb2.finish_and_clear();
+                    match lookup {
+                        crate::cmd_list_data::SessionLookup::Found { vm_name } => {
+                            eprintln!("Resolved tmux session '{}' to VM '{}'.", name, vm_name);
+                            colon_session = Some(name.clone());
+                            let pb3 = penguin_spinner(&format!("Looking up {}...", vm_name));
+                            let resolved = vm_manager.get_vm(&rg, &vm_name);
+                            pb3.finish_and_clear();
+                            let resolved_vm = resolved.with_context(|| {
+                                format!(
+                                    "Found tmux session '{}' on VM '{}', but failed to look up that VM",
+                                    name, vm_name
+                                )
+                            })?;
+                            name = vm_name;
+                            resolved_vm
+                        }
+                        crate::cmd_list_data::SessionLookup::NotFound => {
+                            return Err(get_vm_err.context(format!(
+                                "'{}' also does not match any tmux session name on running VMs",
+                                name
+                            )));
+                        }
+                        crate::cmd_list_data::SessionLookup::Ambiguous { vm_names } => {
+                            anyhow::bail!(
+                                "'{}' is not a known VM, and matches tmux sessions on multiple VMs ({}); use 'azlin connect <vm>:{}' to disambiguate",
+                                name,
+                                vm_names.join(", "),
+                                name
+                            );
+                        }
+                    }
+                }
+            };
 
             let username = vm.admin_username.unwrap_or_else(|| user.clone());
             let use_bastion = vm.public_ip.is_none();

--- a/rust/crates/azlin/src/cmd_connect.rs
+++ b/rust/crates/azlin/src/cmd_connect.rs
@@ -142,12 +142,28 @@ pub(crate) async fn dispatch(
                     {
                         return Err(get_vm_err);
                     }
+                    // Capture the original error as a string up front: it's
+                    // needed in more than one branch below, and anyhow::Error
+                    // isn't Clone.
+                    let get_vm_err_msg = format!("{get_vm_err:#}");
                     let pb2 = penguin_spinner(&format!(
                         "'{}' is not a known VM; searching tmux sessions...",
                         name
                     ));
                     let config = azlin_core::AzlinConfig::load().unwrap_or_default();
-                    let all_vms = vm_manager.list_vms(&rg).unwrap_or_default();
+                    // If listing VMs fails here (e.g. a transient Azure API
+                    // error), don't silently treat that the same as "checked
+                    // and found no matching session" — report the original
+                    // get_vm error together with the listing failure so the
+                    // user knows the fallback lookup itself didn't run.
+                    let all_vms = vm_manager.list_vms(&rg).map_err(|list_err| {
+                        anyhow::anyhow!(
+                            "'{}' is not a known VM ({}), and could not be resolved as a tmux \
+                             session name either: failed to list VMs to search for a match: {list_err}",
+                            name,
+                            get_vm_err_msg
+                        )
+                    })?;
                     let running: Vec<_> = all_vms
                         .into_iter()
                         .filter(|v| v.power_state == azlin_core::models::PowerState::Running)

--- a/rust/crates/azlin/src/cmd_list_data.rs
+++ b/rust/crates/azlin/src/cmd_list_data.rs
@@ -14,6 +14,64 @@ fn resolve_ssh_key() -> Option<std::path::PathBuf> {
     crate::key_helpers::find_preferred_private_key(&ssh_dir)
 }
 
+/// Result of resolving a bare identifier against known tmux session names
+/// across all running VMs in a resource group.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum SessionLookup {
+    /// Exactly one running VM has a tmux session with this name.
+    Found { vm_name: String },
+    /// No running VM has a tmux session with this name.
+    NotFound,
+    /// More than one running VM has a tmux session with this name; caller
+    /// should ask the user to disambiguate with `vm:session` notation.
+    Ambiguous { vm_names: Vec<String> },
+}
+
+/// Search all running VMs in `rg` for a tmux session named `session_name`.
+///
+/// Used by `azlin connect <name>` to fall back to session-name resolution
+/// when `<name>` does not match any VM hostname: if exactly one running VM
+/// has a matching tmux session, callers can connect to `vm_name:session_name`.
+pub(crate) fn find_vm_by_tmux_session(
+    vms: &[VmInfo],
+    rg: &str,
+    subscription_id: &str,
+    connect_timeout: u64,
+    session_name: &str,
+    verbose: bool,
+) -> SessionLookup {
+    // collect_tmux_sessions now auto-detects whether bastion probing is
+    // needed based on the VM list, so no output-format flag is required.
+    let tmux_sessions = collect_tmux_sessions(vms, rg, verbose, subscription_id, connect_timeout);
+    match_session_in_map(&tmux_sessions, session_name)
+}
+
+/// Pure matching logic for [`find_vm_by_tmux_session`], split out so it can
+/// be unit tested without spawning real SSH/az processes.
+pub(crate) fn match_session_in_map(
+    tmux_sessions: &HashMap<String, Vec<String>>,
+    session_name: &str,
+) -> SessionLookup {
+    let mut matches: Vec<String> = Vec::new();
+    for (vm_name, sessions) in tmux_sessions {
+        let has_match = sessions
+            .iter()
+            .any(|raw| parse_session_name(raw).as_deref() == Some(session_name));
+        if has_match {
+            matches.push(vm_name.clone());
+        }
+    }
+    matches.sort();
+
+    match matches.len() {
+        0 => SessionLookup::NotFound,
+        1 => SessionLookup::Found {
+            vm_name: matches.remove(0),
+        },
+        _ => SessionLookup::Ambiguous { vm_names: matches },
+    }
+}
+
 /// Collect tmux sessions for all running VMs via SSH (direct or bastion).
 ///
 /// Always attempts bastion detection when at least one running VM has no
@@ -482,7 +540,8 @@ pub(crate) fn restore_tmux_sessions(tmux_sessions: &HashMap<String, Vec<String>>
                 println!("  Opening tab: {} (session: {})", vm_name, session);
                 let wsl_distro =
                     std::env::var("WSL_DISTRO_NAME").unwrap_or_else(|_| "".to_string());
-                let wt_args = build_wt_restore_args(&wsl_distro, &self_exe, vm_name, &session, restore_mode);
+                let wt_args =
+                    build_wt_restore_args(&wsl_distro, &self_exe, vm_name, &session, restore_mode);
                 let wt_str_args: Vec<&str> = wt_args.iter().map(|s| s.as_str()).collect();
                 match std::process::Command::new("wt.exe")
                     .args(&wt_str_args)
@@ -537,10 +596,7 @@ pub(crate) fn restore_tmux_sessions(tmux_sessions: &HashMap<String, Vec<String>>
                         "  No terminal emulator detected for {}. Run manually:",
                         vm_name
                     );
-                    eprintln!(
-                        "    azlin connect {} --tmux-session {}",
-                        vm_name, session
-                    );
+                    eprintln!("    azlin connect {} --tmux-session {}", vm_name, session);
                     eprintln!("  Tip: set AZLIN_TERMINAL=<your-terminal> to enable auto-restore.");
                 }
             }
@@ -653,8 +709,7 @@ fn detect_linux_terminal() -> Option<LinuxTerminal> {
     if let Ok(custom) = std::env::var("AZLIN_TERMINAL") {
         if !custom.is_empty() {
             // Reject values containing shell metacharacters to prevent injection.
-            if custom.contains([';', '&', '|', '$', '`', '\n', '(', ')'])
-            {
+            if custom.contains([';', '&', '|', '$', '`', '\n', '(', ')']) {
                 eprintln!(
                     "  Warning: AZLIN_TERMINAL contains shell metacharacters, ignoring: {}",
                     custom
@@ -711,7 +766,10 @@ fn open_linux_terminal(terminal: &LinuxTerminal, command: &str) -> Result<(), St
             .spawn(),
         LinuxTerminal::Xfce4Terminal => {
             // xfce4-terminal -e expects a single command string (shell-parsed)
-            let wrapped = format!("bash -lc {}", crate::dispatch_helpers::shell_escape(command));
+            let wrapped = format!(
+                "bash -lc {}",
+                crate::dispatch_helpers::shell_escape(command)
+            );
             std::process::Command::new("xfce4-terminal")
                 .args(["-e", &wrapped])
                 .stdin(std::process::Stdio::null())
@@ -735,5 +793,61 @@ fn open_linux_terminal(terminal: &LinuxTerminal, command: &str) -> Result<(), St
     match result {
         Ok(_) => Ok(()),
         Err(e) => Err(format!("failed to launch terminal: {}", e)),
+    }
+}
+
+#[cfg(test)]
+mod session_lookup_tests {
+    use super::*;
+
+    fn sessions_map(entries: &[(&str, &[&str])]) -> HashMap<String, Vec<String>> {
+        entries
+            .iter()
+            .map(|(vm, sess)| (vm.to_string(), sess.iter().map(|s| s.to_string()).collect()))
+            .collect()
+    }
+
+    #[test]
+    fn test_match_session_found_on_single_vm() {
+        let map = sessions_map(&[("vm-a", &["main:1", "scratch:0"]), ("vm-b", &["other:0"])]);
+        let result = match_session_in_map(&map, "scratch");
+        assert_eq!(
+            result,
+            SessionLookup::Found {
+                vm_name: "vm-a".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_match_session_not_found() {
+        let map = sessions_map(&[("vm-a", &["main:1"])]);
+        let result = match_session_in_map(&map, "nonexistent");
+        assert_eq!(result, SessionLookup::NotFound);
+    }
+
+    #[test]
+    fn test_match_session_ambiguous_across_vms() {
+        let map = sessions_map(&[("vm-a", &["shared:0"]), ("vm-b", &["shared:1"])]);
+        let result = match_session_in_map(&map, "shared");
+        match result {
+            SessionLookup::Ambiguous { vm_names } => {
+                assert_eq!(vm_names, vec!["vm-a".to_string(), "vm-b".to_string()]);
+            }
+            other => panic!("expected Ambiguous, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_match_session_ignores_attached_suffix() {
+        // Session name matching strips the ":attached" suffix via parse_session_name.
+        let map = sessions_map(&[("vm-a", &["work:1"])]);
+        let result = match_session_in_map(&map, "work");
+        assert_eq!(
+            result,
+            SessionLookup::Found {
+                vm_name: "vm-a".to_string()
+            }
+        );
     }
 }


### PR DESCRIPTION
Supersedes #1042, which GitHub auto-closed when its base branch (`fix/azlin-list-tmux-bastion-detection`) was deleted after PR #1040 merged.

## Feature

`azlin connect <name>` now falls back to tmux-session-name resolution when `<name>` doesn't match any known VM hostname: if exactly one running VM has a tmux session named `<name>`, it connects to that VM's session directly. If multiple VMs match, it reports the ambiguity and asks the user to disambiguate with `vm:session` notation. This fallback only triggers for bare identifiers — explicit `vm:session` notation or `--tmux-session` always take priority and are never overridden.

## History / rebuild note

The original PR (#1042) was based on #1040's branch (a real code dependency on the new `collect_tmux_sessions` signature). After #1040 squash-merged and its branch was deleted, #1042 was auto-closed by GitHub with no way to retarget or reopen it. This PR (#1043) was opened from the same head branch retargeted to `main`.

A subsequent `git diff`/`gh pr diff` on the retargeted branch showed a large, clearly-wrong diff (24 unrelated files) — root-caused to git history divergence between the old branch's pre-squash ancestry and `main`'s new squash-merge commits confusing the 3-way merge. Fixed by extracting the true feature-only diff (`git diff <old-base-tip>..<old-branch-head> -- cmd_connect.rs cmd_list_data.rs`) and applying it fresh onto a branch cut directly from current `origin/main`. Final diff scope is clean: `cmd_connect.rs`, `cmd_list_data.rs`, `Cargo.lock`.

## Review history

**crusty-old-engineer review** flagged one real issue: the fallback path used `vm_manager.list_vms(&rg).unwrap_or_default()`, which silently treated a genuine Azure API listing failure identically to "checked and found no matching session" — misleading during real outages, since the user would see "also does not match any tmux session name" when the fallback lookup never actually ran. Fixed: `list_vms` failures are now propagated explicitly, combined with the original `get_vm` error, so failures are visible instead of masked as a false negative.

**Validation performed:**
- `cargo build --locked` and `cargo clippy --all --locked -- -D warnings` clean.
- Full `cargo test -p azlin` suite passed (one test, `test_dispatch_session_set_get_clear`, failed once during an earlier parallel run but passed in isolation and on rerun — confirmed pre-existing test-suite flakiness from shared config-file state under parallel execution, not a regression from this change).
- 4 new unit tests added for the session-matching logic (`session_lookup_tests` module): found-on-single-vm, not-found, ambiguous-across-vms, attached-suffix-stripping.
- All CI checks green (build-and-test x2, cargo-audit x2, security scans).

## Merge-readiness notes

- No merge conflicts; `mergeStateStatus: CLEAN`.
- No branch protection rules configured on `main` (no required status checks / reviews) — verified via `gh api repos/rysweet/azlin/branches/main/protection`.
- **Exception documented per user's merge policy**: the `merge-ready` skill's hard requirement for `gadugi-test`/`qa-team` scenario validation could not be run — `gadugi-test` is not installed in this environment and is not available via pip/npm. All other merge-ready criteria (CI, conflicts, policy/protection, scoped review) were applied in full.
