### PR TITLE
fix: keep Cargo.lock in sync with automated version bumps

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -78,10 +78,49 @@ jobs:
           # 4. src/azlin/__init__.py
           sed -i "s/__version__ = \"${CURRENT}\"/__version__ = \"${NEW_VERSION}\"/" src/azlin/__init__.py
 
+          # 5. rust/Cargo.lock — the workspace member "version" fields must
+          # stay in sync with Cargo.toml, or any subsequent `cargo build
+          # --locked` (used by CI and by contributors) fails with "cannot
+          # update the lock file because --locked was passed". Patch each
+          # local workspace-member entry directly via sed (matching each
+          # package's `name = "..."` line, then the very next `version =
+          # "..."` line two lines below it) — this needs no network access
+          # and no Rust toolchain, unlike `cargo update`/`cargo check`, which
+          # would fail here since this job never sets up a cached registry.
+          #
+          # Members are derived from rust/Cargo.toml's `members = [...]`
+          # array (crate directory name == package name for every member in
+          # this repo) rather than hardcoded, so this loop never silently
+          # drifts out of sync if a crate is added, renamed, or removed.
+          WORKSPACE_MEMBERS=$(sed -n '/^members = \[/,/^\]/p' rust/Cargo.toml \
+            | grep -oP '"crates/\K[^"]+')
+          echo "Workspace members detected: ${WORKSPACE_MEMBERS}"
+          for pkg in ${WORKSPACE_MEMBERS}; do
+            sed -i "/^name = \"${pkg}\"\$/{n;s/^version = \"${CURRENT}\"/version = \"${NEW_VERSION}\"/}" rust/Cargo.lock
+          done
+
+          # Fail loudly rather than silently shipping a stale lock file if
+          # the Cargo.lock format ever changes (e.g. the lockfile layout
+          # shifts) and the sed above stops matching. Check each member
+          # individually — a blunt whole-file count could be misled by an
+          # external dependency that coincidentally shares the same version
+          # string. A silently-skipped update here is worse than no update
+          # at all, since it would look identical to success.
+          if [ -z "${WORKSPACE_MEMBERS}" ]; then
+            echo "::error::Could not parse any workspace members from rust/Cargo.toml's [workspace] members array. The parsing logic in this job needs to be fixed before merging." >&2
+            exit 1
+          fi
+          for pkg in ${WORKSPACE_MEMBERS}; do
+            if ! grep -A1 "^name = \"${pkg}\"\$" rust/Cargo.lock | grep -q "^version = \"${NEW_VERSION}\"\$"; then
+              echo "::error::rust/Cargo.lock entry for workspace member '${pkg}' was not bumped to ${NEW_VERSION}. The sed patterns in this job no longer match the lock file's structure — fix the patch logic before merging." >&2
+              exit 1
+            fi
+          done
+
           # ── Commit and push ───────────────────────────────────────────
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add rust/Cargo.toml pyproject.toml rust/pyproject.toml src/azlin/__init__.py
+          git add rust/Cargo.toml rust/Cargo.lock pyproject.toml rust/pyproject.toml src/azlin/__init__.py
           git commit -m "chore: bump version ${CURRENT} → ${NEW_VERSION} [skip ci]"
           git push
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "azlin"
-version = "2.6.79"
+version = "2.6.80"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-ai"
-version = "2.6.79"
+version = "2.6.80"
 dependencies = [
  "anyhow",
  "azlin-core",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-azure"
-version = "2.6.79"
+version = "2.6.80"
 dependencies = [
  "anyhow",
  "azlin-core",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-cli"
-version = "2.6.79"
+version = "2.6.80"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-core"
-version = "2.6.79"
+version = "2.6.80"
 dependencies = [
  "anyhow",
  "chrono",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-ssh"
-version = "2.6.79"
+version = "2.6.80"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
Fixes a recurring CI-breaking bug in the automated release workflow's version-bump job.

## Problem

`rust-release.yml`'s `version-bump` job bumps `Cargo.toml`, `pyproject.toml`, `rust/pyproject.toml`, and `src/azlin/__init__.py` via `sed`, but never touched `rust/Cargo.lock`. This left the workspace-member `version` fields in `Cargo.lock` permanently one bump behind `Cargo.toml` after every automated release, breaking `cargo build --locked` (used by CI's `build-and-test` job and the documented contributor build command) for any PR merged shortly after a version bump.

This already broke CI twice this session (PR #1041 and mid-work on PR #1043), each requiring a manual `Cargo.lock` regeneration to unblock.

## Fix

Patches the local workspace-member `version` stanzas in `Cargo.lock` directly via `sed` in the same job step, mirroring the existing `Cargo.toml` sed pattern.

**Design notes / review history:**
- **First attempt** used `cargo check --offline --workspace`. Passed locally, but proven unsafe for the real CI runner: this job has no Rust toolchain/cache setup (no `dtolnay/rust-toolchain`, no `Swatinem/rust-cache`), so `--offline` fails immediately on an empty registry cache with "no matching package named ... found". Verified via `CARGO_HOME=/tmp/offline-test cargo check --offline --workspace` on a genuinely fresh cache. My initial "successful" local test was misleading because my dev machine already had a populated dependency cache from earlier work.
- **Corrected approach**: pure `sed` patch requiring no cargo invocation, no network, no toolchain setup.
- **crusty-old-engineer review** flagged that a hardcoded list of workspace members risks silent drift if a crate is added/removed later, and that a silent sed no-match (e.g. from a future lockfile format change) would look identical to success. Fixed both: workspace members are now derived dynamically from `Cargo.toml`'s `members = [...]` array (not hardcoded), and the job now fails loudly (`::error::` + `exit 1`) if any member's Cargo.lock entry doesn't show the expected version after patching, or if member parsing itself yields nothing.

**Validation performed:**
- YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Simulated the full bump+patch+verify logic end-to-end against the real `Cargo.lock`/`Cargo.toml`, including a negative-path test (deliberately breaking the match) confirming the verification step correctly fails loudly instead of silently passing.
- `cargo build --locked` succeeded against the sed-patched lock file in an isolated workspace copy.
- `cargo clippy --all --locked -- -D warnings` clean.
- All CI checks green (build-and-test x2, cargo-audit x2, security scans).

## Merge-readiness notes

- No merge conflicts; `mergeStateStatus: CLEAN`.
- No branch protection rules configured on `main` (no required status checks / reviews) — verified via `gh api repos/rysweet/azlin/branches/main/protection`.
- **Exception documented per user's merge policy**: the `merge-ready` skill's hard requirement for `gadugi-test`/`qa-team` scenario validation could not be run — `gadugi-test` is not installed in this environment and is not available via pip/npm. All other merge-ready criteria (CI, conflicts, policy/protection, scoped quality-audit) were applied in full.
