### PR TITLE
fix: resolve real ARM dnsName for native bastion tunnel (#1046)

### DIFF
--- a/docs-site/changelog.md
+++ b/docs-site/changelog.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - VNC on localhost only with random per-session passwords
   - Works through Azure Bastion for private VMs
 
+### Fixed
+- **Native Bastion tunnel regression** (#1046): `azlin connect` failed for all
+  Standard/Premium SKU bastions. The native Rust tunnel (introduced in v2.6.83)
+  constructed the data-plane endpoint as `{name}.bastion.azure.com`, which does
+  not exist in DNS. It now resolves the bastion resource's real ARM
+  `properties.dnsName` and caches it per VM in the tunnel registry. The cached
+  value is re-validated before reuse to guard against registry tampering.
+
 ## [2.6.16]
 
 ### Fixed

--- a/docs/features/bastion-tunnel-dns-name-resolution.md
+++ b/docs/features/bastion-tunnel-dns-name-resolution.md
@@ -1,0 +1,232 @@
+# Bastion Tunnel Data-Plane DNS Name Resolution
+
+**Issue:** #1046
+**Status:** Implemented
+**Affects:** `azlin connect`, `azlin ssh`, `azlin gui`, `azlin sync` for all
+Standard/Premium SKU Azure Bastion hosts.
+
+## Overview
+
+The native Rust bastion tunnel connects to the Azure Bastion **data plane** using
+the bastion resource's real ARM `properties.dnsName` (for example
+`bst-7299861d-50e0-4142-8b50-2f8bc6f5b549.bastion.azure.com`).
+
+Earlier native-tunnel builds constructed the endpoint by string-formatting the
+bastion *resource name* (`{bastion_name}.bastion.azure.com`). That host does not
+exist in DNS, so the token-exchange request failed at the transport layer with an
+opaque `error sending request for url (...)`, surfaced as `token exchange failed:
+request failed: ...` and then `failed to open native bastion tunnel`. This broke
+`azlin connect` for every Standard/Premium bastion.
+
+Azlin now resolves the correct data-plane FQDN from Azure Resource Manager before
+opening the tunnel, caches it in the tunnel registry for reuse, and surfaces the
+full transport error cause chain when a request does fail.
+
+There are **no user-facing command or configuration changes** — connections that
+previously failed now succeed transparently.
+
+## Behavior
+
+### DNS name resolution
+
+When `get_or_create_tunnel()` needs to open a new tunnel, it resolves the bastion
+data-plane FQDN from ARM:
+
+```bash
+az network bastion show \
+  --name <bastion_name> \
+  --resource-group <resource_group> \
+  --query dnsName -o tsv
+```
+
+- The lookup runs on a blocking worker thread (the same pattern used for Azure AD
+  token acquisition), so it never stalls the async runtime.
+- The returned `dnsName` is used verbatim as the `bastion_endpoint` passed to
+  `azlin_azure::native_tunnel::open_tunnel`.
+- The command is invoked with an argument array (no shell), so the bastion name
+  and resource group are never interpolated into a shell string.
+
+### Validation (fail closed)
+
+The resolved value is validated before use. Azlin **never** falls back to the
+broken `{bastion_name}.bastion.azure.com` form.
+
+The resolved host must:
+
+- be non-empty after trimming,
+- contain no whitespace or control characters and no `/`, `\`, or `@`,
+- end with the `.bastion.azure.com` suffix.
+
+If the `az` lookup fails, returns empty, or the value fails validation, azlin
+returns a clear, actionable error naming the bastion, the resource group, and the
+underlying `az` stderr. For example:
+
+```
+failed to resolve Azure Bastion data-plane DNS name for bastion
+'azlin-bastion-southcentralus' in resource group 'rysweet-linux-vm-pool':
+az network bastion show returned an empty dnsName. Verify the bastion exists
+and that you have read access (az network bastion show -n <name> -g <rg>).
+```
+
+### Caching in the tunnel registry
+
+The resolved `dnsName` is stored on the tunnel registry entry so repeat connects
+and reused tunnels do **not** re-query ARM each time.
+
+- A new `dns_name` field is added to each registry entry.
+- When an existing tunnel is reused, the cached `dns_name` is used directly.
+- Registry files written by older versions (missing `dns_name`) load with an
+  empty value via `#[serde(default)]`; the next new tunnel for that VM re-resolves
+  and repopulates it. This is a one-time, safe re-resolution.
+
+### Transport error transparency
+
+When a token-exchange or cleanup request fails at the transport layer, azlin now
+surfaces the **full `std::error::Error::source()` cause chain** via an internal
+`error_chain` helper (in `azlin_azure::native_tunnel`), so the real cause (DNS
+resolution failure, TLS error, connection timeout) is visible instead of the
+opaque top-level `error sending request for url`.
+
+- `exchange_token` includes the cause chain in the `TokenExchange` error text.
+- `cleanup_token` no longer silently discards failures; it logs the cause chain at
+  `warn` level with the `node_id` for correlation.
+- Tokens, URLs, and header values are **never** logged. Only the error cause chain
+  and non-sensitive identifiers are surfaced.
+
+> Note: azlin does **not** parse or classify tool/error output strings to make
+> decisions. String-classification of `az`/transport output is a brittle-parsing
+> antipattern; the error chain is surfaced for **diagnostics only**.
+
+## API
+
+### `TunnelRegistryEntry` (`azlin::bastion_tunnel`)
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelRegistryEntry {
+    pub vm_resource_id: String,
+    pub bastion_name: String,
+    pub resource_group: String,
+    pub local_port: u16,
+    pub pid: u32,
+    pub created_at: u64,
+
+    /// Tunnel type: "native" (in-process WSS) or "legacy" (az CLI subprocess).
+    #[serde(default = "default_tunnel_type")]
+    pub tunnel_type: String,
+
+    /// Resolved Azure Bastion data-plane FQDN (ARM `properties.dnsName`),
+    /// e.g. "bst-<guid>.bastion.azure.com". Cached to avoid re-querying ARM on
+    /// tunnel reuse. Defaults to empty for registry files written before this
+    /// field existed; an empty value triggers a one-time re-resolution.
+    #[serde(default)]
+    pub dns_name: String,
+}
+```
+
+### DNS name helpers (`azlin::bastion_tunnel`)
+
+```rust
+/// Parse and validate the `dnsName` value returned by
+/// `az network bastion show ... --query dnsName -o tsv`.
+///
+/// Trims the output, takes the first line, and rejects empty values, values
+/// containing whitespace/control characters or `/`, `\`, `@`, and values that
+/// do not end with `.bastion.azure.com`. Pure and offline-testable.
+fn parse_dns_name(az_stdout: &str) -> anyhow::Result<String>;
+
+/// Resolve the Azure Bastion data-plane FQDN from ARM by running
+/// `az network bastion show --name <n> --resource-group <rg>
+///  --query dnsName -o tsv` on a blocking thread, then validating the result
+/// with `parse_dns_name`. Returns an actionable error on failure; never falls
+/// back to a constructed host.
+async fn resolve_bastion_dns_name(
+    bastion_name: &str,
+    resource_group: &str,
+) -> anyhow::Result<String>;
+```
+
+`get_or_create_tunnel()` keeps its existing three-argument signature — no callers
+change:
+
+```rust
+pub async fn get_or_create_tunnel(
+    bastion_name: &str,
+    resource_group: &str,
+    vm_resource_id: &str,
+) -> anyhow::Result<u16>;
+```
+
+## Examples
+
+### End-user (unchanged commands, now working)
+
+```bash
+# Standard/Premium SKU bastion — previously failed with
+# "failed to open native bastion tunnel", now connects successfully.
+azlin connect my-vm
+```
+
+### Inspecting the cached DNS name
+
+```bash
+cat ~/.azlin/tunnels/registry.json
+```
+
+```json
+{
+  "tunnels": {
+    "/subscriptions/.../virtualMachines/my-vm": {
+      "vm_resource_id": "/subscriptions/.../virtualMachines/my-vm",
+      "bastion_name": "azlin-bastion-southcentralus",
+      "resource_group": "rysweet-linux-vm-pool",
+      "local_port": 52341,
+      "pid": 12345,
+      "created_at": 1750000000,
+      "tunnel_type": "native",
+      "dns_name": "bst-7299861d-50e0-4142-8b50-2f8bc6f5b549.bastion.azure.com"
+    }
+  }
+}
+```
+
+### Verifying the data-plane FQDN manually
+
+```bash
+# The value azlin resolves and uses (resolves in DNS):
+az network bastion show \
+  -n azlin-bastion-southcentralus \
+  -g rysweet-linux-vm-pool \
+  --query dnsName -o tsv
+# -> bst-7299861d-50e0-4142-8b50-2f8bc6f5b549.bastion.azure.com
+
+# The old constructed host (does NOT resolve — this was the bug):
+#   azlin-bastion-southcentralus.bastion.azure.com
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| `failed to resolve Azure Bastion data-plane DNS name ...` | `az network bastion show` failed or returned empty | Confirm the bastion name/resource group and that you have read access; run the `az` command manually. |
+| Cause chain shows a DNS/`dns error`/`Name or service not known` | The resolved FQDN could not be looked up | Verify network/DNS connectivity to `*.bastion.azure.com`. |
+| Cause chain shows a TLS or timeout error | Transport failure after DNS resolved | Check firewall/proxy; increase `bastion_tunnel_timeout` in `~/.azlin/config.toml`. |
+| First connect after upgrade is slightly slower | One-time ARM re-resolution because the cached `dns_name` was empty | Expected; subsequent connects reuse the cached value. |
+
+## Testing
+
+Regression coverage proves the endpoint used is the ARM `dnsName`, not the
+constructed `{bastion_name}.bastion.azure.com` form:
+
+- `parse_dns_name` unit tests: valid ARM output; empty/whitespace-only output;
+  hostile multi-line input; input containing `@`, `/`, `\`, or control
+  characters; values missing the `.bastion.azure.com` suffix.
+- A guard test asserting the `{bastion_name}.bastion.azure.com` string form is
+  never produced as the tunnel endpoint.
+- `error_chain` unit tests asserting the full nested `source()` chain is walked
+  and that no token/auth material appears in the rendered string.
+
+## Related
+
+- [Native Bastion Tunnel](native-bastion-tunnel.md) — the underlying native WSS
+  tunnel this fix corrects.

--- a/docs/features/native-bastion-tunnel.md
+++ b/docs/features/native-bastion-tunnel.md
@@ -105,7 +105,7 @@ pub async fn open_tunnel(
 
 | Parameter              | Description                                                    |
 |------------------------|----------------------------------------------------------------|
-| `bastion_endpoint`     | Resolved Bastion endpoint URL (Standard: `bastion.dnsName`; Developer: data pod URL from `/api/connection`) |
+| `bastion_endpoint`     | Resolved Bastion data-plane FQDN. Standard/Premium: the bastion's ARM `properties.dnsName` (`bst-<guid>.bastion.azure.com`) — **not** `{bastion_name}.bastion.azure.com`; Developer: data pod URL from `/api/connection`. See [Bastion Tunnel DNS Name Resolution](bastion-tunnel-dns-name-resolution.md). |
 | `target_resource_id`   | Azure resource ID of the target VM                             |
 | `resource_port`        | Port on the target VM to tunnel to (typically `22` for SSH)    |
 | `token`                | Azure AD bearer token with scope for the Bastion resource      |
@@ -295,8 +295,11 @@ use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // NOTE: bastion_endpoint MUST be the bastion's ARM data-plane dnsName
+    // (e.g. "bst-<guid>.bastion.azure.com"), NOT "{bastion_name}.bastion.azure.com".
+    // See docs/features/bastion-tunnel-dns-name-resolution.md.
     let (local_port, handle) = open_tunnel(
-        "my-bastion.bastion.azure.com",
+        "bst-7299861d-50e0-4142-8b50-2f8bc6f5b549.bastion.azure.com",
         "/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm",
         22,
         &azure_ad_token,

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "azlin"
-version = "2.6.83"
+version = "2.6.84"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-ai"
-version = "2.6.83"
+version = "2.6.84"
 dependencies = [
  "anyhow",
  "azlin-core",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-azure"
-version = "2.6.83"
+version = "2.6.84"
 dependencies = [
  "anyhow",
  "azlin-core",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-cli"
-version = "2.6.83"
+version = "2.6.84"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-core"
-version = "2.6.83"
+version = "2.6.84"
 dependencies = [
  "anyhow",
  "chrono",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "azlin-ssh"
-version = "2.6.83"
+version = "2.6.84"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.83"
+version = "2.6.84"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Ryan Sweet <rysweet@microsoft.com>"]

--- a/rust/crates/azlin-azure/src/native_tunnel.rs
+++ b/rust/crates/azlin-azure/src/native_tunnel.rs
@@ -229,7 +229,10 @@ async fn cleanup_token(
     node_id: &str,
 ) {
     let url = build_token_cleanup_url(endpoint, auth_token);
-    // Surface the full cause chain (never the URL — it embeds the auth token).
+    // The cleanup URL embeds the auth token as a path segment, and reqwest's
+    // error `Display` renders the full request URL (path included). Strip the
+    // URL from the error before logging so the token never reaches the log
+    // sink; the underlying cause chain is preserved for diagnostics.
     if let Err(e) = client
         .delete(&url)
         .header(NODE_ID_HEADER, node_id)
@@ -238,7 +241,7 @@ async fn cleanup_token(
     {
         warn!(
             "bastion token cleanup failed for node {node_id}: {}",
-            error_chain(&e)
+            error_chain(&e.without_url())
         );
     }
 }

--- a/rust/crates/azlin-azure/src/native_tunnel.rs
+++ b/rust/crates/azlin-azure/src/native_tunnel.rs
@@ -167,6 +167,24 @@ fn normalize_endpoint(endpoint: &str) -> Result<String, NativeTunnelError> {
     }
 }
 
+// ── Transport error transparency (issue #1046 hardening) ─────────────────
+//
+// reqwest's top-level `Display` for a transport failure is opaque
+// (`error sending request for url (...)`) and hides the real DNS/TLS/timeout
+// cause. `error_chain` walks `std::error::Error::source()` so the underlying
+// cause is surfaced in `TokenExchange` errors and cleanup warnings. It only
+// reads `Display`/`source()` — it never touches request headers or tokens.
+fn error_chain(err: &dyn std::error::Error) -> String {
+    let mut chain = err.to_string();
+    let mut source = err.source();
+    while let Some(cause) = source {
+        chain.push_str(": ");
+        chain.push_str(&cause.to_string());
+        source = cause.source();
+    }
+    chain
+}
+
 // ── Token exchange ───────────────────────────────────────────────────────
 
 async fn exchange_token(
@@ -186,7 +204,9 @@ async fn exchange_token(
         .body(body)
         .send()
         .await
-        .map_err(|e| NativeTunnelError::TokenExchange(format!("request failed: {e}")))?;
+        .map_err(|e| {
+            NativeTunnelError::TokenExchange(format!("request failed: {}", error_chain(&e)))
+        })?;
 
     if !resp.status().is_success() {
         let status = resp.status();
@@ -209,11 +229,18 @@ async fn cleanup_token(
     node_id: &str,
 ) {
     let url = build_token_cleanup_url(endpoint, auth_token);
-    let _ = client
+    // Surface the full cause chain (never the URL — it embeds the auth token).
+    if let Err(e) = client
         .delete(&url)
         .header(NODE_ID_HEADER, node_id)
         .send()
-        .await;
+        .await
+    {
+        warn!(
+            "bastion token cleanup failed for node {node_id}: {}",
+            error_chain(&e)
+        );
+    }
 }
 
 // ── Bidirectional forwarding ─────────────────────────────────────────────
@@ -453,4 +480,110 @@ pub async fn open_tunnel(
     });
 
     Ok((local_port, handle))
+}
+
+// ── Transport error transparency (issue #1046 hardening) ─────────────────────
+//
+// The regression surfaced as an opaque `error sending request for url (...)`
+// because the reqwest error's *source* chain (the real DNS/TLS/timeout cause)
+// was dropped. `error_chain` walks `std::error::Error::source()` so the true
+// underlying cause is visible in `TokenExchange` errors and cleanup warnings.
+//
+// These tests define that contract before the implementation exists (TDD).
+
+#[cfg(test)]
+mod error_surface_tests {
+    use super::*;
+    use std::error::Error as StdError;
+    use std::fmt;
+
+    #[derive(Debug)]
+    struct DnsCause;
+    impl fmt::Display for DnsCause {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                f,
+                "failed to lookup address information: Name or service not known"
+            )
+        }
+    }
+    impl StdError for DnsCause {}
+
+    #[derive(Debug)]
+    struct SendError(DnsCause);
+    impl fmt::Display for SendError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                f,
+                "error sending request for url (https://x.bastion.azure.com/api/tokens)"
+            )
+        }
+    }
+    impl StdError for SendError {
+        fn source(&self) -> Option<&(dyn StdError + 'static)> {
+            Some(&self.0)
+        }
+    }
+
+    #[test]
+    fn test_error_chain_surfaces_underlying_dns_cause() {
+        let err = SendError(DnsCause);
+        let chain = error_chain(&err);
+        // The opaque top-level message is still present ...
+        assert!(chain.contains("error sending request for url"));
+        // ... but the real, previously-hidden cause is now visible.
+        assert!(
+            chain.contains("Name or service not known"),
+            "cause chain must surface the underlying DNS failure, got: {chain}"
+        );
+    }
+
+    #[test]
+    fn test_error_chain_single_error() {
+        let chain = error_chain(&DnsCause);
+        assert!(chain.contains("Name or service not known"));
+    }
+
+    #[test]
+    fn test_error_chain_walks_multiple_levels() {
+        #[derive(Debug)]
+        struct L3;
+        impl fmt::Display for L3 {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "connection refused")
+            }
+        }
+        impl StdError for L3 {}
+
+        #[derive(Debug)]
+        struct L2(L3);
+        impl fmt::Display for L2 {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "tls handshake failed")
+            }
+        }
+        impl StdError for L2 {
+            fn source(&self) -> Option<&(dyn StdError + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        #[derive(Debug)]
+        struct L1(L2);
+        impl fmt::Display for L1 {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "request failed")
+            }
+        }
+        impl StdError for L1 {
+            fn source(&self) -> Option<&(dyn StdError + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        let chain = error_chain(&L1(L2(L3)));
+        assert!(chain.contains("request failed"), "chain: {chain}");
+        assert!(chain.contains("tls handshake failed"), "chain: {chain}");
+        assert!(chain.contains("connection refused"), "chain: {chain}");
+    }
 }

--- a/rust/crates/azlin-azure/src/native_tunnel.rs
+++ b/rust/crates/azlin-azure/src/native_tunnel.rs
@@ -485,14 +485,11 @@ pub async fn open_tunnel(
     Ok((local_port, handle))
 }
 
-// ── Transport error transparency (issue #1046 hardening) ─────────────────────
+// ── Transport error transparency tests (issue #1046 hardening) ───────────────
 //
-// The regression surfaced as an opaque `error sending request for url (...)`
-// because the reqwest error's *source* chain (the real DNS/TLS/timeout cause)
-// was dropped. `error_chain` walks `std::error::Error::source()` so the true
-// underlying cause is visible in `TokenExchange` errors and cleanup warnings.
-//
-// These tests define that contract before the implementation exists (TDD).
+// These tests define the `error_chain` contract (see the implementation above)
+// before it exists (TDD): the true DNS/TLS/timeout cause must be visible, and
+// the auth token must never leak from the cleanup path.
 
 #[cfg(test)]
 mod error_surface_tests {
@@ -588,5 +585,37 @@ mod error_surface_tests {
         assert!(chain.contains("request failed"), "chain: {chain}");
         assert!(chain.contains("tls handshake failed"), "chain: {chain}");
         assert!(chain.contains("connection refused"), "chain: {chain}");
+    }
+
+    // Regression test for the cleanup-path token leak: the cleanup URL embeds
+    // the auth token as a path segment, and reqwest's error `Display` renders
+    // the full URL. `cleanup_token` logs `error_chain(&e.without_url())`, so the
+    // token must never appear in the logged string even though it is present in
+    // the raw error.
+    #[tokio::test]
+    async fn test_cleanup_error_without_url_does_not_leak_auth_token() {
+        const AUTH_TOKEN: &str = "SUPER-SECRET-AUTH-TOKEN-9f8e7d6c";
+        // `.invalid` is reserved (RFC 6761) and guarantees a resolution failure,
+        // so `send()` returns a URL-bearing transport error without any network.
+        let url = build_token_cleanup_url("host.invalid", AUTH_TOKEN);
+        let err = reqwest::Client::new()
+            .delete(&url)
+            .send()
+            .await
+            .expect_err("request to a .invalid host must fail");
+
+        // Sanity: the raw error would leak the token (this is exactly what the
+        // fix guards against).
+        assert!(
+            error_chain(&err).contains(AUTH_TOKEN),
+            "precondition: raw reqwest error is expected to carry the token in its URL"
+        );
+
+        // The logged form strips the URL, so the token must be gone.
+        let logged = error_chain(&err.without_url());
+        assert!(
+            !logged.contains(AUTH_TOKEN),
+            "auth token leaked into cleanup log line: {logged}"
+        );
     }
 }

--- a/rust/crates/azlin/src/bastion_tunnel.rs
+++ b/rust/crates/azlin/src/bastion_tunnel.rs
@@ -617,10 +617,15 @@ pub async fn get_or_create_tunnel(
 
     // Cache the previously-resolved data-plane dnsName (if any) so a recreate
     // for this VM does not re-query ARM. Empty/legacy entries trigger a re-resolve.
+    // The registry file is treated as untrusted input: re-validate the cached host
+    // through parse_dns_name so a poisoned registry.json cannot smuggle a hostile
+    // host past the *.bastion.azure.com allowlist (issue #1046 hardening). A cached
+    // value that fails validation is discarded, forcing a fresh ARM re-resolve.
     let cached_dns_name = registry
         .get(vm_resource_id)
         .map(|e| e.dns_name.clone())
-        .filter(|d| !d.is_empty());
+        .filter(|d| !d.is_empty())
+        .and_then(|d| parse_dns_name(&d).ok());
 
     // Reuse existing tunnel if it is alive, uniquely mapped, and still listening.
     if let Some(entry) = registry.get(vm_resource_id).cloned() {
@@ -1211,5 +1216,23 @@ mod tests {
             r2.tunnels["/sub/rg/vm/y"].dns_name,
             "bst-abc123.bastion.azure.com"
         );
+    }
+
+    #[test]
+    fn test_cached_dns_name_is_revalidated_before_use() {
+        // Defense-in-depth (issue #1046 hardening): the registry file is untrusted
+        // input. A poisoned cached dns_name must be rejected by the same validator
+        // that gates fresh ARM output, so it can never bypass the *.bastion.azure.com
+        // allowlist. get_or_create_tunnel re-runs parse_dns_name on the cached value
+        // and discards it on failure (forcing a fresh ARM re-resolve).
+        let poisoned = "bst-abc.bastion.azure.com@evil.com";
+        assert!(
+            parse_dns_name(poisoned).is_err(),
+            "a poisoned cached host must not pass validation"
+        );
+
+        // A clean cached value still validates and is reused (no re-resolve).
+        let clean = "bst-abc123.bastion.azure.com";
+        assert_eq!(parse_dns_name(clean).unwrap(), clean);
     }
 }

--- a/rust/crates/azlin/src/bastion_tunnel.rs
+++ b/rust/crates/azlin/src/bastion_tunnel.rs
@@ -57,6 +57,12 @@ pub struct TunnelRegistryEntry {
     /// Defaults to "legacy" for backward compatibility with existing registry files.
     #[serde(default = "default_tunnel_type")]
     pub tunnel_type: String,
+    /// Resolved Azure Bastion data-plane FQDN (ARM `properties.dnsName`, e.g.
+    /// `bst-<uuid>.bastion.azure.com`). Cached so reused/repeat tunnels don't
+    /// re-query ARM. Defaults to empty for registry files written before this
+    /// field existed (empty triggers a one-time re-resolve).
+    #[serde(default)]
+    pub dns_name: String,
 }
 
 fn default_tunnel_type() -> String {
@@ -515,6 +521,87 @@ pub fn ensure_watchdog_running() {
 
 // ---- Public API ----
 
+/// Validate and normalize the Azure Bastion data-plane FQDN returned by
+/// `az network bastion show --query dnsName -o tsv`.
+///
+/// This is the pure, offline-testable seam for the issue #1046 fix. It fails
+/// closed: any output that isn't a single, clean `*.bastion.azure.com` host is
+/// rejected so a malformed/hostile ARM response can never be smuggled into a
+/// request URL (SSRF / authority-spoofing defense). There is NO fallback to the
+/// old `{name}.bastion.azure.com` construction.
+fn parse_dns_name(az_stdout: &str) -> Result<String> {
+    const SUFFIX: &str = ".bastion.azure.com";
+
+    // Take only the first line so a multiline response cannot smuggle a second host.
+    let host = az_stdout.lines().next().unwrap_or("").trim();
+
+    if host.is_empty() {
+        anyhow::bail!("bastion dnsName lookup returned empty output");
+    }
+    if host
+        .chars()
+        .any(|c| c.is_whitespace() || c.is_control() || c == '@' || c == '/' || c == '\\')
+    {
+        anyhow::bail!("bastion dnsName contains invalid characters: {host:?}");
+    }
+    if !host.ends_with(SUFFIX) || host.len() <= SUFFIX.len() || host.starts_with('.') {
+        anyhow::bail!(
+            "bastion dnsName {host:?} is not a valid *.bastion.azure.com data-plane host"
+        );
+    }
+
+    Ok(host.to_string())
+}
+
+/// Resolve the real Azure Bastion data-plane FQDN (ARM `properties.dnsName`)
+/// for a bastion resource. Runs `az network bastion show` on a blocking thread.
+///
+/// Fails closed with an actionable error (never falling back to a constructed
+/// `{name}.bastion.azure.com` host, which does not exist in DNS — issue #1046).
+async fn resolve_bastion_dns_name(bastion_name: &str, resource_group: &str) -> Result<String> {
+    let name = bastion_name.to_string();
+    let rg = resource_group.to_string();
+
+    let output = tokio::task::spawn_blocking(move || {
+        std::process::Command::new("az")
+            .args([
+                "network",
+                "bastion",
+                "show",
+                "--name",
+                &name,
+                "--resource-group",
+                &rg,
+                "--query",
+                "dnsName",
+                "-o",
+                "tsv",
+            ])
+            .output()
+    })
+    .await
+    .context("bastion dnsName lookup task panicked")?
+    .with_context(|| {
+        format!(
+            "failed to run 'az network bastion show' for bastion {bastion_name:?} in resource group {resource_group:?}"
+        )
+    })?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "az network bastion show failed for bastion {bastion_name:?} in resource group {resource_group:?}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_dns_name(&stdout).with_context(|| {
+        format!(
+            "could not resolve a valid data-plane dnsName for bastion {bastion_name:?} in resource group {resource_group:?}"
+        )
+    })
+}
+
 /// Get or create a bastion tunnel for a VM. Reuses existing tunnels from the registry.
 ///
 /// Returns the local port the tunnel is bound to.
@@ -527,6 +614,13 @@ pub async fn get_or_create_tunnel(
 
     let mut registry = TunnelRegistry::load();
     registry.prune();
+
+    // Cache the previously-resolved data-plane dnsName (if any) so a recreate
+    // for this VM does not re-query ARM. Empty/legacy entries trigger a re-resolve.
+    let cached_dns_name = registry
+        .get(vm_resource_id)
+        .map(|e| e.dns_name.clone())
+        .filter(|d| !d.is_empty());
 
     // Reuse existing tunnel if it is alive, uniquely mapped, and still listening.
     if let Some(entry) = registry.get(vm_resource_id).cloned() {
@@ -587,8 +681,14 @@ pub async fn get_or_create_tunnel(
     let config = azlin_core::AzlinConfig::load().unwrap_or_default();
     let timeout = std::time::Duration::from_secs(config.bastion_tunnel_timeout);
 
-    // Resolve bastion endpoint (use bastion DNS name)
-    let bastion_endpoint = format!("{}.bastion.azure.com", bastion_name);
+    // Resolve the REAL Azure Bastion data-plane FQDN from ARM (`properties.dnsName`).
+    // The old `format!("{}.bastion.azure.com", bastion_name)` construction does not
+    // exist in DNS and broke every Standard/Premium connect (issue #1046). Reuse the
+    // cached value when available to avoid a repeat ARM query.
+    let bastion_endpoint = match cached_dns_name {
+        Some(dns_name) => dns_name,
+        None => resolve_bastion_dns_name(bastion_name, resource_group).await?,
+    };
 
     // Open native tunnel (NodeScoped = Standard/Premium SKU, the common case for .bastion.azure.com)
     let (port, handle) = azlin_azure::native_tunnel::open_tunnel(
@@ -618,6 +718,7 @@ pub async fn get_or_create_tunnel(
         pid: std::process::id(),
         created_at: now,
         tunnel_type: "native".to_string(),
+        dns_name: bastion_endpoint,
     });
     registry.save()?;
 
@@ -799,6 +900,7 @@ mod tests {
             pid: 99999,
             created_at: 1000,
             tunnel_type: "legacy".to_string(),
+            dns_name: String::new(),
         });
 
         let json = serde_json::to_string(&r).unwrap();
@@ -818,6 +920,7 @@ mod tests {
             pid: 999999999,
             created_at: 1000,
             tunnel_type: "legacy".to_string(),
+            dns_name: String::new(),
         });
         r.prune();
         assert!(r.tunnels.is_empty(), "dead PID should be pruned");
@@ -945,6 +1048,7 @@ mod tests {
             pid: 1,
             created_at: 1,
             tunnel_type: "legacy".to_string(),
+            dns_name: String::new(),
         });
         registry.insert(TunnelRegistryEntry {
             vm_resource_id: "/vm/b".to_string(),
@@ -954,6 +1058,7 @@ mod tests {
             pid: 2,
             created_at: 2,
             tunnel_type: "legacy".to_string(),
+            dns_name: String::new(),
         });
         registry.insert(TunnelRegistryEntry {
             vm_resource_id: "/vm/c".to_string(),
@@ -963,6 +1068,7 @@ mod tests {
             pid: 3,
             created_at: 3,
             tunnel_type: "legacy".to_string(),
+            dns_name: String::new(),
         });
 
         let removed = purge_registry_entries_for_port(&mut registry, 50200);
@@ -973,5 +1079,137 @@ mod tests {
         assert!(!registry.tunnels.contains_key("/vm/a"));
         assert!(!registry.tunnels.contains_key("/vm/b"));
         assert!(registry.tunnels.contains_key("/vm/c"));
+    }
+
+    // ── Regression tests: bastion data-plane dnsName resolution (issue #1046) ──
+    //
+    // The regression (v2.6.83): get_or_create_tunnel built the data-plane host as
+    // `format!("{}.bastion.azure.com", bastion_name)`, which does not exist in DNS.
+    // The fix resolves the REAL ARM `properties.dnsName` (e.g. `bst-<uuid>.bastion.azure.com`)
+    // and feeds it, validated, to the native tunnel. These tests pin that contract.
+    //
+    // `parse_dns_name` is the pure, offline-testable validation/normalization seam
+    // applied to `az network bastion show --query dnsName -o tsv` output.
+
+    #[test]
+    fn test_parse_dns_name_accepts_real_arm_form() {
+        // ARM returns the real data-plane FQDN with a `bst-<uuid>` prefix.
+        let out = "bst-7299861d-50e0-4142-8b50-2f8bc6f5b549.bastion.azure.com";
+        assert_eq!(parse_dns_name(out).unwrap(), out);
+    }
+
+    #[test]
+    fn test_parse_dns_name_trims_trailing_newline_and_spaces() {
+        // `-o tsv` output typically carries a trailing newline; surrounding
+        // whitespace must be trimmed to yield a clean host.
+        let out = "  bst-abc123.bastion.azure.com \n";
+        assert_eq!(parse_dns_name(out).unwrap(), "bst-abc123.bastion.azure.com");
+    }
+
+    #[test]
+    fn test_parse_dns_name_rejects_empty() {
+        // Empty ARM output must fail closed (no fallback to a constructed host).
+        assert!(parse_dns_name("").is_err());
+    }
+
+    #[test]
+    fn test_parse_dns_name_rejects_whitespace_only() {
+        assert!(parse_dns_name("   \n\t ").is_err());
+    }
+
+    #[test]
+    fn test_parse_dns_name_rejects_wrong_suffix() {
+        // SSRF/tamper defense: only genuine `.bastion.azure.com` hosts are allowed.
+        assert!(parse_dns_name("evil.example.com").is_err());
+        assert!(parse_dns_name("bst-abc.bastion.azure.com.evil.com").is_err());
+    }
+
+    #[test]
+    fn test_parse_dns_name_rejects_at_injection() {
+        // A userinfo-style '@' must never survive into the host (URL authority spoofing).
+        assert!(parse_dns_name("bst-abc.bastion.azure.com@evil.com").is_err());
+    }
+
+    #[test]
+    fn test_parse_dns_name_rejects_path_and_control_chars() {
+        assert!(parse_dns_name("bst-abc.bastion.azure.com/api/tokens").is_err());
+        assert!(parse_dns_name("bst-abc\t.bastion.azure.com").is_err());
+    }
+
+    #[test]
+    fn test_parse_dns_name_takes_first_line_and_drops_injected_tail() {
+        // Hostile multiline output must not smuggle a second host past validation.
+        let hostile = "bst-good.bastion.azure.com\nevil.example.com";
+        let parsed = parse_dns_name(hostile).unwrap();
+        assert_eq!(parsed, "bst-good.bastion.azure.com");
+        assert!(!parsed.contains("evil"));
+        assert!(!parsed.contains('\n'));
+    }
+
+    #[test]
+    fn test_resolved_endpoint_is_arm_dns_name_not_constructed() {
+        // Core regression guard: the endpoint fed to the tunnel is the ARM dnsName,
+        // NOT the buggy `{name}.bastion.azure.com` construction.
+        let bastion_name = "azlin-bastion-southcentralus";
+        let arm_output = "bst-7299861d-50e0-4142-8b50-2f8bc6f5b549.bastion.azure.com\n";
+
+        let resolved = parse_dns_name(arm_output).unwrap();
+        assert_eq!(
+            resolved,
+            "bst-7299861d-50e0-4142-8b50-2f8bc6f5b549.bastion.azure.com"
+        );
+
+        let regressed = format!("{bastion_name}.bastion.azure.com");
+        assert_ne!(
+            resolved, regressed,
+            "endpoint must be the ARM dnsName, never {{name}}.bastion.azure.com (issue #1046)"
+        );
+    }
+
+    // ── Registry back-compat: TunnelRegistryEntry.dns_name caching ──
+
+    #[test]
+    fn test_registry_entry_dns_name_defaults_for_old_files() {
+        // registry.json written before the `dns_name` field must still deserialize,
+        // yielding an empty dns_name (which triggers a one-time ARM re-resolve).
+        let old_json = r#"{
+            "tunnels": {
+                "/sub/rg/vm/x": {
+                    "vm_resource_id": "/sub/rg/vm/x",
+                    "bastion_name": "b",
+                    "resource_group": "rg",
+                    "local_port": 50200,
+                    "pid": 1234,
+                    "created_at": 1000,
+                    "tunnel_type": "native"
+                }
+            }
+        }"#;
+        let reg: TunnelRegistry = serde_json::from_str(old_json).unwrap();
+        assert_eq!(reg.tunnels["/sub/rg/vm/x"].dns_name, "");
+    }
+
+    #[test]
+    fn test_registry_roundtrip_preserves_dns_name() {
+        // A resolved dnsName must survive a save/load cycle so reused tunnels and
+        // repeat connects do not re-query ARM.
+        let mut r = TunnelRegistry::default();
+        r.insert(TunnelRegistryEntry {
+            vm_resource_id: "/sub/rg/vm/y".to_string(),
+            bastion_name: "b".to_string(),
+            resource_group: "rg".to_string(),
+            local_port: 50210,
+            pid: 4321,
+            created_at: 2000,
+            tunnel_type: "native".to_string(),
+            dns_name: "bst-abc123.bastion.azure.com".to_string(),
+        });
+
+        let json = serde_json::to_string(&r).unwrap();
+        let r2: TunnelRegistry = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            r2.tunnels["/sub/rg/vm/y"].dns_name,
+            "bst-abc123.bastion.azure.com"
+        );
     }
 }

--- a/rust/crates/azlin/src/bastion_tunnel.rs
+++ b/rust/crates/azlin/src/bastion_tunnel.rs
@@ -572,6 +572,8 @@ async fn resolve_bastion_dns_name(bastion_name: &str, resource_group: &str) -> R
                 &name,
                 "--resource-group",
                 &rg,
+                // `az` flattens the ARM resource, so the data-plane FQDN is
+                // queried as `dnsName` (not `properties.dnsName`).
                 "--query",
                 "dnsName",
                 "-o",

--- a/rust/crates/azlin/src/tests/test_group_72.rs
+++ b/rust/crates/azlin/src/tests/test_group_72.rs
@@ -24,6 +24,7 @@ fn test_tunnel_registry_entry_has_tunnel_type_field() {
         pid: 999,
         created_at: 1700000000,
         tunnel_type: "native".to_string(),
+        dns_name: String::new(),
     };
     assert_eq!(entry.tunnel_type, "native");
 }
@@ -62,6 +63,7 @@ fn test_tunnel_registry_mixed_types_round_trip() {
             pid: 100,
             created_at: 1700000000,
             tunnel_type: "native".to_string(),
+            dns_name: String::new(),
         },
     );
     registry.tunnels.insert(
@@ -74,6 +76,7 @@ fn test_tunnel_registry_mixed_types_round_trip() {
             pid: 200,
             created_at: 1700000000,
             tunnel_type: "legacy".to_string(),
+            dns_name: String::new(),
         },
     );
 
@@ -200,6 +203,7 @@ fn test_native_tunnel_entry_sets_type() {
         pid: std::process::id(),
         created_at: 0,
         tunnel_type: "native".to_string(),
+        dns_name: String::new(),
     };
     assert_eq!(entry.tunnel_type, "native");
     assert_eq!(entry.pid, std::process::id(), "native tunnels use own PID");
@@ -216,6 +220,7 @@ fn test_legacy_tunnel_entry_sets_type() {
         pid: 9999,
         created_at: 0,
         tunnel_type: "legacy".to_string(),
+        dns_name: String::new(),
     };
     assert_eq!(entry.tunnel_type, "legacy");
 }
@@ -265,6 +270,7 @@ fn test_tunnel_type_serialized_in_json() {
         pid: 1,
         created_at: 0,
         tunnel_type: "native".to_string(),
+        dns_name: String::new(),
     };
     let json = serde_json::to_string(&entry).unwrap();
     assert!(json.contains("tunnel_type"), "JSON must contain tunnel_type field");


### PR DESCRIPTION
## Summary

Fixes a **confirmed regression** (issue #1046) introduced in v2.6.83 when the native Rust bastion tunnel replaced the `az network bastion tunnel` subprocess. `azlin connect` broke for **all Standard/Premium SKU bastions**.

### Root cause

`get_or_create_tunnel()` built the Bastion data-plane endpoint as:

```rust
let bastion_endpoint = format!("{}.bastion.azure.com", bastion_name);
```

This host does **not exist in DNS**. The real data-plane FQDN is the bastion resource's ARM `properties.dnsName` (e.g. `bst-7299861d-...bastion.azure.com`). `reqwest` failed at transport, surfaced as the opaque `token exchange failed: request failed: error sending request for url ...` → `failed to open native bastion tunnel`.

Verified live: `az network bastion show --query dnsName` returns `bst-...bastion.azure.com` (resolves), while `<name>.bastion.azure.com` does **not** resolve.

## Fix

1. **Resolve the real dnsName from ARM.** `resolve_bastion_dns_name()` runs `az network bastion show --name <n> --resource-group <rg> --query dnsName -o tsv` on a blocking thread and feeds the validated result to the native tunnel. No silent fallback to the broken constructed host — failures return an actionable error (name + resource group + `az` stderr).
2. **Cache in the registry.** `TunnelRegistryEntry` gains a `#[serde(default)] dns_name` field so reused tunnels and repeat connects don't re-query ARM. Old registry files deserialize with an empty value (one-time re-resolve).
3. **Fail-closed validation.** `parse_dns_name()` takes the first line, trims, enforces a `.bastion.azure.com` suffix allowlist, and rejects control chars / whitespace / `@` / `/` / `\` (SSRF / authority-spoofing defense).
4. **Error-surfacing hardening.** `error_chain()` walks `std::error::Error::source()` so the real DNS/TLS/timeout cause is visible in `TokenExchange` errors and cleanup warnings instead of the opaque top-level message. It only reads `Display`/`source()` — never logs the URL (which embeds the auth token) or headers. No brittle string-classification module.

## Tests

- `parse_dns_name`: accepts real ARM form; trims; rejects empty / whitespace-only / wrong-suffix / `@`-injection / path / control chars / hostile multiline tail.
- Regression guard: resolved endpoint equals the ARM dnsName and is **never** `{name}.bastion.azure.com`.
- Registry back-compat + dnsName roundtrip caching.
- `error_chain`: surfaces underlying DNS cause, walks multi-level source chains.

## Validation

- `cargo build` ✅
- `cargo test -p azlin -p azlin-azure` ✅ (2429 lib tests + all integration groups, 0 failures)
- `cargo clippy --all --locked -- -D warnings` ✅ clean

Closes #1046

---

## Step 13: Local Testing Results

Detected toolchains:
- **Rust / Cargo** — `rust/Cargo.toml` workspace with `Cargo.lock`; changed files are `rust/crates/azlin/src/bastion_tunnel.rs` and `rust/crates/azlin-azure/src/native_tunnel.rs`. User boundary is the `azlin` CLI whose native bastion tunnel resolves the Azure Bastion data-plane FQDN via `az network bastion show ... --query dnsName -o tsv`. Per qa-team repo detection, a Rust CLI repo uses `cargo test` + native tests (no gadugi framework).

Chosen validation strategy:
- Run the full CI gate locally (`cargo build --locked`, `cargo test --locked`, `cargo clippy --all --locked -- -D warnings`) plus a **live outside-in reproduction** of the exact regression through the real Azure/DNS boundary the fix depends on. Scenario 1 exercises the pure resolution/registry/error seams (the consumer boundary for the logic). Scenario 2 reproduces the live root cause against the exact bastion named in the issue, proving the ARM `dnsName` resolves while the old constructed host does not.

CI gate (all green):
- `cargo build --locked` → success
- `cargo clippy --all --locked -- -D warnings` → success, 0 warnings
- `cargo test --locked -p azlin -p azlin-azure` → all passed (bastion_tunnel: 43 tests; native_tunnel: 28 tests; doc-tests: 7)

### Scenario 1 — Regression + hardening unit tests (fix logic seam)
Command: `cargo test --locked -p azlin dns_name && cargo test --locked -p azlin-azure error_chain`
Result: PASS
Output:
```
test bastion_tunnel::tests::test_resolved_endpoint_is_arm_dns_name_not_constructed ... ok
test bastion_tunnel::tests::test_parse_dns_name_accepts_real_arm_form ... ok
test bastion_tunnel::tests::test_parse_dns_name_rejects_wrong_suffix ... ok
test bastion_tunnel::tests::test_parse_dns_name_rejects_at_injection ... ok
test bastion_tunnel::tests::test_parse_dns_name_rejects_path_and_control_chars ... ok
test bastion_tunnel::tests::test_parse_dns_name_takes_first_line_and_drops_injected_tail ... ok
test bastion_tunnel::tests::test_cached_dns_name_is_revalidated_before_use ... ok
test bastion_tunnel::tests::test_registry_entry_dns_name_defaults_for_old_files ... ok
test bastion_tunnel::tests::test_registry_roundtrip_preserves_dns_name ... ok
test result: ok. 12 passed; 0 failed  (dns_name)
test native_tunnel::error_surface_tests::test_error_chain_surfaces_underlying_dns_cause ... ok
test native_tunnel::error_surface_tests::test_error_chain_walks_multiple_levels ... ok
test native_tunnel::error_surface_tests::test_error_chain_single_error ... ok
test result: ok. 3 passed; 0 failed  (error_chain)
```
The `test_resolved_endpoint_is_arm_dns_name_not_constructed` guard asserts the endpoint fed to the tunnel is the ARM `dnsName` and is **never** `{name}.bastion.azure.com`; `error_chain` tests prove the full reqwest source chain (DNS/TLS/timeout) is surfaced instead of the opaque `error sending request for url`.

### Scenario 2 — Live root-cause reproduction (real Azure + DNS boundary)
Command:
```
az network bastion show --name azlin-bastion-southcentralus \
  --resource-group rysweet-linux-vm-pool --query dnsName -o tsv   # what the fix calls
getent hosts <resolved-dnsName>                                    # fix endpoint reachability
getent hosts azlin-bastion-southcentralus.bastion.azure.com        # old constructed host
```
Result: PASS
Output:
```
ARM dnsName (fix path): bst-7299861d-50e0-4142-8b50-2f8bc6f5b549.bastion.azure.com
  -> getent: 20.165.78.64  bst-7299861d-...bastion.azure.com   RESOLVES: YES

Old constructed host (regression): azlin-bastion-southcentralus.bastion.azure.com
  -> getent: (no result)                                       RESOLVES: NO (Name or service not known)
```
This reproduces the issue #1046 root cause against the exact bastion from the report: the ARM `dnsName` the fix now resolves is reachable, while the old `format!("{}.bastion.azure.com", name)` host does not exist in DNS — the transport failure that broke `azlin connect` for all Standard/Premium bastions. The fix routes through the resolving endpoint, so the user-visible regression is corrected.

Both scenarios passed. Existing behavior preserved: full `azlin` + `azlin-azure` suites pass and clippy is clean.
