### PR TITLE
fix(bastion): form-encode token exchange to fix HTTP 500

### DIFF
--- a/rust/crates/azlin-azure/src/native_tunnel.rs
+++ b/rust/crates/azlin-azure/src/native_tunnel.rs
@@ -115,20 +115,26 @@ pub fn build_token_cleanup_url(endpoint: &str, auth_token: &str) -> String {
     )
 }
 
-/// Build the JSON body for the token exchange POST request.
-pub fn build_token_exchange_body(
+/// Build the `application/x-www-form-urlencoded` parameters for the token
+/// exchange POST request.
+///
+/// The Azure Bastion data-plane expects a **form-encoded** body, not JSON
+/// (mirrors the `azext_bastion` Python extension). The ARM access token is
+/// carried in the `aztoken` field; auth is NOT sent as an `Authorization`
+/// header. The `token` field (a previously-issued auth token) is omitted on
+/// the initial exchange — `azext_bastion` sends `last_token=None`, which the
+/// Python `requests` form encoder drops entirely.
+pub fn build_token_exchange_form(
     target_resource_id: &str,
     resource_port: u16,
     token: &str,
-) -> String {
-    let body = serde_json::json!({
-        "resourceId": target_resource_id,
-        "protocol": "tcptunnel",
-        "workloadHostPort": resource_port.to_string(),
-        "aztoken": token,
-        "token": token,
-    });
-    body.to_string()
+) -> Vec<(&'static str, String)> {
+    vec![
+        ("resourceId", target_resource_id.to_string()),
+        ("protocol", "tcptunnel".to_string()),
+        ("workloadHostPort", resource_port.to_string()),
+        ("aztoken", token.to_string()),
+    ]
 }
 
 // ── Local listener ───────────────────────────────────────────────────────
@@ -195,13 +201,14 @@ async fn exchange_token(
     token: &str,
 ) -> Result<BastionTokenResponse, NativeTunnelError> {
     let url = build_token_exchange_url(endpoint);
-    let body = build_token_exchange_body(target_resource_id, resource_port, token);
+    let form = build_token_exchange_form(target_resource_id, resource_port, token);
 
+    // The Bastion data-plane expects `application/x-www-form-urlencoded` with
+    // the ARM token in the `aztoken` field (mirrors azext_bastion). Sending
+    // JSON or an `Authorization` header makes the service return HTTP 500.
     let resp = client
         .post(&url)
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", token))
-        .body(body)
+        .form(&form)
         .send()
         .await
         .map_err(|e| {

--- a/rust/crates/azlin-azure/tests/native_tunnel_unit.rs
+++ b/rust/crates/azlin-azure/tests/native_tunnel_unit.rs
@@ -130,26 +130,28 @@ fn test_wss_url_encodes_special_chars_in_node_id() {
 // 3. Token exchange request building
 // ═══════════════════════════════════════════════════════════════════════
 
-/// Token exchange request body must contain the correct fields.
+/// Token exchange request must be form-encoded with the correct fields.
 #[test]
 fn test_token_exchange_request_body() {
-    let body = azlin_azure::native_tunnel::build_token_exchange_body(
+    let form = azlin_azure::native_tunnel::build_token_exchange_form(
         "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
         22,
         "bearer-token-xyz",
     );
-    // Should be valid JSON with the required fields
-    let parsed: serde_json::Value = serde_json::from_str(&body)
-        .expect("token exchange body must be valid JSON");
+
+    let get = |k: &str| form.iter().find(|(key, _)| *key == k).map(|(_, v)| v.as_str());
+
     assert_eq!(
-        parsed["resourceId"],
-        "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1"
+        get("resourceId"),
+        Some("/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1")
     );
-    assert_eq!(parsed["protocol"], "tcptunnel");
-    assert_eq!(parsed["workloadHostPort"], "22");
-    // aztoken and token fields must both be the bearer token
-    assert_eq!(parsed["aztoken"], "bearer-token-xyz");
-    assert_eq!(parsed["token"], "bearer-token-xyz");
+    assert_eq!(get("protocol"), Some("tcptunnel"));
+    assert_eq!(get("workloadHostPort"), Some("22"));
+    // The ARM token is carried in `aztoken`, NOT an Authorization header.
+    assert_eq!(get("aztoken"), Some("bearer-token-xyz"));
+    // The `token` field is omitted on the initial exchange (mirrors azext_bastion,
+    // which sends last_token=None). It must never carry the ARM bearer token.
+    assert_eq!(get("token"), None);
 }
 
 /// BastionTokenResponse must deserialize from the expected JSON shape.


### PR DESCRIPTION
## Problem

After the DNS fix (v2.6.84), `azlin connect` reached the Bastion data-plane but the token exchange failed with **HTTP 500 \"Unexpected internal error\"**, so the native tunnel still could not be established.

## Root cause

Our token-exchange POST to `/api/tokens` sent a **JSON** body plus an `Authorization: Bearer` header. The Bastion data-plane rejects this. Azure's own `azext_bastion` extension posts an `application/x-www-form-urlencoded` body with the ARM token in the `aztoken` field and **no** `Authorization` header. The `token` field (a previously-issued auth token) is omitted on the initial exchange.

## Fix

- Replace `build_token_exchange_body` (JSON) with `build_token_exchange_form` returning form key/value pairs (`resourceId`, `protocol=tcptunnel`, `workloadHostPort`, `aztoken`).
- POST via reqwest `.form(&form)` (auto sets form content-type); drop the JSON content-type and Authorization header.

## Verification

- `cargo test -p azlin-azure` → 28 passed
- `cargo clippy --all --locked -- -D warnings` → clean
- **Live end-to-end**: `azlin connect ia2 --resource-group rysweet-linux-vm-pool --no-tmux -y -- 'echo AZLIN_NATIVE_TUNNEL_OK; hostname'` now prints `AZLIN_NATIVE_TUNNEL_OK` + `ia2` (previously HTTP 500).

This completes the bastion-tunnel regression fix chain (DNS name in #1048, token-exchange encoding here). Cuts v2.6.85.