### PR TITLE
fix(connect): stop penguin spinner overlaying the SSH session

### DIFF
--- a/rust/crates/azlin/src/cmd_connect.rs
+++ b/rust/crates/azlin/src/cmd_connect.rs
@@ -131,7 +131,15 @@ pub(crate) async fn dispatch(
 
             let pb = penguin_spinner(&format!("Looking up {}...", name));
             let vm = match vm_manager.get_vm(&rg, &name) {
-                Ok(vm) => vm,
+                Ok(vm) => {
+                    // Stop the spinner's steady-tick thread before proceeding to
+                    // the SSH handoff. Without this the penguin animation keeps
+                    // redrawing over the entire interactive session (regression
+                    // from the tmux-session fallback refactor, which only cleared
+                    // the spinner in the Err arm below).
+                    pb.finish_and_clear();
+                    vm
+                }
                 Err(get_vm_err) => {
                     pb.finish_and_clear();
                     // Fall back to tmux-session-name resolution only when the


### PR DESCRIPTION
## Problem
When connecting to a VM, the "Looking up <vm>..." penguin spinner keeps animating **over the entire interactive SSH/tmux session** — a continuously moving overlay. Present since v2.6.82; v2.6.81 is clean.

## Root cause
The tmux-session-fallback refactor (#1043, shipped in v2.6.82) wrapped the VM lookup in `match vm_manager.get_vm(...)`, but only calls `pb.finish_and_clear()` in the **`Err`** arm. On the normal successful lookup (`Ok(vm) => vm`) the spinner is never finished, so indicatif's steady-tick thread keeps redrawing the penguin over the session until the process exits.

## Fix
Call `pb.finish_and_clear()` in the `Ok` arm as well (mirrors the `Err` arm). One-line behavioral fix; no other command has this pattern (verified — all others use `get_vm(...)?; pb.finish_and_clear();`).

## Verification (PTY capture, real connect to a private VM)
- **Before:** 111 penguin frames, spanning from lookup through `REMOTE_START`→`REMOTE_END` (whole session).
- **After:** 37 frames, all during lookup; **0 frames after the session starts**.
- `cargo clippy --all --locked -D warnings` clean; release build OK.

Cuts v2.6.86.