### PR TITLE
fix(update): skip prereleases when checking/self-updating

### DIFF
--- a/rust/crates/azlin/src/cmd_self_update.rs
+++ b/rust/crates/azlin/src/cmd_self_update.rs
@@ -61,27 +61,28 @@ fn find_latest_release() -> Result<(String, String)> {
     let releases: Vec<serde_json::Value> =
         serde_json::from_slice(&output.stdout).context("Failed to parse GitHub releases JSON")?;
 
-    for release in &releases {
-        let tag = release["tag_name"].as_str().unwrap_or("");
-        if !tag.contains("-rust") {
-            continue;
-        }
-        let assets = release["assets"].as_array();
-        if let Some(assets) = assets {
-            for asset in assets {
-                let name = asset["name"].as_str().unwrap_or("");
-                if name.contains(suffix) && name.ends_with(".tar.gz") {
-                    let dl_url = asset["browser_download_url"]
-                        .as_str()
-                        .ok_or_else(|| anyhow::anyhow!("Missing download URL"))?;
-                    // Tag format: v2.5.0-rust.abc1234 — extract base version + commit
-                    let version = tag.strip_prefix('v').unwrap_or(tag).to_string();
-                    return Ok((dl_url.to_string(), version));
-                }
-            }
+    // Choose the highest-semver stable release that publishes a binary for this
+    // platform. Prereleases/drafts are excluded so `azlin update` never installs
+    // a yanked or incomplete build (see crate::release_select).
+    let release = crate::release_select::best_stable_release(&releases, Some(suffix))
+        .ok_or_else(|| anyhow::anyhow!("No stable release found for platform '{}'", suffix))?;
+
+    let tag = release["tag_name"].as_str().unwrap_or("");
+    let assets = release["assets"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("Release '{}' has no assets", tag))?;
+    for asset in assets {
+        let name = asset["name"].as_str().unwrap_or("");
+        if name.contains(suffix) && name.ends_with(".tar.gz") {
+            let dl_url = asset["browser_download_url"]
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("Missing download URL"))?;
+            // Tag format: v2.5.0-rust.abc1234 — extract base version + commit
+            let version = tag.strip_prefix('v').unwrap_or(tag).to_string();
+            return Ok((dl_url.to_string(), version));
         }
     }
-    anyhow::bail!("No release found for platform '{}'", suffix)
+    anyhow::bail!("No matching asset for platform '{}' in release '{}'", suffix, tag)
 }
 
 /// Download and extract the binary, replacing the current executable.

--- a/rust/crates/azlin/src/main.rs
+++ b/rust/crates/azlin/src/main.rs
@@ -29,6 +29,7 @@ mod auth_forward;
 mod dispatch;
 mod dispatch_helpers;
 mod update_check;
+mod release_select;
 const ORPHANED_PUBLIC_IP_MONTHLY_COST: f64 = 3.65;
 
 /// Default admin username for Azure VMs.

--- a/rust/crates/azlin/src/release_select.rs
+++ b/rust/crates/azlin/src/release_select.rs
@@ -1,0 +1,162 @@
+//! Shared GitHub-release selection logic for the update notice and the
+//! self-update downloader.
+//!
+//! Both callers must agree on which release is "latest", and both must ignore
+//! prereleases and drafts. GitHub's `/releases` endpoint returns items ordered
+//! by creation time, which is NOT the same as semantic-version order and does
+//! not exclude prereleases — so naively taking the first `-rust` tag can select
+//! a yanked prerelease (e.g. a release republished as a prerelease keeps its
+//! assets and can sort ahead of a newer stable one). Always filter, then pick
+//! the highest semver.
+
+use serde_json::Value;
+
+/// Parse a release tag such as `v2.6.86-rust.d82739c` (or a bare `2.6.86`) into
+/// its numeric `(major, minor, patch)` components. Returns `None` if the base
+/// version isn't three dot-separated integers.
+pub fn parse_base_version(tag: &str) -> Option<(u64, u64, u64)> {
+    let s = tag.strip_prefix('v').unwrap_or(tag);
+    // Drop the `-rust.<sha>` (or any other `-` suffix) before parsing.
+    let base = s.split('-').next().unwrap_or(s);
+    let mut parts = base.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    // Reject trailing junk like "2.6.86.1" so the format stays strict.
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+/// Return true if the release is a usable stable `-rust` release: it carries a
+/// `-rust` tag with a parseable version and is neither a prerelease nor a draft.
+fn is_stable_rust_release(release: &Value) -> bool {
+    let tag = release["tag_name"].as_str().unwrap_or("");
+    tag.contains("-rust")
+        && parse_base_version(tag).is_some()
+        && !release["prerelease"].as_bool().unwrap_or(false)
+        && !release["draft"].as_bool().unwrap_or(false)
+}
+
+/// Return true if the release has an asset whose name contains `suffix` and ends
+/// with `.tar.gz` (the platform binary tarball).
+fn has_matching_asset(release: &Value, suffix: &str) -> bool {
+    release["assets"]
+        .as_array()
+        .map(|assets| {
+            assets.iter().any(|a| {
+                let name = a["name"].as_str().unwrap_or("");
+                name.contains(suffix) && name.ends_with(".tar.gz")
+            })
+        })
+        .unwrap_or(false)
+}
+
+/// Select the highest-semver stable `-rust` release from a GitHub `/releases`
+/// JSON array. When `require_asset` is `Some(suffix)`, only releases that
+/// publish a matching `<suffix>*.tar.gz` asset are considered (used by the
+/// downloader so it never selects an assetless yanked release). Returns the
+/// chosen release object, or `None` if nothing qualifies.
+pub fn best_stable_release<'a>(
+    releases: &'a [Value],
+    require_asset: Option<&str>,
+) -> Option<&'a Value> {
+    releases
+        .iter()
+        .filter(|r| is_stable_rust_release(r))
+        .filter(|r| match require_asset {
+            Some(suffix) => has_matching_asset(r, suffix),
+            None => true,
+        })
+        .max_by_key(|r| {
+            // Safe: is_stable_rust_release already guaranteed a parseable tag.
+            parse_base_version(r["tag_name"].as_str().unwrap_or("")).unwrap_or((0, 0, 0))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_rust_tag() {
+        assert_eq!(parse_base_version("v2.6.86-rust.d82739c"), Some((2, 6, 86)));
+        assert_eq!(parse_base_version("2.6.86-rust.abc"), Some((2, 6, 86)));
+        assert_eq!(parse_base_version("v2.6.86"), Some((2, 6, 86)));
+        assert_eq!(parse_base_version("v10.20.30-rust.x"), Some((10, 20, 30)));
+    }
+
+    #[test]
+    fn rejects_malformed_tags() {
+        assert_eq!(parse_base_version("v2.6"), None);
+        assert_eq!(parse_base_version("2.6.86.1"), None);
+        assert_eq!(parse_base_version("latest"), None);
+        assert_eq!(parse_base_version("v2.x.0-rust.y"), None);
+    }
+
+    fn rel(tag: &str, prerelease: bool, draft: bool, assets: &[&str]) -> Value {
+        json!({
+            "tag_name": tag,
+            "prerelease": prerelease,
+            "draft": draft,
+            "assets": assets.iter().map(|n| json!({"name": n})).collect::<Vec<_>>(),
+        })
+    }
+
+    #[test]
+    fn skips_prerelease_even_if_newest_and_has_assets() {
+        // A prerelease with a higher patch must NOT be chosen over a stable one.
+        let releases = vec![
+            rel("v2.6.84-rust.aaa", true, false, &["azlin-linux-aarch64.tar.gz"]),
+            rel("v2.6.83-rust.bbb", true, false, &[]),
+            rel("v2.6.82-rust.ccc", false, false, &["azlin-linux-aarch64.tar.gz"]),
+        ];
+        let best = best_stable_release(&releases, None).unwrap();
+        assert_eq!(best["tag_name"], "v2.6.82-rust.ccc");
+    }
+
+    #[test]
+    fn picks_highest_semver_regardless_of_list_order() {
+        // Out-of-order list; must still pick 2.6.86, not the first element.
+        let releases = vec![
+            rel("v2.6.80-rust.a", false, false, &["azlin-linux-aarch64.tar.gz"]),
+            rel("v2.6.86-rust.b", false, false, &["azlin-linux-aarch64.tar.gz"]),
+            rel("v2.6.85-rust.c", false, false, &["azlin-linux-aarch64.tar.gz"]),
+        ];
+        let best = best_stable_release(&releases, None).unwrap();
+        assert_eq!(best["tag_name"], "v2.6.86-rust.b");
+    }
+
+    #[test]
+    fn require_asset_skips_assetless_and_wrong_platform() {
+        let releases = vec![
+            rel("v2.6.86-rust.a", false, false, &[]), // assetless (yanked-style)
+            rel("v2.6.85-rust.b", false, false, &["azlin-macos-x86_64.tar.gz"]),
+            rel("v2.6.84-rust.c", false, false, &["azlin-linux-aarch64.tar.gz"]),
+        ];
+        let best = best_stable_release(&releases, Some("linux-aarch64")).unwrap();
+        assert_eq!(best["tag_name"], "v2.6.84-rust.c");
+    }
+
+    #[test]
+    fn ignores_non_rust_and_drafts() {
+        let releases = vec![
+            rel("v9.9.9", false, false, &["azlin-linux-aarch64.tar.gz"]), // no -rust
+            rel("v2.6.90-rust.d", false, true, &["azlin-linux-aarch64.tar.gz"]), // draft
+            rel("v2.6.86-rust.e", false, false, &["azlin-linux-aarch64.tar.gz"]),
+        ];
+        let best = best_stable_release(&releases, None).unwrap();
+        assert_eq!(best["tag_name"], "v2.6.86-rust.e");
+    }
+
+    #[test]
+    fn returns_none_when_nothing_qualifies() {
+        let releases = vec![
+            rel("v2.6.84-rust.a", true, false, &["azlin-linux-aarch64.tar.gz"]),
+            rel("v9.9.9", false, false, &["azlin-linux-aarch64.tar.gz"]),
+        ];
+        assert!(best_stable_release(&releases, None).is_none());
+    }
+}

--- a/rust/crates/azlin/src/update_check.rs
+++ b/rust/crates/azlin/src/update_check.rs
@@ -58,10 +58,14 @@ fn now_secs() -> u64 {
         .as_secs()
 }
 
-/// Query GitHub for the latest Rust release version string.
-/// Uses gh CLI first (authenticated), falls back to curl.
+/// Query GitHub for the latest **stable** Rust release version string.
+/// Uses gh CLI first (authenticated), falls back to curl. Prereleases and
+/// drafts are excluded and the highest semver is chosen (see
+/// [`crate::release_select`]) so the notice never points at a yanked
+/// prerelease.
 fn fetch_latest_version() -> Option<String> {
-    // Try gh CLI first (wrapped with timeout to prevent hanging)
+    // Try gh CLI first (wrapped with timeout to prevent hanging). Fetch the
+    // full release array (`--jq .`) so selection happens in Rust, not in jq.
     let output = std::process::Command::new("timeout")
         .args([
             "5",
@@ -69,7 +73,7 @@ fn fetch_latest_version() -> Option<String> {
             "api",
             &format!("repos/{}/releases", GITHUB_REPO),
             "--jq",
-            r#"[.[] | select(.tag_name | contains("-rust"))][0].tag_name"#,
+            ".",
         ])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
@@ -77,7 +81,7 @@ fn fetch_latest_version() -> Option<String> {
         .ok()
         .filter(|o| o.status.success())
         .or_else(|| {
-            // Fall back to curl + basic parsing
+            // Fall back to curl.
             std::process::Command::new("curl")
                 .args([
                     "-sS",
@@ -92,7 +96,7 @@ fn fetch_latest_version() -> Option<String> {
                     "-H",
                     "Accept: application/vnd.github+json",
                     &format!(
-                        "https://api.github.com/repos/{}/releases?per_page=10",
+                        "https://api.github.com/repos/{}/releases?per_page=30",
                         GITHUB_REPO
                     ),
                 ])
@@ -103,29 +107,11 @@ fn fetch_latest_version() -> Option<String> {
                 .filter(|o| o.status.success())
         })?;
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let trimmed = stdout.trim().trim_matches('"');
-
-    // If we got a single tag from jq
-    if !trimmed.is_empty() && !trimmed.starts_with('[') {
-        let tag = trimmed.strip_prefix('v').unwrap_or(trimmed);
-        if tag.contains("-rust") {
-            return Some(tag.to_string());
-        }
-    }
-
-    // If we got JSON array from curl, parse it
-    if let Ok(releases) = serde_json::from_str::<Vec<serde_json::Value>>(stdout.trim()) {
-        for release in &releases {
-            if let Some(tag) = release["tag_name"].as_str() {
-                if tag.contains("-rust") {
-                    return Some(tag.strip_prefix('v').unwrap_or(tag).to_string());
-                }
-            }
-        }
-    }
-
-    None
+    let releases: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).ok()?;
+    let best = crate::release_select::best_stable_release(&releases, None)?;
+    let tag = best["tag_name"].as_str()?;
+    Some(tag.strip_prefix('v').unwrap_or(tag).to_string())
 }
 
 /// Compare version strings. Returns true if `latest` is newer than `current`.


### PR DESCRIPTION
## Problem

`azlin update` and the background update-check notice could surface and install a **yanked prerelease** (e.g. v2.6.83). Both code paths iterated GitHub's `/releases` list in creation order and took the first `-rust` tag:

- No `prerelease`/`draft` exclusion
- No semantic-version sort (GitHub orders by `created_at`, not semver)

A release republished as a prerelease keeps its assets and can sort ahead of a newer stable one, so the notice pointed at v2.6.83 and poisoned the user's `last_update_check` cache with it.

## Fix

New shared `release_select` module (`best_stable_release`) that:
1. Excludes prereleases, drafts, and non-`-rust` tags
2. Picks the **highest semver**
3. Optionally requires a matching platform `<suffix>*.tar.gz` asset (downloader), so an assetless yanked release is never chosen

Both `update_check.rs::fetch_latest_version` and `cmd_self_update.rs::find_latest_release` now use it.

## Testing

- 7 new unit tests in `release_select` (prerelease skip, semver ordering, asset requirement, draft/non-rust exclusion, malformed tags) — all pass
- `cargo clippy --all --locked -- -D warnings` clean
- `cargo test -p azlin` green

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>