### PR TITLE
fix(release): re-sync Python version files & guard against silent drift

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -117,6 +117,27 @@ jobs:
             fi
           done
 
+          # Fail loudly if any Rust-versioned file was NOT bumped to
+          # NEW_VERSION. These files must track the Rust release version, but
+          # the seds above key off ${CURRENT} (read from rust/Cargo.toml); if a
+          # file ever falls behind, its sed silently stops matching and it
+          # drifts forever (this is exactly how rust/pyproject.toml and
+          # src/azlin/__init__.py got stuck at 2.6.83 while releases marched on,
+          # mislabelling every published wheel). Verifying here turns that
+          # silent drift into a hard failure. NOTE: the repo-root pyproject.toml
+          # is intentionally on a SEPARATE version lineage (it is the Python
+          # `azlin` package, not the Rust build) and is deliberately excluded.
+          for vf in rust/Cargo.toml rust/pyproject.toml; do
+            if ! grep -q "^version = \"${NEW_VERSION}\"" "${vf}"; then
+              echo "::error::${vf} was not bumped to ${NEW_VERSION}. It has drifted out of sync with the Rust release version — re-sync its 'version' field to the current version so the bump sed matches again." >&2
+              exit 1
+            fi
+          done
+          if ! grep -q "^__version__ = \"${NEW_VERSION}\"" src/azlin/__init__.py; then
+            echo "::error::src/azlin/__init__.py __version__ was not bumped to ${NEW_VERSION}. It has drifted out of sync with the Rust release version — re-sync it to the current version so the bump sed matches again." >&2
+            exit 1
+          fi
+
           # ── Commit and push ───────────────────────────────────────────
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/rust/pyproject.toml
+++ b/rust/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "azlin-rs"
-version = "2.6.83"
+version = "2.6.87"
 description = "Azure VM fleet management CLI (Rust) — provision, manage, and monitor development VMs"
 requires-python = ">=3.8"
 license = {text = "MIT"}

--- a/src/azlin/__init__.py
+++ b/src/azlin/__init__.py
@@ -18,5 +18,5 @@ Version 2.0 Features:
 - Enhanced CLI with subcommands
 """
 
-__version__ = "2.6.83"
+__version__ = "2.6.87"
 __all__ = ["__version__"]


### PR DESCRIPTION
## Problem

Every published wheel asset on recent releases was mislabelled **`azlin_rs-2.6.83`** even though the release was 2.6.87 (see assets on v2.6.87). Two Rust-versioned files were stuck at 2.6.83:

- `rust/pyproject.toml` (the maturin `azlin_rs` wheel)
- `src/azlin/__init__.py` (`__version__`)

**Root cause:** the release workflow bumps versions with `sed s/^version = "${CURRENT}"/.../`, where `CURRENT` is read from `rust/Cargo.toml`. Once these two files fell behind at 2.6.83, `CURRENT` (2.6.8x) no longer matched their value, so the sed silently no-op'd and they could never catch up — permanent, invisible drift. (This is the same yanked `.83` that caused the connect/self-update issues, now leaking into wheel metadata.)

Note: wheels are GitHub release assets only (no PyPI publish), so this is metadata mislabelling, not shipping old code — but it's still wrong and confusing.

## Fix

1. Re-sync `rust/pyproject.toml` and `src/azlin/__init__.py` to **2.6.87**, so the next automated bump's sed matches them again and keeps them in lockstep.
2. Add a verification guard to `rust-release.yml` (modelled on the existing `Cargo.lock` guard) that **fails the release job** if any Rust-versioned file wasn't bumped to `NEW_VERSION` — turning future silent drift into a hard error.

The repo-root `pyproject.toml` is intentionally on a **separate** version lineage (the Python `azlin` package, currently `2.11.0`) and is deliberately left untouched and excluded from the guard.

## Testing

- Simulated the workflow's `2.6.87 → 2.6.88` bump: guard **passes** when files sync, and **fails** on a deliberately drifted file.
- `python3 -c "yaml.safe_load(...)"` confirms the workflow YAML is valid; `tomllib` confirms `rust/pyproject.toml` parses with `version = 2.6.87`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>