### PR TITLE
fix(release): make release job depend on wheels

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -265,7 +265,13 @@ jobs:
 
   # ── Create GitHub Release ─────────────────────────────────────────────
   release:
-    needs: [version-bump, build]
+    # MUST depend on `wheels` as well as `build`: the release job downloads
+    # all artifacts and attaches whatever exists at that moment. Without the
+    # `wheels` dependency the release can finish before the wheel jobs upload
+    # their artifacts (a timing race), publishing a release with the platform
+    # tarballs but NO wheels — silently breaking the documented
+    # `pip install azlin-rs --find-links .../releases/latest` path.
+    needs: [version-bump, build, wheels]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

**v2.6.88 (current Latest) shipped with NO Python wheels** — only the 4 platform tarballs. The documented `pip install azlin-rs --find-links https://github.com/rysweet/azlin/releases/latest` path is silently broken.

**Root cause:** the `release` job downloads all artifacts and attaches whatever exists at that moment, but only declared `needs: [version-bump, build]` — **not `wheels`**. So `release` can finish before the four `wheels` matrix jobs upload their artifacts (a timing race). Earlier releases (e.g. v2.6.87) got wheels only by timing luck; a small shift in job timing dropped them entirely for v2.6.88.

## Fix

Add `wheels` to the `release` job's `needs`:

```yaml
needs: [version-bump, build, wheels]
```

Now the release always waits for wheels to be built and uploaded before collecting/attaching artifacts. If wheels fail, the release fails loudly rather than publishing an incomplete set.

## Effect

Merging cuts **v2.6.89**, which will include the 4 tarballs **and** correctly-named `azlin_rs-2.6.89-*.whl` wheels (version-labelling fixed in #1053), becoming Latest and healing the `--find-links .../releases/latest` path.

## Testing

`yaml.safe_load` confirms the workflow parses and `release.needs == ['version-bump', 'build', 'wheels']`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>