### PR TITLE
fix(bastion): match az CLI known_hosts handling on all loopback SSH paths

### DIFF
--- a/rust/crates/azlin/src/bastion_tunnel.rs
+++ b/rust/crates/azlin/src/bastion_tunnel.rs
@@ -809,78 +809,45 @@ impl ScopedBastionTunnel {
     }
 }
 
-/// Build SSH args that route through a bastion tunnel (127.0.0.1 on a local port).
-pub fn bastion_ssh_args(
-    user: &str,
-    local_port: u16,
-    cmd: &str,
-    connect_timeout: u64,
-) -> Vec<String> {
-    vec![
-        "-o".to_string(),
-        "StrictHostKeyChecking=accept-new".to_string(),
-        "-o".to_string(),
-        format!("ConnectTimeout={}", connect_timeout),
-        "-o".to_string(),
-        "BatchMode=yes".to_string(),
-        "-p".to_string(),
-        local_port.to_string(),
-        format!("{}@127.0.0.1", user),
-        cmd.to_string(),
+/// Canonical SSH `-o` options for connecting through a bastion tunnel on
+/// 127.0.0.1, as separate argv tokens.
+///
+/// A bastion tunnel is an ephemeral loopback listener whose local port is
+/// assigned by the OS and therefore reused across different VMs over time.
+/// Recording the VM's host key against `[127.0.0.1]:port` in the user's
+/// `known_hosts` means the NEXT connection that happens to reuse that port for
+/// a DIFFERENT VM sees a mismatched key and SSH aborts with
+/// "WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!" — even though the real
+/// host is fine. The tunnel itself is already TLS-secured end-to-end to Azure
+/// Bastion, so pinning a host key on the throwaway loopback port adds no real
+/// protection. Disable host-key persistence entirely for these connections by
+/// using `StrictHostKeyChecking=no` and discarding known_hosts via
+/// `UserKnownHostsFile=/dev/null`. `LogLevel=Error` suppresses the
+/// "Warning: Permanently added ..." line SSH would otherwise print.
+///
+/// These are exactly the options the Azure CLI native bastion client uses
+/// (`az network bastion ssh` → `azext_bastion/custom.py`:
+/// `ssh username@localhost -p <port> -o StrictHostKeyChecking=no
+/// -o UserKnownHostsFile=/dev/null -o LogLevel=Error`).
+///
+/// This is the single source of truth for every 127.0.0.1 bastion SSH/SCP call
+/// site; keep new bastion connections routed through it (or
+/// [`BASTION_LOOPBACK_SSH_OPTS_STR`]) rather than re-hardcoding the options.
+pub(crate) fn bastion_loopback_ssh_opts() -> [&'static str; 6] {
+    [
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "LogLevel=Error",
     ]
 }
 
-/// Build SCP args that route through a bastion tunnel.
-pub fn bastion_scp_args(
-    user: &str,
-    local_port: u16,
-    sources: &[&str],
-    remote_path: &str,
-    connect_timeout: u64,
-    recursive: bool,
-) -> Vec<String> {
-    let mut args = Vec::new();
-    if recursive {
-        args.push("-r".to_string());
-    }
-    args.extend_from_slice(&[
-        "-o".to_string(),
-        "StrictHostKeyChecking=accept-new".to_string(),
-        "-o".to_string(),
-        format!("ConnectTimeout={}", connect_timeout),
-        "-o".to_string(),
-        "BatchMode=yes".to_string(),
-        "-P".to_string(),
-        local_port.to_string(),
-    ]);
-    for src in sources {
-        args.push(src.to_string());
-    }
-    args.push(format!("{}@127.0.0.1:{}", user, remote_path));
-    args
-}
-
-/// Build SCP args for downloading from VM through bastion tunnel.
-pub fn bastion_scp_download_args(
-    user: &str,
-    local_port: u16,
-    remote_path: &str,
-    local_dest: &str,
-    connect_timeout: u64,
-) -> Vec<String> {
-    vec![
-        "-o".to_string(),
-        "StrictHostKeyChecking=accept-new".to_string(),
-        "-o".to_string(),
-        format!("ConnectTimeout={}", connect_timeout),
-        "-o".to_string(),
-        "BatchMode=yes".to_string(),
-        "-P".to_string(),
-        local_port.to_string(),
-        format!("{}@127.0.0.1:{}", user, remote_path),
-        local_dest.to_string(),
-    ]
-}
+/// The same options as [`bastion_loopback_ssh_opts`], pre-joined for embedding
+/// inside an rsync `-e "ssh ..."` transport string.
+pub(crate) const BASTION_LOOPBACK_SSH_OPTS_STR: &str =
+    "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=Error";
 
 #[cfg(test)]
 mod tests {
@@ -888,36 +855,27 @@ mod tests {
     use std::net::TcpListener;
 
     #[test]
-    fn test_bastion_ssh_args_format() {
-        let args = bastion_ssh_args("admin", 50200, "uptime", 30);
-        assert!(args.contains(&"-p".to_string()));
-        assert!(args.contains(&"50200".to_string()));
-        assert!(args.contains(&"admin@127.0.0.1".to_string()));
-        assert!(args.contains(&"ConnectTimeout=30".to_string()));
-        assert_eq!(args.last().unwrap(), "uptime");
+    fn test_bastion_loopback_ssh_opts_disable_known_hosts() {
+        let opts = bastion_loopback_ssh_opts();
+        // Must disable host-key persistence so reused 127.0.0.1 tunnel ports
+        // across different VMs never trigger "REMOTE HOST IDENTIFICATION
+        // CHANGED".
+        assert!(opts.contains(&"StrictHostKeyChecking=no"));
+        assert!(opts.contains(&"UserKnownHostsFile=/dev/null"));
+        // LogLevel=Error suppresses the "Permanently added" warning, matching
+        // the Azure CLI native bastion client.
+        assert!(opts.contains(&"LogLevel=Error"));
+        // Must NOT use accept-new, which would still record per-port keys.
+        assert!(!opts.contains(&"StrictHostKeyChecking=accept-new"));
     }
 
     #[test]
-    fn test_bastion_scp_args_format() {
-        let args = bastion_scp_args("admin", 50201, &["/tmp/file.txt"], "~/", 30, false);
-        assert!(args.contains(&"-P".to_string()));
-        assert!(args.contains(&"50201".to_string()));
-        assert!(args.contains(&"/tmp/file.txt".to_string()));
-        assert!(args.contains(&"admin@127.0.0.1:~/".to_string()));
-        assert!(!args.contains(&"-r".to_string()));
-    }
-
-    #[test]
-    fn test_bastion_scp_args_recursive() {
-        let args = bastion_scp_args("user", 50202, &["/tmp/dir"], "~/dest/", 10, true);
-        assert_eq!(args[0], "-r");
-    }
-
-    #[test]
-    fn test_bastion_scp_download_args() {
-        let args = bastion_scp_download_args("admin", 50203, "~/file.txt", "/tmp/file.txt", 30);
-        assert!(args.contains(&"admin@127.0.0.1:~/file.txt".to_string()));
-        assert!(args.contains(&"/tmp/file.txt".to_string()));
+    fn test_bastion_loopback_ssh_opts_str_matches_tokens() {
+        // The rsync `-e` string form must stay in sync with the token form.
+        assert_eq!(
+            BASTION_LOOPBACK_SSH_OPTS_STR,
+            bastion_loopback_ssh_opts().join(" ")
+        );
     }
 
     #[test]

--- a/rust/crates/azlin/src/cmd_connect.rs
+++ b/rust/crates/azlin/src/cmd_connect.rs
@@ -302,11 +302,14 @@ pub(crate) async fn dispatch(
                     // Ensure an SSH key exists; auto-generate if missing.
                     let ssh_key = resolve_key_and_push(&key, &rg, &name, &username)?;
                     let mut args = vec![
-                        "-o".to_string(),
-                        "StrictHostKeyChecking=accept-new".to_string(),
                         "-p".to_string(),
                         tunnel.local_port.to_string(),
                     ];
+                    args.extend(
+                        crate::bastion_tunnel::bastion_loopback_ssh_opts()
+                            .iter()
+                            .map(|s| s.to_string()),
+                    );
                     if let Some(ref k) = ssh_key {
                         args.push("-i".to_string());
                         args.push(k.to_string_lossy().to_string());

--- a/rust/crates/azlin/src/cmd_list_data.rs
+++ b/rust/crates/azlin/src/cmd_list_data.rs
@@ -173,7 +173,8 @@ pub(crate) async fn collect_tmux_sessions(
                 // Bastion SSH via pre-created tunnel
                 join_set.spawn(async move {
                     let mut cmd = tokio::process::Command::new("ssh");
-                    cmd.args(["-o", "StrictHostKeyChecking=accept-new", "-o", &timeout_arg, "-o", "BatchMode=yes"]);
+                    cmd.args(crate::bastion_tunnel::bastion_loopback_ssh_opts());
+                    cmd.args(["-o", &timeout_arg, "-o", "BatchMode=yes"]);
                     cmd.args(["-p", &port.to_string()]);
                     if let Some(ref key) = ssh_key {
                         cmd.args(["-i", key.to_str().unwrap_or("")]);

--- a/rust/crates/azlin/src/cmd_sync_ops.rs
+++ b/rust/crates/azlin/src/cmd_sync_ops.rs
@@ -63,7 +63,8 @@ pub(crate) async fn handle_sync(
                 )
                 .await?;
                 let ssh_cmd = format!(
-                    "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -p {}",
+                    "ssh {} -o BatchMode=yes -p {}",
+                    crate::bastion_tunnel::BASTION_LOOPBACK_SSH_OPTS_STR,
                     tunnel.local_port
                 );
                 let dest = format!("{}@127.0.0.1:~/", target.user);
@@ -196,16 +197,18 @@ pub(crate) async fn handle_cp(
                     dest.clone()
                 };
 
-                let mut scp_args = vec![
-                    "-o".to_string(),
-                    "StrictHostKeyChecking=accept-new".to_string(),
+                let mut scp_args: Vec<String> = crate::bastion_tunnel::bastion_loopback_ssh_opts()
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect();
+                scp_args.extend([
                     "-o".to_string(),
                     timeout_val.clone(),
                     "-o".to_string(),
                     "BatchMode=yes".to_string(),
                     "-P".to_string(),
                     port_str,
-                ];
+                ]);
                 if let Some(ref key) = bastion.ssh_key_path {
                     scp_args.push("-i".to_string());
                     scp_args.push(key.to_string_lossy().to_string());

--- a/rust/crates/azlin/src/cmd_tunnel.rs
+++ b/rust/crates/azlin/src/cmd_tunnel.rs
@@ -374,17 +374,18 @@ pub(crate) fn build_bastion_ssh_args(
     user: &str,
     key: Option<&std::path::Path>,
 ) -> Vec<String> {
-    let mut args = vec![
-        "-N".to_string(),
-        "-o".to_string(),
-        "StrictHostKeyChecking=no".to_string(),
-        "-o".to_string(),
-        "UserKnownHostsFile=/dev/null".to_string(),
+    let mut args = vec!["-N".to_string()];
+    args.extend(
+        crate::bastion_tunnel::bastion_loopback_ssh_opts()
+            .iter()
+            .map(|s| s.to_string()),
+    );
+    args.extend([
         "-p".to_string(),
         bastion_local_port.to_string(),
         "-L".to_string(),
         format!("{}:localhost:{}", lport, remote_port),
-    ];
+    ]);
     if let Some(k) = key {
         args.push("-i".to_string());
         args.push(k.display().to_string());

--- a/rust/crates/azlin/src/tests/test_group_72.rs
+++ b/rust/crates/azlin/src/tests/test_group_72.rs
@@ -226,36 +226,6 @@ fn test_legacy_tunnel_entry_sets_type() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// 5. bastion_ssh_args still works (no regression)
-// ═══════════════════════════════════════════════════════════════════════
-
-/// bastion_ssh_args must still produce correct SSH arguments.
-#[test]
-fn test_bastion_ssh_args_unchanged() {
-    let args = crate::bastion_tunnel::bastion_ssh_args("azureuser", 12345, "whoami", 30);
-    assert!(args.contains(&"-p".to_string()));
-    assert!(args.contains(&"12345".to_string()));
-    assert!(args.contains(&"azureuser@127.0.0.1".to_string()));
-    assert!(args.contains(&"whoami".to_string()));
-}
-
-/// bastion_scp_args must still produce correct SCP arguments.
-#[test]
-fn test_bastion_scp_args_unchanged() {
-    let args = crate::bastion_tunnel::bastion_scp_args(
-        "azureuser",
-        12345,
-        &["file.txt"],
-        "/home/user/",
-        30,
-        false,
-    );
-    assert!(args.contains(&"-P".to_string()));
-    assert!(args.contains(&"12345".to_string()));
-    assert!(args.contains(&"file.txt".to_string()));
-}
-
-// ═══════════════════════════════════════════════════════════════════════
 // 6. Edge cases
 // ═══════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Problem

`azlin connect` (and `list`/`sync`) to private, bastion-only VMs began failing with `REMOTE HOST IDENTIFICATION HAS CHANGED` even though the target host was unchanged.

Root cause: the native bastion tunnel (v2.6.83) connects SSH to a local `127.0.0.1:<port>` listener. The connect/list/sync paths used `StrictHostKeyChecking=accept-new` against the user's real `~/.ssh/known_hosts`, recording each VM's host key under `[127.0.0.1]:<port>`. The OS reuses loopback ports across different VMs over time, so a later connection reusing a port for a *different* VM saw a mismatched key → hard SSH abort. It also polluted `known_hosts` and printed `Warning: Permanently added [127.0.0.1]:<port>` on every connect.

## Fix

Match the Azure CLI native bastion client exactly (`azext_bastion/custom.py`):

```
ssh username@localhost -p <port> \
  -o StrictHostKeyChecking=no \
  -o UserKnownHostsFile=/dev/null \
  -o LogLevel=Error
```

The tunnel is already TLS-secured end-to-end to Azure Bastion, so pinning a host key on the throwaway loopback port adds no protection. Discarding it via `/dev/null` eliminates collisions and never touches the user's `known_hosts`; `LogLevel=Error` suppresses the spurious "Permanently added" warning.

## Changes

- New single source of truth in `bastion_tunnel.rs`: `bastion_loopback_ssh_opts()` + `BASTION_LOOPBACK_SSH_OPTS_STR`.
- Routed every 127.0.0.1 bastion call site through it:
  - `cmd_connect.rs` — interactive / `ay` connect via bastion
  - `cmd_list_data.rs` — tmux session collection
  - `cmd_sync_ops.rs` — rsync `-e` transport and scp
  - `cmd_tunnel.rs` — `build_bastion_ssh_args` (also gains `LogLevel=Error`)
- Direct real-IP SSH paths (public-IP connect, `collect_procs`, batch) intentionally keep `StrictHostKeyChecking=accept-new` — their per-host keys are stable.
- Removed three dead helpers (`bastion_ssh_args`, `bastion_scp_args`, `bastion_scp_download_args`) with no non-test callers, plus their obsolete tests.

## Testing

- `cargo clippy --all --locked -- -D warnings` — clean
- `cargo test -p azlin` — all pass
- Live-verified `azlin connect ia2 ... -- 'echo OK; hostname'` succeeds; the pre-existing `[127.0.0.1]` known_hosts pollution is the exact behavior this removes.