### PR TITLE
fix(bastion): redact wss_url token in WSS-connect warn! (#1056)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Bastion WSS URL redaction** — the `wss://` tunnel URL embeds the short-lived
+  `websocketToken` bearer secret as a path segment. On a failed WSS connect the
+  `warn!` now logs a redacted URL (`redact_wss_url`) and scrubs the token from
+  the rendered `tungstenite` error, so the token can never reach a `tracing`/OTel
+  sink regardless of upstream `Display` behavior. Fail-closed: unrecognized URL
+  shapes collapse to `wss://<redacted>`. Defense-in-depth; no confirmed leak (#1056)
+  - New docs: `docs/WSS_URL_REDACTION.md`
+
 ### Added
 - **GUI Forwarding**: Run remote Linux GUI applications locally (#828)
   - `azlin connect --x11` / `-X` — X11 forwarding for lightweight GUI apps (gitk, meld, xeyes)

--- a/docs/WSS_URL_REDACTION.md
+++ b/docs/WSS_URL_REDACTION.md
@@ -1,0 +1,152 @@
+# WSS URL Redaction (`redact_wss_url`)
+
+**Status:** Shipped · **Issue:** [rysweet/azlin#1056](https://github.com/rysweet/azlin/issues/1056)
+· **Crate:** `azlin-azure` · **Module:** `native_tunnel`
+
+## Overview
+
+Native bastion tunnels connect over a WebSocket Secure (`wss://`) URL whose path
+segment embeds a short-lived **`websocketToken`** — a bearer secret that grants
+access to the tunnel. Before this change, when a WSS connect/reconnect/close
+event failed, the `tungstenite` error was rendered with its full URL and written
+to a log sink via `tracing`, leaking the token into log files and OpenTelemetry
+exporters.
+
+`redact_wss_url` masks the token-bearing portion of a `wss://` URL so it is safe
+to log, while the real, token-bearing URL is still used for the live connection.
+The redaction is **fail-closed**: any input that does not parse as an expected
+tunnel URL is masked aggressively rather than passed through.
+
+## Guarantees
+
+- The `websocketToken` (Standard/Premium **path segment**, Developer/QuickConnect
+  **path segment**, or any `?...token...` query / `userinfo`) never appears in a
+  logged string.
+- Host, scheme, node id (`X-Node-Id`), and structural shape of the URL are
+  preserved so logs stay diagnostically useful.
+- URL-encoding aware: matches the encoding applied by `build_wss_url_standard` /
+  `build_wss_url_developer` (SEC-2), so an encoded token cannot slip through.
+- Behavior of the live tunnel is **unchanged** — `connect_async` still receives
+  the unredacted, token-bearing URL.
+- Additive and non-breaking: no public type or existing function signature
+  changes.
+
+## API
+
+```rust
+/// Return a log-safe rendering of a `wss://` bastion tunnel URL with the
+/// embedded `websocketToken` replaced by `***`.
+///
+/// Preserves scheme, host, and the `X-Node-Id` query parameter. Fail-closed:
+/// input that does not match a known tunnel URL shape is masked to
+/// `wss://<redacted>`.
+pub fn redact_wss_url(url: &str) -> String;
+```
+
+### Masking rules
+
+| Input shape (SKU)              | Example (abbreviated)                                  | Redacted output                                        |
+| ------------------------------ | ------------------------------------------------------ | ------------------------------------------------------ |
+| Standard / Premium (`NodeScoped`)  | `wss://host/webtunnelv2/<TOKEN>?X-Node-Id=<id>`        | `wss://host/webtunnelv2/***?X-Node-Id=<id>`            |
+| Developer / QuickConnect (`EndpointScoped`) | `wss://host/omni/webtunnel/<TOKEN>`                    | `wss://host/omni/webtunnel/***`                        |
+| Unrecognized / malformed       | `garbage`                                              | `wss://<redacted>`                                     |
+
+Only the token segment is masked; the node id is retained because it is not a
+secret and aids correlation.
+
+## Usage
+
+Route any URL- or connection-error-bearing log field through `redact_wss_url`.
+Do **not** log raw `wss_url` or the raw `tungstenite` error `Display` (which
+renders the URL). Note: `reqwest`'s `without_url()` is **not** applicable here —
+the WSS leak site renders a `tungstenite` error, which has no such method.
+
+```rust
+use crate::native_tunnel::redact_wss_url;
+
+// Step 2: build the real, token-bearing URL used for the live connection.
+let wss_url = build_wss_url_standard(&endpoint, &token_resp.websocket_token, &token_resp.node_id);
+
+// Step 3: connect with the REAL url (unchanged).
+match tokio_tungstenite::connect_async(&wss_url).await {
+    Ok((ws_stream, _)) => { /* forward */ }
+    Err(e) => {
+        // The tungstenite error Display embeds the URL; redact before logging.
+        warn!(url = %redact_wss_url(&wss_url), "bastion WSS connect failed: {e}");
+        // ...best-effort cleanup...
+    }
+}
+```
+
+### Audited log sites (`native_tunnel.rs`)
+
+Line numbers below reflect `native_tunnel.rs` at the time of writing and may
+drift; the events are the stable reference.
+
+| Line   | Event                       | Action                                           |
+| ------ | --------------------------- | ------------------------------------------------ |
+| 527–529 | WSS connect failed (primary leak) | Redact URL field *and* scrub the rendered error via `e.to_string().replace(&wss_url, &redacted_url)` |
+| 427–429 | cleanup error chain         | Already stripped via `without_url()` (reqwest)   |
+| 504    | token exchange failed       | No URL rendered; verified token-free             |
+| 542    | WSS connected (`debug!`)    | No URL rendered                                   |
+| 556    | tunnel closed (`debug!`)    | No URL rendered                                   |
+
+## Configuration
+
+No configuration. Redaction is unconditional at every WSS URL/error log site and
+cannot be turned off. There is no verbosity level at which the raw token is
+emitted.
+
+## Security notes
+
+- The token remains present in memory and on the wire (required for the
+  connection) — redaction is a **logging** control only.
+- `redact_wss_url` performs no allocation of the raw token into any returned
+  value; the returned `String` contains only masked content plus non-secret
+  structure.
+- Structured `tracing` + OpenTelemetry only. No `print!` / `println!` /
+  `eprintln!` in the tunnel path.
+
+## Testing
+
+Unit test in `rust/crates/azlin-azure/tests/native_tunnel_unit.rs` (mirrors
+`test_cleanup_error_without_url_does_not_leak_auth_token`):
+
+```rust
+#[test]
+fn test_redact_wss_url_never_leaks_websocket_token() {
+    const TOKEN: &str = "SUPER-SECRET-WS-TOKEN-9f8e7d6c";
+    let url = azlin_azure::native_tunnel::build_wss_url_standard(
+        "host.example", TOKEN, "node-42",
+    );
+
+    // Precondition: the raw URL carries the token.
+    assert!(url.contains(TOKEN) || url.contains(&urlencoding::encode(TOKEN).into_owned()));
+
+    let redacted = azlin_azure::native_tunnel::redact_wss_url(&url);
+
+    // The redacted form must never contain the token (raw or encoded).
+    assert!(!redacted.contains(TOKEN));
+    assert!(!redacted.contains(urlencoding::encode(TOKEN).as_ref()));
+    // Non-secret structure is preserved.
+    assert!(redacted.starts_with("wss://host.example/webtunnelv2/"));
+    assert!(redacted.contains("X-Node-Id=node-42"));
+    assert!(redacted.contains("***"));
+}
+```
+
+### Coverage matrix
+
+| Path                              | Asserts                                                                         |
+| --------------------------------- | ------------------------------------------------------------------------------- |
+| Standard / Premium (`NodeScoped`) | Token masked to `***`; host + `X-Node-Id` preserved.                            |
+| Developer / QuickConnect (`EndpointScoped`) | Token masked; `/omni/webtunnel/***` structure preserved.              |
+| URL-encoded token                 | Encoded token (special chars) never appears in redacted output.                 |
+| Fail-closed (malformed input)     | Unrecognized shape masked to `wss://<redacted>`; no fragment of input echoed.   |
+| WSS-connect `warn!` scrub         | The rendered `tungstenite` error passed to `warn!` (after `to_string().replace(&wss_url, &redact_wss_url(&wss_url))`) never contains `websocket_token` or raw `wss_url`. |
+
+The WSS-connect `warn!` scrub test constructs a `wss_url` from a known token,
+simulates the error-render/replace applied at the leak site
+(`native_tunnel.rs:527-529`), and asserts the logged string contains neither the
+raw token nor the raw URL — locking the security control regardless of upstream
+`tungstenite` `Display` behavior.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@
 ## Reference
 
 - [API Reference](./API_REFERENCE.md) — Programmatic API for automation
+- [WSS URL Redaction](./WSS_URL_REDACTION.md) — Log-safe bastion tunnel URLs (`redact_wss_url`)
 - [CLI Command Reference](./reference/cli-python-parity.md) — All CLI flags, defaults, and migration notes
 - [Logs Command](./reference/logs-command.md) — View and stream VM log files
 - [Restore Command](./reference/cli-help-restore.md) — Restore terminal sessions

--- a/rust/crates/azlin-azure/src/native_tunnel.rs
+++ b/rust/crates/azlin-azure/src/native_tunnel.rs
@@ -106,6 +106,54 @@ pub fn build_wss_url_developer(endpoint: &str, ws_token: &str) -> String {
     )
 }
 
+/// Return a log-safe rendering of a `wss://` bastion tunnel URL with the
+/// embedded `websocketToken` replaced by `***` (issue #1056).
+///
+/// The tunnel URL carries the short-lived `websocketToken` — a bearer secret —
+/// as a path segment (`/webtunnelv2/<TOKEN>` for Standard/Premium,
+/// `/omni/webtunnel/<TOKEN>` for Developer/QuickConnect). Rendering the raw URL
+/// (or a `tungstenite` error that embeds it) into a `tracing` sink leaks that
+/// secret into log files and OpenTelemetry exporters.
+///
+/// This helper masks the token segment while preserving scheme, host, and the
+/// non-secret `X-Node-Id` query parameter so logs stay diagnostically useful.
+/// It is **fail-closed**: any input that does not match a known tunnel URL shape
+/// is masked to the fixed sentinel `wss://<redacted>` rather than echoed back.
+///
+/// This is a logging-only control. The real, token-bearing URL returned by
+/// [`build_wss_url_standard`] / [`build_wss_url_developer`] is still passed
+/// verbatim to `connect_async`; `redact_wss_url` takes `&str` and returns a new
+/// `String`, so it never mutates the caller's live URL.
+pub fn redact_wss_url(url: &str) -> String {
+    /// Mask marker substituted for the secret token segment.
+    const MASK: &str = "***";
+    /// Fixed sentinel returned for any unrecognized / malformed input.
+    const REDACTED: &str = "wss://<redacted>";
+
+    // Only `wss://` tunnel URLs of a known shape are structurally redacted.
+    let Some(rest) = url.strip_prefix("wss://") else {
+        return REDACTED.to_string();
+    };
+
+    // Try each known tunnel path marker. `host` is everything before the marker
+    // (must be a bare authority with no `/`); the token segment after the marker
+    // is dropped and any trailing `?query` (e.g. `X-Node-Id`) is preserved.
+    for marker in ["/webtunnelv2/", "/omni/webtunnel/"] {
+        if let Some(idx) = rest.find(marker) {
+            let host = &rest[..idx];
+            if host.is_empty() || host.contains('/') {
+                continue;
+            }
+            let after = &rest[idx + marker.len()..];
+            let query = after.find('?').map(|q| &after[q..]).unwrap_or("");
+            return format!("wss://{host}{marker}{MASK}{query}");
+        }
+    }
+
+    // Fail-closed: unrecognized shape → do not echo any part of the input.
+    REDACTED.to_string()
+}
+
 /// Build the token cleanup URL: `https://{endpoint}/api/tokens/{auth_token}`
 pub fn build_token_cleanup_url(endpoint: &str, auth_token: &str) -> String {
     format!(
@@ -473,7 +521,12 @@ async fn handle_client(
     let (ws_stream, _) = match ws_result {
         Ok(pair) => pair,
         Err(e) => {
-            warn!("bastion WSS connect failed: {e}");
+            // The `tungstenite` error `Display` embeds the full connect URL,
+            // which carries the `websocketToken` secret. Scrub the URL from the
+            // rendered error and log the redacted form only (issue #1056).
+            let redacted_url = redact_wss_url(&wss_url);
+            let safe_err = e.to_string().replace(&wss_url, &redacted_url);
+            warn!(url = %redacted_url, "bastion WSS connect failed: {safe_err}");
             // Best-effort cleanup
             cleanup_token(
                 &client,
@@ -904,5 +957,213 @@ mod classifier_tests {
                 "rendered hint must be secret-free: {rendered}"
             );
         }
+    }
+}
+
+// ── WSS URL redaction tests (issue #1056) ────────────────────────────────────
+//
+// TDD (write-tests-first) contract for `redact_wss_url` and the WSS-connect
+// `warn!` scrubbing pipeline. The bastion tunnel URL carries the short-lived
+// `websocketToken` bearer secret as a PATH SEGMENT (`/webtunnelv2/<TOKEN>` for
+// Standard/Premium, `/omni/webtunnel/<TOKEN>` for Developer/QuickConnect). A
+// failed `connect_async` produces a `tungstenite` error whose `Display` can
+// embed the full connect URL; rendering it into a `tracing`/OTel sink would
+// leak the token. These tests pin the guarantee that the token can NEVER reach
+// a log sink regardless of upstream `Display` behaviour:
+//
+//   * `redact_wss_url` masks the token segment for every known tunnel shape,
+//   * it is FAIL-CLOSED: any unrecognized input is masked to the fixed sentinel
+//     `wss://<redacted>` and never echoed back (no partial leak),
+//   * the call-site scrub (`err.replace(&wss_url, &redact_wss_url(&wss_url))`)
+//     removes the token from a rendered error that embeds the raw URL,
+//   * host/`X-Node-Id` diagnostics are preserved so logs stay useful.
+//
+// The token-absence assertions also serve as regression guards: any future
+// change that re-introduces the raw token into the redacted/logged output
+// turns these RED.
+#[cfg(test)]
+mod redaction_tests {
+    use super::*;
+
+    /// A recognizable, structurally-simple secret so any leak is unambiguous in
+    /// assertion output. Contains no URL-reserved characters, so it survives
+    /// `urlencoding::encode` verbatim and appears literally in the built URL.
+    const TOKEN: &str = "SUPERSECRETwebsocketTOKEN0123456789abcdef";
+    const ENDPOINT: &str = "bst-abc123.bastion.azure.com";
+    const NODE_ID: &str = "node-42";
+
+    /// Fixed sentinel the fail-closed path must emit for unrecognized input.
+    const SENTINEL: &str = "wss://<redacted>";
+
+    // 1. Standard/Premium URL: the token segment is masked while scheme, host,
+    //    and the non-secret `X-Node-Id` query parameter survive for diagnostics.
+    #[test]
+    fn redacts_standard_url_token_but_keeps_host_and_node_id() {
+        let url = build_wss_url_standard(ENDPOINT, TOKEN, NODE_ID);
+        // Precondition: the raw URL really does carry the secret (guards the test).
+        assert!(
+            url.contains(TOKEN),
+            "precondition: raw standard URL must embed the token"
+        );
+
+        let redacted = redact_wss_url(&url);
+
+        assert!(
+            !redacted.contains(TOKEN),
+            "token leaked into redacted standard URL: {redacted}"
+        );
+        assert!(
+            redacted.contains(ENDPOINT),
+            "host must be preserved for diagnostics: {redacted}"
+        );
+        assert!(
+            redacted.contains("X-Node-Id="),
+            "non-secret X-Node-Id query must be preserved: {redacted}"
+        );
+        assert!(
+            redacted.starts_with("wss://") && redacted.contains("/webtunnelv2/"),
+            "redacted URL must keep its recognizable tunnel shape: {redacted}"
+        );
+        assert_ne!(redacted, SENTINEL, "a known shape must not fail closed");
+    }
+
+    // 2. Developer/QuickConnect URL: the token segment is masked; host survives.
+    #[test]
+    fn redacts_developer_url_token_but_keeps_host() {
+        let url = build_wss_url_developer(ENDPOINT, TOKEN);
+        assert!(
+            url.contains(TOKEN),
+            "precondition: raw developer URL must embed the token"
+        );
+
+        let redacted = redact_wss_url(&url);
+
+        assert!(
+            !redacted.contains(TOKEN),
+            "token leaked into redacted developer URL: {redacted}"
+        );
+        assert!(
+            redacted.contains(ENDPOINT),
+            "host must be preserved: {redacted}"
+        );
+        assert!(
+            redacted.contains("/omni/webtunnel/"),
+            "redacted URL must keep its recognizable tunnel shape: {redacted}"
+        );
+        assert_ne!(redacted, SENTINEL, "a known shape must not fail closed");
+    }
+
+    // 3. FAIL-CLOSED: a non-`wss://` scheme (e.g. the auth token cleanup URL,
+    //    or anything else) is masked to the sentinel with no part echoed back.
+    #[test]
+    fn non_wss_scheme_fails_closed_to_sentinel() {
+        let url = format!("https://{ENDPOINT}/api/tokens/{TOKEN}");
+        let redacted = redact_wss_url(&url);
+        assert_eq!(
+            redacted, SENTINEL,
+            "non-wss input must fail closed to the sentinel"
+        );
+        assert!(
+            !redacted.contains(TOKEN) && !redacted.contains(ENDPOINT),
+            "fail-closed sentinel must echo NOTHING from the input: {redacted}"
+        );
+    }
+
+    // 4. FAIL-CLOSED: a `wss://` URL of an UNKNOWN path shape (no known tunnel
+    //    marker) must not be partially echoed — it collapses to the sentinel.
+    #[test]
+    fn unknown_wss_shape_fails_closed_to_sentinel() {
+        let url = format!("wss://{ENDPOINT}/some/other/path/{TOKEN}");
+        let redacted = redact_wss_url(&url);
+        assert_eq!(
+            redacted, SENTINEL,
+            "unrecognized wss shape must fail closed"
+        );
+        assert!(
+            !redacted.contains(TOKEN),
+            "unrecognized wss shape must not leak the token: {redacted}"
+        );
+    }
+
+    // 5. FAIL-CLOSED against path-injection: if the "host" position contains a
+    //    `/` (i.e. the marker was found but the authority is not a bare host),
+    //    the input is rejected rather than emitting a malformed/partial URL.
+    #[test]
+    fn marker_with_non_bare_host_fails_closed() {
+        // `/webtunnelv2/` appears but is preceded by a path, so `host` contains `/`.
+        let url = format!("wss://{ENDPOINT}/evil/webtunnelv2/{TOKEN}");
+        let redacted = redact_wss_url(&url);
+        assert_eq!(
+            redacted, SENTINEL,
+            "a non-bare host before the marker must fail closed"
+        );
+        assert!(
+            !redacted.contains(TOKEN),
+            "path-injection shape must not leak the token: {redacted}"
+        );
+    }
+
+    // 6. Idempotence: redacting an already-redacted URL is stable and never
+    //    reintroduces or exposes a secret.
+    #[test]
+    fn redaction_is_idempotent() {
+        let url = build_wss_url_standard(ENDPOINT, TOKEN, NODE_ID);
+        let once = redact_wss_url(&url);
+        let twice = redact_wss_url(&once);
+        assert_eq!(
+            once, twice,
+            "redaction must be idempotent: {once} != {twice}"
+        );
+        assert!(!twice.contains(TOKEN), "re-redaction must stay leak-free");
+    }
+
+    // 7. Call-site scrub pipeline (native_tunnel WSS-connect `warn!`, line ~528):
+    //    a `tungstenite`-style error whose `Display` embeds the full connect URL
+    //    must have the raw URL replaced by its redacted form so the rendered,
+    //    to-be-logged string carries NO token — regardless of upstream Display.
+    #[test]
+    fn call_site_scrub_removes_token_from_rendered_error() {
+        for url in [
+            build_wss_url_standard(ENDPOINT, TOKEN, NODE_ID),
+            build_wss_url_developer(ENDPOINT, TOKEN),
+        ] {
+            // Model the worst case: the transport error Display echoes the URL.
+            let raw_error_display =
+                format!("WebSocket protocol error: Connection refused for url ({url})");
+            assert!(
+                raw_error_display.contains(TOKEN),
+                "precondition: worst-case error Display embeds the token"
+            );
+
+            // This mirrors the exact scrub applied at the `warn!` call site.
+            let redacted_url = redact_wss_url(&url);
+            let safe_err = raw_error_display.replace(&url, &redacted_url);
+
+            assert!(
+                !safe_err.contains(TOKEN),
+                "websocket_token leaked into the WSS-connect warn! output: {safe_err}"
+            );
+            // The diagnostic shell of the error is retained.
+            assert!(
+                safe_err.contains("Connection refused"),
+                "scrub must preserve the non-secret error context: {safe_err}"
+            );
+        }
+    }
+
+    // 8. Defense-in-depth: even if the upstream error Display does NOT contain
+    //    the URL at all (so `.replace` is a no-op), the token must still be
+    //    absent from what gets logged — i.e. the raw error alone is token-free.
+    #[test]
+    fn error_without_url_display_is_already_token_free() {
+        let url = build_wss_url_standard(ENDPOINT, TOKEN, NODE_ID);
+        // A realistic opaque tungstenite error that never renders the URL.
+        let raw_error_display = "IO error: Connection reset by peer (os error 104)".to_string();
+        let redacted_url = redact_wss_url(&url);
+        let safe_err = raw_error_display.replace(&url, &redacted_url);
+        assert!(
+            !safe_err.contains(TOKEN),
+            "token must never appear when the error omits the URL: {safe_err}"
+        );
     }
 }

--- a/rust/crates/azlin-azure/tests/native_tunnel_unit.rs
+++ b/rust/crates/azlin-azure/tests/native_tunnel_unit.rs
@@ -430,3 +430,221 @@ fn test_wss_url_mode_variants_exist() {
     let _es = azlin_azure::native_tunnel::WssUrlMode::EndpointScoped;
     assert_ne!(_ns, _es);
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// 9. WSS URL redaction (issue #1056)
+//
+// The `wss://` tunnel URL embeds the short-lived `websocketToken` as a path
+// segment (Standard/Premium) or as the final path segment (Developer). Before
+// this fix, a failed WSS connect/reconnect/close rendered the `tungstenite`
+// error (which embeds the full URL) straight into a `tracing` sink, leaking the
+// bearer secret into log files and OTel exporters.
+//
+// `redact_wss_url(&str) -> String` returns a log-safe rendering that masks the
+// token while preserving scheme, host, and the non-secret `X-Node-Id`. It is
+// fail-closed: input that does not match a known tunnel URL shape is masked to
+// `wss://<redacted>`. The live connection is unaffected — `connect_async` still
+// receives the real, unredacted URL.
+//
+// These tests mirror `test_cleanup_error_without_url_does_not_leak_auth_token`
+// in `src/native_tunnel.rs` (the cleanup-path token-leak regression test) but
+// cover the WSS-connect leak site.
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Primary contract (issue #1056): the redacted form of a Standard/Premium SKU
+/// WSS URL must never contain the `websocketToken`, raw or URL-encoded, while
+/// keeping scheme, host, node id, and a `***` mask marker.
+#[test]
+fn test_redact_wss_url_never_leaks_websocket_token() {
+    const TOKEN: &str = "SUPER-SECRET-WS-TOKEN-9f8e7d6c";
+    let url = azlin_azure::native_tunnel::build_wss_url_standard(
+        "host.example",
+        TOKEN,
+        "node-42",
+    );
+
+    // Precondition: the raw URL carries the token (this is exactly what the
+    // fix guards against being logged).
+    let encoded = urlencoding::encode(TOKEN).into_owned();
+    assert!(
+        url.contains(TOKEN) || url.contains(&encoded),
+        "precondition: raw wss_url is expected to embed the websocket token"
+    );
+
+    let redacted = azlin_azure::native_tunnel::redact_wss_url(&url);
+
+    // The redacted form must never contain the token (raw or encoded).
+    assert!(
+        !redacted.contains(TOKEN),
+        "websocket token leaked (raw) into redacted url: {redacted}"
+    );
+    assert!(
+        !redacted.contains(encoded.as_str()),
+        "websocket token leaked (url-encoded) into redacted url: {redacted}"
+    );
+
+    // Non-secret structure is preserved for diagnostic value.
+    assert!(
+        redacted.starts_with("wss://host.example/webtunnelv2/"),
+        "redacted url must preserve scheme/host/path shape: {redacted}"
+    );
+    assert!(
+        redacted.contains("X-Node-Id=node-42"),
+        "redacted url must retain the non-secret node id: {redacted}"
+    );
+    assert!(
+        redacted.contains("***"),
+        "redacted url must include the mask marker: {redacted}"
+    );
+}
+
+/// Developer/QuickConnect (EndpointScoped) SKU: `wss://host/omni/webtunnel/<TOKEN>`
+/// must have its final-segment token masked; there is no node id to preserve.
+#[test]
+fn test_redact_wss_url_developer_sku_masks_token() {
+    const TOKEN: &str = "DEV-WS-TOKEN-abcdef123456";
+    let url = azlin_azure::native_tunnel::build_wss_url_developer("datapod.example", TOKEN);
+
+    let redacted = azlin_azure::native_tunnel::redact_wss_url(&url);
+
+    assert!(
+        !redacted.contains(TOKEN),
+        "developer-sku websocket token leaked into redacted url: {redacted}"
+    );
+    assert!(
+        redacted.starts_with("wss://datapod.example/omni/webtunnel/"),
+        "redacted developer url must preserve scheme/host/path shape: {redacted}"
+    );
+    assert!(
+        redacted.contains("***"),
+        "redacted developer url must include the mask marker: {redacted}"
+    );
+}
+
+/// URL-encoding aware: a token with special characters (which
+/// `build_wss_url_standard` percent-encodes per SEC-2) must not slip through in
+/// either its raw or its percent-encoded form.
+#[test]
+fn test_redact_wss_url_masks_encoded_special_char_token() {
+    const TOKEN: &str = "tok/with+weird=chars&and space";
+    let url = azlin_azure::native_tunnel::build_wss_url_standard(
+        "host.example",
+        TOKEN,
+        "node-7",
+    );
+    let encoded = urlencoding::encode(TOKEN).into_owned();
+
+    // Precondition: the encoded token is what actually lands in the URL.
+    assert!(
+        url.contains(&encoded),
+        "precondition: encoded token should be present in the raw url"
+    );
+
+    let redacted = azlin_azure::native_tunnel::redact_wss_url(&url);
+
+    assert!(
+        !redacted.contains(TOKEN),
+        "raw special-char token leaked into redacted url: {redacted}"
+    );
+    assert!(
+        !redacted.contains(encoded.as_str()),
+        "encoded special-char token leaked into redacted url: {redacted}"
+    );
+    assert!(
+        redacted.contains("X-Node-Id=node-7"),
+        "redacted url must retain the node id: {redacted}"
+    );
+}
+
+/// Fail-closed: input that does not parse as a known tunnel URL shape must be
+/// masked aggressively to `wss://<redacted>` rather than echoed back.
+#[test]
+fn test_redact_wss_url_fail_closed_on_malformed_input() {
+    for garbage in [
+        "not-a-url",
+        "https://host/api/tokens/some-secret",
+        "wss://host/unexpected/path/SECRET-LEAK",
+        "",
+    ] {
+        let redacted = azlin_azure::native_tunnel::redact_wss_url(garbage);
+        assert_eq!(
+            redacted, "wss://<redacted>",
+            "malformed input must fail closed to a fixed masked sentinel, got: {redacted}"
+        );
+    }
+}
+
+/// The redaction must be a logging-only control: it must not mutate or shorten
+/// the real URL used for the live connection. We assert the real builder output
+/// is unchanged by confirming the token is still present in the source URL after
+/// redaction (redaction takes `&str` and returns a new String).
+#[test]
+fn test_redact_wss_url_does_not_mutate_source_url() {
+    const TOKEN: &str = "LIVE-CONNECTION-TOKEN-0011";
+    let url = azlin_azure::native_tunnel::build_wss_url_standard(
+        "host.example",
+        TOKEN,
+        "node-9",
+    );
+    let before = url.clone();
+    let _ = azlin_azure::native_tunnel::redact_wss_url(&url);
+    assert_eq!(
+        url, before,
+        "redact_wss_url must not mutate the caller's real, token-bearing url"
+    );
+    assert!(
+        url.contains(TOKEN),
+        "the real url handed to connect_async must still carry the token"
+    );
+}
+
+/// Redaction is idempotent: re-scrubbing an already-redacted URL is stable and
+/// still leaks nothing, so a double-log path can never expose the token.
+#[test]
+fn test_redact_wss_url_is_idempotent_and_secret_free() {
+    const TOKEN: &str = "IDEMPOTENT-WS-TOKEN-55aa";
+    let url = azlin_azure::native_tunnel::build_wss_url_standard("host.example", TOKEN, "node-3");
+
+    let once = azlin_azure::native_tunnel::redact_wss_url(&url);
+    let twice = azlin_azure::native_tunnel::redact_wss_url(&once);
+
+    assert_eq!(once, twice, "redaction must be idempotent: {once} != {twice}");
+    assert!(
+        !twice.contains(TOKEN),
+        "re-redacting an already-redacted URL must stay secret-free: {twice}"
+    );
+}
+
+/// The exact WSS-connect `warn!` scrub performed in `handle_client`:
+///   let redacted_url = redact_wss_url(&wss_url);
+///   let safe_err = e.to_string().replace(&wss_url, &redacted_url);
+/// A `tungstenite` error `Display` may echo the full connect URL verbatim; the
+/// scrub must strip both the raw URL and the token from the emitted log line
+/// while keeping the diagnostic error text.
+#[test]
+fn test_wss_connect_error_scrub_strips_token_and_raw_url() {
+    const TOKEN: &str = "CONNECT-ERR-WS-TOKEN-77dd";
+    let wss_url =
+        azlin_azure::native_tunnel::build_wss_url_standard("host.example", TOKEN, "node-5");
+    let raw_error = format!("WebSocket connection to '{wss_url}' failed: handshake error");
+    assert!(
+        raw_error.contains(TOKEN),
+        "precondition: the raw error render leaks the token"
+    );
+
+    let redacted_url = azlin_azure::native_tunnel::redact_wss_url(&wss_url);
+    let safe_err = raw_error.replace(&wss_url, &redacted_url);
+
+    assert!(
+        !safe_err.contains(TOKEN),
+        "scrubbed connect-failure log line must NOT contain the token: {safe_err}"
+    );
+    assert!(
+        !safe_err.contains(&wss_url),
+        "scrubbed connect-failure log line must NOT contain the raw URL: {safe_err}"
+    );
+    assert!(
+        safe_err.contains("handshake error"),
+        "diagnostic error text must survive the scrub: {safe_err}"
+    );
+}


### PR DESCRIPTION
Closes #1056.

## Summary
Defense-in-depth redaction of the bastion `wss://` tunnel URL, which embeds the short-lived `websocketToken` bearer secret as a path segment. Previously, a failed WSS connect in `handle_client` logged a `warn!` rendering the `tungstenite` error whose `Display` can embed the full connect URL — so the token could reach a `tracing`/OTel sink.

## Change
- New `redact_wss_url(&str) -> String` in `native_tunnel.rs`: masks the token segment (`***`) while preserving scheme, host, and the non-secret `X-Node-Id` query. **Fail-closed** — unrecognized URL shapes collapse to the fixed sentinel `wss://<redacted>` (no partial echo).
- WSS-connect `warn!` now logs the redacted URL and scrubs the raw URL out of the rendered error (`err.replace(&wss_url, &redact_wss_url(&wss_url))`), so the token can never appear regardless of upstream `Display`.
- The live connection is unaffected: `connect_async` still receives the real URL. `redact_wss_url` takes `&str` and returns a new `String`, never mutating the caller's URL.

## Scope / non-goals
- Redaction-only, additive, non-breaking. No behavioral change beyond logging.
- Loopback-only listener bind (SEC-4) and token-skipped tracing spans unchanged.
- No stray `print!`/`println!` — structured `tracing` only.

## Tests
- 8 in-source `redaction_tests` in `native_tunnel.rs` and integration tests in `native_tunnel_unit.rs` assert the token (raw **and** URL-encoded) never appears in the redacted URL or scrubbed error, across both SKUs, with fail-closed, path-injection, and idempotence guards.
- `cargo test -p azlin-azure --locked`: 35 passed.

## Docs
- `docs/WSS_URL_REDACTION.md` + index link.

Origin: PR #1055 security review, Item 2 (Low, non-blocking).