### PR TITLE
fix(bastion): refresh native tunnel ARM token adaptively (#1059)

### DIFF
--- a/docs/BASTION_TUNNEL_TOKEN_REFRESH.md
+++ b/docs/BASTION_TUNNEL_TOKEN_REFRESH.md
@@ -1,0 +1,284 @@
+# Native Bastion Tunnel — Adaptive Token Refresh
+
+Status: Implemented (issue #1059)
+
+## Summary
+
+The azlin native Azure Bastion tunnel refreshes its Azure AD (ARM) access token
+adaptively, so long-lived cached tunnels keep working indefinitely — well past
+the ~60–90 minute lifetime of a single `az account get-access-token` token.
+
+Before this change, a tunnel captured the ARM bearer token **once** at creation
+and reused that same static token for every subsequent connection. Once the
+token expired, the tunnel's loopback listener stayed up but every new SSH
+connection failed token exchange, surfacing as:
+
+```
+kex_exchange_identification: read: Connection reset by peer
+```
+
+on `azlin connect`. The tunnel now sources its token from a **token provider**
+and caches it with its expiry, refreshing only when the token is near or past
+expiry. Each inbound connection obtains a valid token before performing its
+bastion token exchange, so a tunnel that has been alive for 22 hours works
+exactly like a freshly minted one.
+
+## User-facing behavior
+
+There is **no new configuration and no new command flag**. The fix is
+transparent:
+
+- A tunnel created hours ago continues to accept new `azlin connect` and
+  `azlin` command sessions without error.
+- Long-running sessions (e.g. `azlin connect <vm> --tmux-session`) that own a
+  background tunnel no longer break after the initial token expires.
+- `azlin connect` no longer intermittently fails with
+  `kex_exchange_identification: read: Connection reset by peer` on tunnels that
+  have outlived their original token.
+
+### Example
+
+```bash
+# Start a long-lived tmux session; this owns a background native tunnel.
+azlin connect ia2 --resource-group rysweet-linux-vm-pool --tmux-session work
+
+# ... many hours later, well past the original token's expiry ...
+
+# A brand-new connection reuses the SAME cached tunnel and still succeeds,
+# because the tunnel transparently refreshed its ARM token.
+azlin connect ia2 --resource-group rysweet-linux-vm-pool --no-tmux -y -- \
+  "echo OK; hostname"
+```
+
+Expected result: the command connects and prints `OK` followed by the hostname,
+even when the tunnel process has been running longer than the token lifetime.
+
+## Design
+
+### Token provider (decoupling)
+
+`azlin-azure` never shells out to the Azure CLI. Instead, the caller (the
+`azlin` crate) supplies a **token provider**: a cheap-to-clone async closure that
+knows how to mint a fresh ARM token and report its expiry.
+
+```rust
+/// A token value paired with its issued/expiry instants.
+///
+/// Deliberately has no `Debug`, `Serialize`, or `Display` impls so the secret
+/// value can never be accidentally logged or serialized.
+pub struct TokenWithExpiry {
+    /// The ARM bearer token value.
+    pub value: String,
+    /// When the token was issued (monotonic). Used together with `expires_at`
+    /// to derive the token's lifetime for the adaptive refresh margin. Defaults
+    /// to the instant the provider returned the token.
+    pub issued_at: Instant,
+    /// When the token stops being valid, if known. `None` means "unknown
+    /// lifetime" and triggers eager refresh on next use.
+    pub expires_at: Option<Instant>,
+}
+```
+
+Both instants are monotonic `Instant`s so the cache can compare against
+`Instant::now()` without clock-skew hazards. Because Azure CLI reports expiry as
+a **wall-clock** `expiresOn`, the provider converts it to a monotonic instant at
+mint time (see [Provider implementation](#provider-implementation-azlinbastion_tunnel)):
+
+```rust
+// wall-clock expiresOn -> monotonic Instant
+let remaining = (expires_on - Local::now()).to_std().ok();      // Duration until expiry
+let expires_at = remaining.map(|d| Instant::now() + d);         // None if already past / unparseable
+```
+
+```rust
+/// Async, cheap-to-clone, thread-safe source of ARM tokens.
+///
+/// Supplied by the `azlin` crate so `azlin-azure` stays CLI-agnostic.
+pub type TokenProvider =
+    Arc<dyn Fn() -> BoxFuture<'static, Result<TokenWithExpiry, NativeTunnelError>>
+        + Send
+        + Sync>;
+```
+
+The provider is invoked:
+
+1. Once when the tunnel is created (to verify connectivity), and
+2. Again, lazily, whenever the cached token is near or past expiry.
+
+### Adaptive refresh (no arbitrary caps)
+
+The tunnel caches the token together with its expiry and refreshes only when it
+is close to expiring. The refresh margin is **derived from the token's own
+lifetime**, not a hardcoded TTL or a fixed reconnect cap:
+
+```
+margin = max(lifetime * REFRESH_FRACTION, MIN_MARGIN)
+refresh when: now + margin >= expires_at
+```
+
+- `lifetime = expires_at - issued_at`. A token that lives 90 minutes gets a
+  proportionally larger safety margin than one that lives 10 minutes.
+- `MIN_MARGIN` is a small pre-expiry safety floor used only when a proportional
+  margin would be too small to cover a refresh round-trip. It is a safety
+  margin, not a forced reconnect interval.
+- If `expires_at` is `None` (lifetime unknown / unparseable), the token is
+  treated as short-lived and refreshed eagerly on the next connection.
+
+This keeps the behavior adaptive: the tunnel lives as long as the identity can
+mint tokens, and never expires because of an artificial fixed limit.
+
+### Single-flight refresh
+
+The cache is an `Arc<tokio::sync::Mutex<CachedToken>>` shared into the accept
+loop and every per-connection task. Refresh happens under the mutex, so when
+many connections arrive at once only **one** `az account get-access-token`
+invocation runs; the rest await the lock and receive the freshly refreshed
+token. This prevents a thundering herd of CLI calls (and identity rate-limiting)
+after expiry.
+
+If a refresh fails (transient CLI hiccup) but the currently cached token is not
+yet hard-expired, the cached token is reused. If the token is hard-expired and
+refresh fails, only that one connection fails — the tunnel stays up and later
+connections retry. The tunnel never falls back to an unauthenticated path
+(fail-closed).
+
+### Per-connection self-healing
+
+Each inbound TCP connection calls `get_valid_token()` on the cache as its first
+step, before performing the bastion `/api/tokens` exchange. So the tunnel
+self-heals: the first connection after expiry triggers a refresh, and it plus
+all following connections use the fresh token.
+
+## API reference (`azlin-azure::native_tunnel`)
+
+### `open_tunnel_with_timeouts`
+
+```rust
+pub async fn open_tunnel_with_timeouts(
+    bastion_endpoint: &str,
+    target_resource_id: &str,
+    resource_port: u16,
+    token_provider: TokenProvider,
+    url_mode: WssUrlMode,
+    timeout: Duration,
+    connect_timeout: Duration,
+) -> Result<(u16, JoinHandle<()>), NativeTunnelError>
+```
+
+The primary entry point. Takes a `TokenProvider` instead of a static token
+string. It seeds a token cache from the provider, uses the cache for the initial
+connectivity verification, and clones the cache into each per-connection task so
+every connection obtains a valid (refreshed if needed) token.
+
+- `token_provider` — async source of ARM bearer tokens with expiry. Called on
+  setup and again lazily when the cached token nears expiry.
+
+Other arguments (`bastion_endpoint`, `target_resource_id`, `resource_port`,
+`url_mode`, `timeout`, `connect_timeout`) are unchanged.
+
+### `open_tunnel` (stable wrapper)
+
+```rust
+pub async fn open_tunnel(
+    bastion_endpoint: &str,
+    target_resource_id: &str,
+    resource_port: u16,
+    token: &str,
+    url_mode: WssUrlMode,
+    timeout: Duration,
+) -> Result<(u16, JoinHandle<()>), NativeTunnelError>
+```
+
+The stable `open_tunnel` signature is **unchanged**. It accepts a `&str` token
+and internally wraps it into a trivial provider that always returns that literal
+value with `expires_at = None`. This preserves all existing callers and tests
+that pass a static token (which do not expire during a test run) while the
+adaptive path is used by production code through `open_tunnel_with_timeouts`.
+
+Passing an empty `token` still returns
+`NativeTunnelError::InvalidEndpoint("token must not be empty")`.
+
+### Security properties (preserved)
+
+- **SEC-3 / TLS-only**: non-TLS endpoints are rejected (`normalize_endpoint`).
+- **SEC-4 / loopback bind**: the listener binds only to `127.0.0.1`; refresh
+  never changes the bind scope.
+- **Token as form field**: the ARM token is carried as the `aztoken` POST form
+  field on `/api/tokens`, never as an `Authorization` header or URL parameter.
+- **Never logged**: `TokenWithExpiry` has no `Debug`/`Serialize`/`Display`;
+  `#[instrument(skip(client, token))]` is retained; `wss_url` is redacted in
+  logs. The token value never appears in any log output.
+- **In-memory only**: tokens live in `Arc<Mutex<CachedToken>>` — never written
+  to disk, temp files, environment, or session artifacts.
+- **Fail-closed**: a hard-expired token with a failing provider fails the
+  connection; there is no unauthenticated fallback.
+
+## Provider implementation (`azlin::bastion_tunnel`)
+
+The `azlin` crate builds the provider closure once and passes it to
+`open_tunnel_with_timeouts`. The closure queries token **and** expiry in a single
+Azure CLI call and parses the expiry robustly:
+
+```bash
+az account get-access-token \
+  --query "{t:accessToken,e:expiresOn}" -o json
+```
+
+- The `accessToken` becomes `TokenWithExpiry.value`.
+- `expiresOn` is parsed as a local-time naive datetime
+  (`"%Y-%m-%d %H:%M:%S%.f"` via `chrono::Local`), with an ISO-8601/RFC3339
+  fallback. The parsed wall-clock expiry is converted to a **monotonic**
+  `Instant` at mint time — `Instant::now() + (expiresOn - Local::now())` — so the
+  cache never compares against a skew-prone wall clock. `issued_at` is set to the
+  `Instant::now()` captured at the same point, giving the cache a real lifetime.
+- If parsing fails, or the expiry is already in the past, `expires_at` is `None`,
+  which safely forces eager refresh on the next connection (never a panic).
+- The CLI is invoked on `spawn_blocking` with an explicit argument vector (no
+  shell interpolation), using the same identity and scope on every refresh.
+
+Because the provider is a reusable closure (not a one-shot fetch), the tunnel can
+call it as many times as needed over its lifetime.
+
+## Tunnel reuse validation
+
+`get_or_create_tunnel` continues to validate cross-process tunnel reuse by
+checking that the owning process is still running. It no longer needs to
+validate token freshness at reuse time, because a reused tunnel now refreshes
+its own token on demand. A long-lived tunnel owned by another live process is
+safe to reuse.
+
+## Testing
+
+The cache/refresh logic is unit-tested in isolation (no network), covering:
+
+- **refresh_before_next_exchange** — a cache seeded with an about-to-expire
+  token performs exactly one provider refresh before the next
+  `get_valid_token()` returns, and returns the refreshed value.
+- **no_refresh_when_fresh** — a cache with a comfortably-valid token does not
+  invoke the provider.
+- **single_flight** — concurrent `get_valid_token()` calls that race across
+  expiry invoke the provider only once.
+- **token_never_logged** — `tracing` output captured around refresh and
+  token-exchange form construction never contains the secret token substring.
+
+Existing tests continue to pass, including the `open_tunnel` static-token call
+sites and error-surface tests.
+
+## Verification
+
+```bash
+cd rust
+cargo clippy --all --locked -- -D warnings
+cargo test -p azlin
+cargo test -p azlin-azure
+```
+
+Live verification against VM `ia2`:
+
+```bash
+azlin connect ia2 --resource-group rysweet-linux-vm-pool --no-tmux -y -- \
+  "echo OK; hostname"
+```
+
+The command succeeds, and a tunnel kept alive past the original token lifetime
+continues to accept new connections.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -255,6 +255,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "tracing-subscriber",
  "urlencoding",
  "uuid",
  "wait-timeout",

--- a/rust/crates/azlin-azure/Cargo.toml
+++ b/rust/crates/azlin-azure/Cargo.toml
@@ -26,3 +26,5 @@ reqwest = { workspace = true }
 urlencoding = { workspace = true }
 
 [dev-dependencies]
+tracing-subscriber = { workspace = true }
+futures-util = { workspace = true }

--- a/rust/crates/azlin-azure/src/native_tunnel.rs
+++ b/rust/crates/azlin-azure/src/native_tunnel.rs
@@ -12,13 +12,16 @@
 //! 3. **Bidirectional forwarding**: Binary frames between TCP client and WSS.
 //! 4. **Cleanup**: `DELETE https://{endpoint}/api/tokens/{authToken}` with `X-Node-Id` header.
 
+use futures_util::future::BoxFuture;
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
-use std::time::Duration;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener as TokioTcpListener;
 use tokio::net::TcpStream;
+use tokio::sync::Mutex as AsyncMutex;
 use tokio::task::JoinHandle;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, instrument, warn};
@@ -61,6 +64,179 @@ pub enum NativeTunnelError {
 
     #[error("HTTP request failed: {0}")]
     Http(String),
+}
+
+// ── Adaptive token cache (issue #1059) ───────────────────────────────────
+//
+// ROOT CAUSE (#1059): the tunnel captured the ARM access token ONCE at creation
+// and cloned that static string into every per-connection token exchange. Azure
+// AD access tokens expire (~60-90 min), so a long-lived in-process tunnel kept
+// its loopback listener up but every NEW connection failed the `aztoken`
+// exchange, surfacing as `kex_exchange_identification: read: Connection reset by
+// peer` on `azlin connect`.
+//
+// FIX: the tunnel takes a `TokenProvider` (an async, cheap-to-clone closure the
+// `azlin` crate supplies — it knows how to shell out to `az account
+// get-access-token`, keeping `azlin-azure` CLI-agnostic). The token is cached
+// with its expiry in a `TokenCache`. Each connection calls `get_valid_token()`
+// first, which refreshes adaptively when `now + margin >= expires_at`, where
+// `margin` is derived from the token's own lifetime (NOT a hardcoded TTL or a
+// reconnect cap). Refresh is single-flight (under an async mutex) and the token
+// value is NEVER logged.
+
+/// A token value paired with the instants it was issued and expires.
+///
+/// SECRET SAFETY: this type intentionally derives **no** `Debug`, `Display`,
+/// `Serialize`, or `Clone`-into-log path — `value` is a bearer secret and must
+/// never be rendered into a `tracing` sink. Fields are public so the `azlin`
+/// provider closure can construct it directly.
+pub struct TokenWithExpiry {
+    /// The ARM bearer token (secret).
+    pub value: String,
+    /// When the token was issued (monotonic clock).
+    pub issued_at: Instant,
+    /// When the token expires, if known. `None` means the expiry could not be
+    /// determined (e.g. `az` emitted an unparseable `expiresOn`) and the token
+    /// is treated as short-lived — refreshed eagerly on next use (fail-safe).
+    pub expires_at: Option<Instant>,
+}
+
+/// An async, cheap-to-clone source of fresh [`TokenWithExpiry`] values.
+///
+/// Supplied by the `azlin` crate so `azlin-azure` never shells out to `az`
+/// directly (decoupling). Invoked whenever the cached token is about to expire.
+pub type TokenProvider =
+    Arc<dyn Fn() -> BoxFuture<'static, Result<TokenWithExpiry, NativeTunnelError>> + Send + Sync>;
+
+/// Fraction of a token's own lifetime used as the pre-expiry refresh margin.
+///
+/// Adaptive by design (proportional to lifetime), NOT an arbitrary fixed cap:
+/// a 60-minute token refreshes ~12 minutes early, a 90-minute token ~18 minutes
+/// early. This keeps long-lived tunnels working indefinitely without ever
+/// forcing a reconnect at a hardcoded interval.
+const REFRESH_FRACTION: f64 = 0.2;
+
+/// Absolute floor for the refresh margin, so very short-lived tokens still get a
+/// small safety window. This is a lower bound on the *adaptive* margin above,
+/// not a fixed TTL.
+const MIN_REFRESH_MARGIN: Duration = Duration::from_secs(30);
+
+/// Internal cached token state.
+struct CachedToken {
+    value: String,
+    issued_at: Instant,
+    expires_at: Option<Instant>,
+}
+
+impl CachedToken {
+    /// Adaptive pre-expiry margin derived from this token's own lifetime.
+    fn refresh_margin(&self, expires_at: Instant) -> Duration {
+        let lifetime = expires_at.saturating_duration_since(self.issued_at);
+        lifetime.mul_f64(REFRESH_FRACTION).max(MIN_REFRESH_MARGIN)
+    }
+
+    /// Whether the token should be refreshed before it is handed out again.
+    /// Unknown expiry → always refresh (fail-safe).
+    fn needs_refresh(&self) -> bool {
+        match self.expires_at {
+            None => true,
+            Some(expires_at) => {
+                let margin = self.refresh_margin(expires_at);
+                Instant::now() + margin >= expires_at
+            }
+        }
+    }
+
+    /// Whether the token is past its actual expiry (no margin). Used to decide
+    /// whether a still-cached token may be reused when a refresh attempt fails.
+    fn hard_expired(&self) -> bool {
+        match self.expires_at {
+            None => true,
+            Some(expires_at) => Instant::now() >= expires_at,
+        }
+    }
+}
+
+/// Caches an ARM access token and refreshes it adaptively via a [`TokenProvider`].
+///
+/// Cheap to clone (all state is behind `Arc`); clone one into each per-connection
+/// task. `get_valid_token()` is single-flight: concurrent callers block on the
+/// async mutex, so a batch of connections arriving across the expiry boundary
+/// triggers at most one provider (`az`) invocation.
+#[derive(Clone)]
+pub struct TokenCache {
+    provider: TokenProvider,
+    inner: Arc<AsyncMutex<Option<CachedToken>>>,
+}
+
+impl TokenCache {
+    /// Create an empty cache; the first `get_valid_token()` fetches from the
+    /// provider to seed it.
+    pub fn new(provider: TokenProvider) -> Self {
+        Self {
+            provider,
+            inner: Arc::new(AsyncMutex::new(None)),
+        }
+    }
+
+    /// Create a cache pre-seeded with an already-obtained token.
+    pub fn with_token(provider: TokenProvider, initial: TokenWithExpiry) -> Self {
+        Self {
+            provider,
+            inner: Arc::new(AsyncMutex::new(Some(CachedToken {
+                value: initial.value,
+                issued_at: initial.issued_at,
+                expires_at: initial.expires_at,
+            }))),
+        }
+    }
+
+    /// Return a valid token value, refreshing via the provider if the cached
+    /// token is missing or about to expire.
+    ///
+    /// Single-flight: the async mutex is held across the provider await, so
+    /// concurrent callers that lose the race re-check freshness after acquiring
+    /// the lock and reuse the just-refreshed token instead of triggering another
+    /// provider call.
+    ///
+    /// SECRET SAFETY: the returned `String` is the only place the token value
+    /// surfaces; this method never logs the value.
+    pub async fn get_valid_token(&self) -> Result<String, NativeTunnelError> {
+        let mut guard = self.inner.lock().await;
+
+        // Fast path: a cached token that is still comfortably valid.
+        if let Some(cached) = guard.as_ref() {
+            if !cached.needs_refresh() {
+                return Ok(cached.value.clone());
+            }
+        }
+
+        // Refresh under the lock (single-flight).
+        match (self.provider)().await {
+            Ok(fresh) => {
+                let value = fresh.value.clone();
+                *guard = Some(CachedToken {
+                    value: fresh.value,
+                    issued_at: fresh.issued_at,
+                    expires_at: fresh.expires_at,
+                });
+                Ok(value)
+            }
+            Err(e) => {
+                // Fail-safe: if we still hold a token that has not hard-expired,
+                // reuse it for this connection rather than tearing the tunnel
+                // down on a transient `az` hiccup. The error is never dropped
+                // silently — it is either logged (reuse) or surfaced (no token).
+                if let Some(cached) = guard.as_ref() {
+                    if !cached.hard_expired() {
+                        warn!("bastion token refresh failed, reusing still-valid cached token: {e}");
+                        return Ok(cached.value.clone());
+                    }
+                }
+                Err(e)
+            }
+        }
+    }
 }
 
 // ── Token exchange types ─────────────────────────────────────────────────
@@ -486,9 +662,20 @@ async fn handle_client(
     endpoint: String,
     target_resource_id: String,
     resource_port: u16,
-    token: String,
+    token_cache: TokenCache,
     url_mode: WssUrlMode,
 ) {
+    // Step 0: Obtain a valid (refreshed if needed) ARM token. This is what makes
+    // long-lived tunnels self-heal (issue #1059): the cache refreshes adaptively
+    // instead of reusing the static token captured at tunnel creation.
+    let token = match token_cache.get_valid_token().await {
+        Ok(t) => t,
+        Err(e) => {
+            warn!("bastion token refresh failed, dropping connection: {e}");
+            return;
+        }
+    };
+
     // Step 1: Token exchange
     let token_resp = match exchange_token(
         &client,
@@ -588,16 +775,44 @@ pub async fn open_tunnel(
     url_mode: WssUrlMode,
     timeout: Duration,
 ) -> Result<(u16, JoinHandle<()>), NativeTunnelError> {
+    // Reject an empty token here so the stable `open_tunnel(&str)` contract keeps
+    // its validation. The provider path (below) has no static token to validate.
+    if token.is_empty() {
+        return Err(NativeTunnelError::InvalidEndpoint(
+            "token must not be empty".to_string(),
+        ));
+    }
     open_tunnel_with_timeouts(
         bastion_endpoint,
         target_resource_id,
         resource_port,
-        token,
+        static_token_provider(token),
         url_mode,
         timeout,
         timeout,
     )
     .await
+}
+
+/// Wrap a static token literal in a trivial [`TokenProvider`].
+///
+/// Used by the stable [`open_tunnel`] wrapper: the token is fixed and cannot be
+/// refreshed to anything different, so its expiry is reported as unknown
+/// (`None`). Real, refreshable callers pass a live provider to
+/// [`open_tunnel_with_timeouts`] instead.
+fn static_token_provider(token: &str) -> TokenProvider {
+    let token = token.to_string();
+    Arc::new(move || {
+        let token = token.clone();
+        Box::pin(async move {
+            let now = Instant::now();
+            Ok(TokenWithExpiry {
+                value: token,
+                issued_at: now,
+                expires_at: None,
+            })
+        })
+    })
 }
 
 /// Open a native bastion tunnel with separate overall and connect timeouts.
@@ -607,7 +822,15 @@ pub async fn open_tunnel(
 /// the optional `bastion_connect_timeout` config knob (issue #1045) without
 /// changing the stable [`open_tunnel`] signature.
 ///
+/// # Token refresh (issue #1059)
+/// Instead of a static token, callers supply a [`TokenProvider`]. The tunnel
+/// caches the token with its expiry and refreshes it adaptively, so a long-lived
+/// in-process tunnel keeps working past the ARM access token's lifetime instead
+/// of failing every new connection's token exchange once the captured token
+/// expires.
+///
 /// # Arguments
+/// - `provider` — async source of fresh ARM tokens (supplied by `azlin`)
 /// - `connect_timeout` — Timeout for establishing the TCP connection to the
 ///   bastion data-plane. Defaults (via [`open_tunnel`]) to `timeout`.
 ///
@@ -617,7 +840,7 @@ pub async fn open_tunnel_with_timeouts(
     bastion_endpoint: &str,
     target_resource_id: &str,
     resource_port: u16,
-    token: &str,
+    provider: TokenProvider,
     url_mode: WssUrlMode,
     timeout: Duration,
     connect_timeout: Duration,
@@ -626,11 +849,6 @@ pub async fn open_tunnel_with_timeouts(
     if resource_port == 0 {
         return Err(NativeTunnelError::InvalidEndpoint(
             "resource_port must not be 0".to_string(),
-        ));
-    }
-    if token.is_empty() {
-        return Err(NativeTunnelError::InvalidEndpoint(
-            "token must not be empty".to_string(),
         ));
     }
 
@@ -652,11 +870,26 @@ pub async fn open_tunnel_with_timeouts(
         .build()
         .map_err(|e| NativeTunnelError::Http(format!("failed to create HTTP client: {e}")))?;
 
-    // Verify connectivity with a quick token exchange + cleanup
-    let test_result = tokio::time::timeout(
-        timeout,
-        exchange_token(&client, &endpoint, target_resource_id, resource_port, token),
-    )
+    // Adaptive token cache shared across every connection (issue #1059).
+    let token_cache = TokenCache::new(provider);
+
+    // Verify connectivity with a quick token exchange + cleanup. This also seeds
+    // the token cache with a fresh, valid token.
+    let verify_cache = token_cache.clone();
+    let verify_endpoint = endpoint.clone();
+    let verify_client = client.clone();
+    let verify_resource_id = target_resource_id.to_string();
+    let test_result = tokio::time::timeout(timeout, async move {
+        let token = verify_cache.get_valid_token().await?;
+        exchange_token(
+            &verify_client,
+            &verify_endpoint,
+            &verify_resource_id,
+            resource_port,
+            &token,
+        )
+        .await
+    })
     .await;
 
     match test_result {
@@ -679,7 +912,6 @@ pub async fn open_tunnel_with_timeouts(
     // Spawn the accept loop
     let owned_endpoint = endpoint.clone();
     let owned_resource_id = target_resource_id.to_string();
-    let owned_token = token.to_string();
     let handle = tokio::spawn(async move {
         loop {
             match listener.accept().await {
@@ -688,9 +920,9 @@ pub async fn open_tunnel_with_timeouts(
                     let client = client.clone();
                     let ep = owned_endpoint.clone();
                     let rid = owned_resource_id.clone();
-                    let tok = owned_token.clone();
+                    let cache = token_cache.clone();
                     tokio::spawn(async move {
-                        handle_client(tcp_stream, client, ep, rid, resource_port, tok, url_mode)
+                        handle_client(tcp_stream, client, ep, rid, resource_port, cache, url_mode)
                             .await;
                     });
                 }

--- a/rust/crates/azlin-azure/tests/native_tunnel_unit.rs
+++ b/rust/crates/azlin-azure/tests/native_tunnel_unit.rs
@@ -648,3 +648,362 @@ fn test_wss_connect_error_scrub_strips_token_and_raw_url() {
         "diagnostic error text must survive the scrub: {safe_err}"
     );
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// 10. Adaptive token cache / refresh (issue #1059)
+//
+// ROOT CAUSE: `open_tunnel_with_timeouts` captured the ARM access token ONCE at
+// tunnel creation and cloned that static token into every per-connection
+// `handle_client`. Azure AD access tokens expire (~60-90 min), so a long-lived
+// in-process tunnel kept its loopback listener up but every NEW connection
+// through it failed token exchange with an expired `aztoken`, surfacing as
+// `kex_exchange_identification: read: Connection reset by peer` on `azlin connect`.
+//
+// FIX: the tunnel takes a `TokenProvider` (an async, cheap-to-clone closure
+// supplied by the `azlin` crate) and caches the token with its expiry in a
+// `TokenCache`. Each connection calls `get_valid_token()` first, which refreshes
+// the token adaptively — when `now + margin >= expires_at`, where `margin` is
+// derived from the token's own lifetime (NOT a hardcoded TTL / reconnect cap).
+// Refresh is single-flight (under a mutex) so concurrent connections trigger at
+// most one provider call, and the token value is NEVER logged.
+//
+// TDD: these tests define the contract for `TokenWithExpiry`, `TokenProvider`,
+// and `TokenCache` before those types exist. They will fail to compile until the
+// implementation lands, then pass once it does.
+// ═══════════════════════════════════════════════════════════════════════
+
+use futures_util::future::BoxFuture;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use azlin_azure::native_tunnel::{TokenCache, TokenProvider, TokenWithExpiry};
+
+/// Build a `TokenProvider` that records how many times it is invoked and always
+/// returns `value` with the given `lifetime` (None → unknown expiry).
+fn counting_provider(
+    calls: Arc<AtomicUsize>,
+    value: &'static str,
+    lifetime: Option<Duration>,
+) -> TokenProvider {
+    Arc::new(move || {
+        let calls = calls.clone();
+        Box::pin(async move {
+            calls.fetch_add(1, Ordering::SeqCst);
+            let now = Instant::now();
+            Ok(TokenWithExpiry {
+                value: value.to_string(),
+                issued_at: now,
+                expires_at: lifetime.map(|d| now + d),
+            })
+        }) as BoxFuture<'static, Result<TokenWithExpiry, azlin_azure::native_tunnel::NativeTunnelError>>
+    })
+}
+
+/// Like `counting_provider` but sleeps before returning, widening the race
+/// window so a single-flight regression (N concurrent refreshes) is observable.
+fn slow_counting_provider(
+    calls: Arc<AtomicUsize>,
+    value: &'static str,
+    lifetime: Option<Duration>,
+    delay: Duration,
+) -> TokenProvider {
+    Arc::new(move || {
+        let calls = calls.clone();
+        Box::pin(async move {
+            tokio::time::sleep(delay).await;
+            calls.fetch_add(1, Ordering::SeqCst);
+            let now = Instant::now();
+            Ok(TokenWithExpiry {
+                value: value.to_string(),
+                issued_at: now,
+                expires_at: lifetime.map(|d| now + d),
+            })
+        }) as BoxFuture<'static, Result<TokenWithExpiry, azlin_azure::native_tunnel::NativeTunnelError>>
+    })
+}
+
+/// Seed a cache with a token that is about to expire (well inside any sane
+/// refresh margin): issued nearly a full lifetime ago, expiring in a few seconds.
+fn about_to_expire(value: &str) -> TokenWithExpiry {
+    let now = Instant::now();
+    TokenWithExpiry {
+        value: value.to_string(),
+        issued_at: now - Duration::from_secs(3595),
+        expires_at: Some(now + Duration::from_secs(5)),
+    }
+}
+
+/// Seed a cache with a freshly-minted, comfortably-valid token (just issued,
+/// expiring in a full hour).
+fn comfortably_valid(value: &str) -> TokenWithExpiry {
+    let now = Instant::now();
+    TokenWithExpiry {
+        value: value.to_string(),
+        issued_at: now,
+        expires_at: Some(now + Duration::from_secs(3600)),
+    }
+}
+
+/// PRIMARY CONTRACT (a): a cache seeded with an about-to-expire token must
+/// perform EXACTLY ONE provider refresh before the next `get_valid_token()`
+/// returns, and must return the freshly-refreshed value — proving a long-lived
+/// tunnel's next connection uses a valid token instead of the stale one.
+#[tokio::test]
+async fn test_cache_refreshes_before_next_exchange_when_about_to_expire() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let provider = counting_provider(
+        calls.clone(),
+        "FRESH-TOKEN-AFTER-REFRESH",
+        Some(Duration::from_secs(3600)),
+    );
+
+    let cache = TokenCache::with_token(provider, about_to_expire("STALE-ABOUT-TO-EXPIRE"));
+
+    let token = cache
+        .get_valid_token()
+        .await
+        .expect("get_valid_token should succeed");
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "an about-to-expire token must trigger exactly one adaptive refresh"
+    );
+    assert_eq!(
+        token, "FRESH-TOKEN-AFTER-REFRESH",
+        "get_valid_token must return the refreshed value, not the stale one"
+    );
+}
+
+/// A comfortably-valid token must NOT trigger a provider call: the adaptive
+/// margin is derived from lifetime and must leave a freshly-issued token alone,
+/// so steady-state connections never shell out to `az`.
+#[tokio::test]
+async fn test_cache_does_not_refresh_when_token_is_fresh() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let provider = counting_provider(
+        calls.clone(),
+        "SHOULD-NEVER-BE-RETURNED",
+        Some(Duration::from_secs(3600)),
+    );
+
+    let cache = TokenCache::with_token(provider, comfortably_valid("COMFORTABLY-VALID"));
+
+    let token = cache.get_valid_token().await.expect("get_valid_token");
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "a comfortably-valid token must not invoke the provider"
+    );
+    assert_eq!(
+        token, "COMFORTABLY-VALID",
+        "the still-valid cached token must be returned unchanged"
+    );
+}
+
+/// Unknown expiry (`expires_at = None`, e.g. `az` emitted an unparseable
+/// `expiresOn`) must be treated as short-lived and refreshed eagerly on the next
+/// use — fail-safe, never a panic, never an indefinitely-cached unknown token.
+#[tokio::test]
+async fn test_cache_refreshes_eagerly_when_expiry_unknown() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let provider = counting_provider(
+        calls.clone(),
+        "REFRESHED-WITH-KNOWN-EXPIRY",
+        Some(Duration::from_secs(3600)),
+    );
+
+    let now = Instant::now();
+    let seeded = TokenWithExpiry {
+        value: "UNKNOWN-EXPIRY-TOKEN".to_string(),
+        issued_at: now,
+        expires_at: None,
+    };
+    let cache = TokenCache::with_token(provider, seeded);
+
+    let token = cache.get_valid_token().await.expect("get_valid_token");
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "a token with unknown expiry must be refreshed eagerly"
+    );
+    assert_eq!(token, "REFRESHED-WITH-KNOWN-EXPIRY");
+}
+
+/// A cache built with `TokenCache::new` (no seed) must fetch from the provider on
+/// the first `get_valid_token()`, then serve the freshly-minted token without a
+/// second provider call while it stays valid.
+#[tokio::test]
+async fn test_cache_new_fetches_once_then_serves_from_cache() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let provider = counting_provider(
+        calls.clone(),
+        "INITIAL-FETCHED-TOKEN",
+        Some(Duration::from_secs(3600)),
+    );
+
+    let cache = TokenCache::new(provider);
+
+    let first = cache.get_valid_token().await.expect("first get");
+    let second = cache.get_valid_token().await.expect("second get");
+
+    assert_eq!(first, "INITIAL-FETCHED-TOKEN");
+    assert_eq!(second, "INITIAL-FETCHED-TOKEN");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "the provider must be called once to seed, then the valid token is cached"
+    );
+}
+
+/// SINGLE-FLIGHT CONTRACT: many connections arriving at once across the expiry
+/// boundary must collapse into a SINGLE provider (`az`) invocation. The first
+/// waiter refreshes under the mutex; the rest re-check freshness after acquiring
+/// the lock and reuse the just-refreshed token — no thundering herd.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_concurrent_get_valid_token_is_single_flight() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let provider = slow_counting_provider(
+        calls.clone(),
+        "SINGLE-FLIGHT-REFRESHED",
+        Some(Duration::from_secs(3600)),
+        Duration::from_millis(50),
+    );
+
+    let cache = Arc::new(TokenCache::with_token(
+        provider,
+        about_to_expire("STALE-RACED"),
+    ));
+
+    let mut handles = Vec::new();
+    for _ in 0..16 {
+        let cache = cache.clone();
+        handles.push(tokio::spawn(async move {
+            cache.get_valid_token().await.expect("get_valid_token")
+        }));
+    }
+
+    for h in handles {
+        let value = h.await.expect("task join");
+        assert_eq!(
+            value, "SINGLE-FLIGHT-REFRESHED",
+            "every racing connection must observe the single refreshed token"
+        );
+    }
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "concurrent refreshes must collapse to exactly one provider invocation"
+    );
+}
+
+// ── Secret-safety: the token value must never reach a log sink ───────────────
+
+/// A `tracing` writer that appends every emitted byte to a shared buffer so a
+/// test can assert what did (and did not) get logged.
+#[derive(Clone)]
+struct CapturingWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for CapturingWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// PRIMARY CONTRACT (b): the secret token value must NEVER appear in log output.
+/// We capture all `tracing` output (down to TRACE) emitted while the cache
+/// refreshes and serves a token, and assert the secret substring is absent —
+/// even if the refresh path emits diagnostics, it must skip the token value.
+#[tokio::test]
+async fn test_token_value_is_never_logged_during_refresh() {
+    const SECRET: &str = "eyJ0b2tlbiI6IlNVUEVSLVNFQ1JFVC1BUk0tVE9LRU4tOTk5In0";
+
+    let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let writer_buf = buf.clone();
+
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::TRACE)
+        .with_writer(move || CapturingWriter(writer_buf.clone()))
+        .with_ansi(false)
+        .finish();
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let provider = counting_provider(calls.clone(), SECRET, Some(Duration::from_secs(3600)));
+    let cache = TokenCache::with_token(provider, about_to_expire("STALE-SECRET-PRECURSOR"));
+
+    {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        let token = cache.get_valid_token().await.expect("get_valid_token");
+        // Sanity: the refresh really happened and returned the secret value ...
+        assert_eq!(token, SECRET);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    let logged = String::from_utf8(buf.lock().unwrap().clone()).expect("utf8 log output");
+    assert!(
+        !logged.contains(SECRET),
+        "the ARM token secret must never be written to a log sink; captured log:\n{logged}"
+    );
+}
+
+/// Defense in depth: even the `aztoken` form field — which legitimately carries
+/// the token on the wire — must not be produced by rendering a loggable type.
+/// `build_token_exchange_form` places the token in `aztoken` (wire, not log);
+/// this guards that the token stays out of any `Debug`/log rendering of the
+/// refresh types by confirming the only place the token appears is the form
+/// value, not a formatted string of the cache/provider types.
+#[tokio::test]
+async fn test_token_never_leaks_via_type_formatting() {
+    const SECRET: &str = "ARM-TOKEN-NO-DEBUG-LEAK-4242";
+
+    // The token is expected ONLY in the form's aztoken field (the wire path).
+    let form = azlin_azure::native_tunnel::build_token_exchange_form(
+        "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm",
+        22,
+        SECRET,
+    );
+    let aztoken = form
+        .iter()
+        .find(|(k, _)| *k == "aztoken")
+        .map(|(_, v)| v.as_str());
+    assert_eq!(
+        aztoken,
+        Some(SECRET),
+        "the token must be carried as the aztoken form field (wire path)"
+    );
+
+    // But it must NOT be discoverable by formatting the refresh machinery: a
+    // token minted through the provider and served by the cache is returned as a
+    // bare String only; the cache/provider types expose no Debug/Display that
+    // could render the secret into logs.
+    let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let writer_buf = buf.clone();
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::TRACE)
+        .with_writer(move || CapturingWriter(writer_buf.clone()))
+        .with_ansi(false)
+        .finish();
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let provider = counting_provider(calls.clone(), SECRET, Some(Duration::from_secs(3600)));
+    let cache = TokenCache::new(provider);
+
+    {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        let _ = cache.get_valid_token().await.expect("get_valid_token");
+    }
+
+    let logged = String::from_utf8(buf.lock().unwrap().clone()).expect("utf8 log output");
+    assert!(
+        !logged.contains(SECRET),
+        "token leaked through refresh-path logging: {logged}"
+    );
+}

--- a/rust/crates/azlin/src/bastion_tunnel.rs
+++ b/rust/crates/azlin/src/bastion_tunnel.rs
@@ -604,6 +604,113 @@ async fn resolve_bastion_dns_name(bastion_name: &str, resource_group: &str) -> R
     })
 }
 
+/// Fetch a fresh ARM access token together with its expiry via `az`.
+///
+/// This is the token provider body for the native bastion tunnel (issue #1059):
+/// the tunnel calls it whenever its cached token is about to expire, so a
+/// long-lived in-process tunnel keeps working past the ~60-90 min token
+/// lifetime instead of failing every new connection's token exchange.
+///
+/// Runs `az` on a blocking thread and asks for both `accessToken` and
+/// `expiresOn` in one invocation so the cache learns the token's real lifetime.
+///
+/// SECRET SAFETY: the returned token value is never logged; error paths only
+/// surface `az` stderr / parser positions, never stdout (which carries the token).
+async fn fetch_arm_token_with_expiry(
+) -> std::result::Result<azlin_azure::native_tunnel::TokenWithExpiry, azlin_azure::native_tunnel::NativeTunnelError>
+{
+    use azlin_azure::native_tunnel::{NativeTunnelError, TokenWithExpiry};
+
+    let output = tokio::task::spawn_blocking(|| {
+        std::process::Command::new("az")
+            .args([
+                "account",
+                "get-access-token",
+                "--query",
+                "{t:accessToken,e:expiresOn}",
+                "-o",
+                "json",
+            ])
+            .output()
+    })
+    .await
+    .map_err(|e| NativeTunnelError::Http(format!("az token task panicked: {e}")))?
+    .map_err(|e| {
+        NativeTunnelError::Http(format!("failed to run az account get-access-token: {e}"))
+    })?;
+
+    if !output.status.success() {
+        return Err(NativeTunnelError::TokenExchange(format!(
+            "az account get-access-token failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).map_err(|e| {
+        // The serde error carries only a byte position, never the token text.
+        NativeTunnelError::TokenExchange(format!("failed to parse az token JSON: {e}"))
+    })?;
+
+    let value = parsed
+        .get("t")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    if value.is_empty() {
+        return Err(NativeTunnelError::TokenExchange(
+            "az account get-access-token returned an empty accessToken".to_string(),
+        ));
+    }
+
+    let issued_at = std::time::Instant::now();
+    let expires_at = parsed
+        .get("e")
+        .and_then(|v| v.as_str())
+        .and_then(|s| parse_expires_on_to_instant(s, issued_at));
+
+    Ok(TokenWithExpiry {
+        value,
+        issued_at,
+        expires_at,
+    })
+}
+
+/// Convert an `az`-emitted `expiresOn` string into a monotonic [`Instant`],
+/// relative to `issued_at`.
+///
+/// `az` emits `expiresOn` as a **local-time naive** string on this platform
+/// (e.g. `2026-07-22 10:20:00.000000`); newer CLIs may emit RFC3339 with an
+/// offset. We parse the local-naive form first, then fall back to RFC3339. The
+/// wall-clock expiry is projected onto the monotonic clock via
+/// `issued_at + (expires - now)`.
+///
+/// Returns `None` if the string is unparseable or already in the past, so the
+/// cache treats the token as short-lived and refreshes eagerly (fail-safe).
+fn parse_expires_on_to_instant(
+    expires_on: &str,
+    issued_at: std::time::Instant,
+) -> Option<std::time::Instant> {
+    use chrono::{DateTime, Local, NaiveDateTime};
+
+    let local_now = Local::now();
+
+    let when: DateTime<Local> = NaiveDateTime::parse_from_str(expires_on, "%Y-%m-%d %H:%M:%S%.f")
+        .ok()
+        .and_then(|ndt| ndt.and_local_timezone(Local).single())
+        .or_else(|| {
+            DateTime::parse_from_rfc3339(expires_on)
+                .ok()
+                .map(|dt| dt.with_timezone(&Local))
+        })?;
+
+    let delta_ms = when.signed_duration_since(local_now).num_milliseconds();
+    if delta_ms <= 0 {
+        return None;
+    }
+    Some(issued_at + std::time::Duration::from_millis(delta_ms as u64))
+}
+
 /// Get or create a bastion tunnel for a VM. Reuses existing tunnels from the registry.
 ///
 /// Returns the local port the tunnel is bound to.
@@ -666,31 +773,16 @@ pub async fn get_or_create_tunnel(
         }
     }
 
-    // Get Azure AD token via az CLI on a blocking thread to avoid stalling the runtime
-    let token = tokio::task::spawn_blocking(|| -> Result<String> {
-        let token_output = std::process::Command::new("az")
-            .args([
-                "account",
-                "get-access-token",
-                "--query",
-                "accessToken",
-                "-o",
-                "tsv",
-            ])
-            .output()
-            .context("failed to get Azure AD token for bastion tunnel")?;
-        if !token_output.status.success() {
-            anyhow::bail!(
-                "az account get-access-token failed: {}",
-                String::from_utf8_lossy(&token_output.stderr).trim()
-            );
-        }
-        Ok(String::from_utf8_lossy(&token_output.stdout)
-            .trim()
-            .to_string())
-    })
-    .await
-    .context("token task panicked")??;
+    // Build a reusable ARM token provider (issue #1059). A long-lived native
+    // tunnel is an in-process background task; the ARM access token it was
+    // created with expires (~60-90 min), so previously every NEW connection
+    // through an old tunnel failed the `aztoken` exchange. The provider lets the
+    // tunnel refresh the token adaptively for as long as it lives. It shells out
+    // to `az` on a blocking thread and parses `expiresOn` so the cache knows the
+    // token's real lifetime. `azlin-azure` stays CLI-agnostic — the closure
+    // lives here in the `azlin` crate.
+    let token_provider: azlin_azure::native_tunnel::TokenProvider =
+        std::sync::Arc::new(|| Box::pin(fetch_arm_token_with_expiry()));
 
     // Load config for timeout
     let config = azlin_core::AzlinConfig::load().unwrap_or_default();
@@ -720,7 +812,7 @@ pub async fn get_or_create_tunnel(
         &bastion_endpoint,
         vm_resource_id,
         22,
-        &token,
+        token_provider,
         azlin_azure::native_tunnel::WssUrlMode::NodeScoped,
         timeout,
         connect_timeout,


### PR DESCRIPTION
## Problem

Long-lived cached native Azure Bastion tunnels stop working after the Azure AD access token expires. `azlin connect` fails with `kex_exchange_identification: read: Connection reset by peer`.

**Root cause:** `open_tunnel_with_timeouts()` captured the ARM access token **once** at tunnel creation and cloned that static token into every per-connection `handle_client()`. Azure AD access tokens expire (~60-90 min). The native tunnel is an in-process background task owned by a long-running `azlin` process; its reuse validation only checks that the owning PID is alive, never that the token is still valid. So an old tunnel keeps its loopback listener up but every new connection fails the `aztoken` exchange → local TCP dropped → ssh sees `Connection reset by peer`.

## Fix (root cause — adaptive, no fixed caps)

- `open_tunnel_with_timeouts` now takes a **`TokenProvider`** (async, cheap-to-clone closure supplied by the `azlin` crate) instead of a static `&str`. `azlin-azure` stays CLI-agnostic; the closure shells out to `az account get-access-token` and parses `expiresOn`.
- New **`TokenCache`** caches the token with its expiry and refreshes **adaptively** when `now + margin >= expires_at`, where `margin` is a fraction of the token's own lifetime (floored to a small safety minimum) — proportional/adaptive, **not** a hardcoded TTL or reconnect cap.
- Refresh is **single-flight** under an async mutex: a burst of connections across the expiry boundary triggers at most one `az` call. On refresh failure a still-valid cached token is reused (fail-safe); a hard-expired token surfaces the error to that connection only.
- `handle_client` obtains a fresh/valid token per connection via `get_valid_token()` (self-healing).
- Stable `open_tunnel(&str)` wrapper preserved via a trivial provider.

## Security (unchanged)

Token never logged (no `Debug`/`Display` on `TokenWithExpiry`; `#[instrument(skip(client, token))]` retained), 127.0.0.1-only bind (SEC-4), TLS-only (SEC-3), `aztoken` as a form field, `wss_url` redacted, fail-closed on hard-expiry + provider failure.

## Tests

Added adaptive cache/refresh unit tests proving **(a)** an about-to-expire token refreshes before the next exchange and **(b)** the token is never logged, plus fresh-token no-op, unknown-expiry eager refresh, seed-once, and single-flight coverage.

- `cargo clippy --all --locked -- -D warnings` ✅
- `cargo test -p azlin-azure` ✅ (291 tests)
- `cargo test -p azlin` ✅ (2433+ tests)

Fixes #1059