### PR TITLE
fix(destroy): stop leaking session Public IP and NSG (regressed #516/#517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`destroy` no longer leaks the session Public IP and NSG** — `az vm delete`
+  removes only the VM; the disk and NIC disappear via ARM's implicit
+  `deleteOption: Delete`, but Azure has no equivalent for the Public IP or the
+  NSG, so both were left behind on every create/destroy cycle. The leaked
+  Standard static Public IP bills ~$3.65/month indefinitely, and the leftover
+  `<vm>NSG` blocks reusing the VM name. This regressed the NSG behavior fixed by
+  #517 (issue #516) and the Public IP behavior that the removed Python
+  `vm_lifecycle.py` also implemented; neither was reimplemented during the Rust
+  rewrite (#516, #517)
+  - New teardown planner discovers the VM's disks, NIC, Public IP and NSG,
+    scoped by the `azlin-session` tag so sibling sessions are never touched
+  - Deletes in dependency order (VM → disks → NIC → Public IP → NSG), since
+    Azure refuses to delete a Public IP or NSG while a NIC still references it
+  - A second `plan_recheck` pass re-evaluates resources skipped as in-use after
+    the NIC delete settles, covering Azure's eventual consistency on NIC/NSG
+    association
+  - `destroy --dry-run` now queries Azure and reports the actual resources and
+    the estimated monthly saving, instead of printing a static string
+  - `killall` now matches session VMs by exact name rather than a JMESPath name
+    prefix, so destroying `foo` can no longer match `foobar`
+
 ### Security
 - **Bastion WSS URL redaction** — the `wss://` tunnel URL embeds the short-lived
   `websocketToken` bearer secret as a path segment. On a failed WSS connect the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the estimated monthly saving, instead of printing a static string
   - `killall` now matches session VMs by exact name rather than a JMESPath name
     prefix, so destroying `foo` can no longer match `foobar`
+  - Pooled sessions (`azlin new --name X --pool N`) tag every member's Public
+    IP/NSG with the pool's base name, not that member's own VM name. Recovering
+    a member's orphaned Public IP/NSG after its VM is already gone now falls
+    back to Azure's default per-VM resource naming (`also_match_by_name`) when
+    the guessed session tag cannot match, so a pool member's leak is no longer
+    silently unrecoverable
 
 ### Security
 - **Bastion WSS URL redaction** — the `wss://` tunnel URL embeds the short-lived

--- a/docs/reference/destroy-command.md
+++ b/docs/reference/destroy-command.md
@@ -41,7 +41,7 @@ azlin destroy my-vm-name --force
 | `--config` | Path to custom config file |
 | `--force` | Skip confirmation prompt |
 | `--dry-run` | Show what would be deleted without actually deleting |
-| `--delete-rg` | Delete the entire resource group (DANGEROUS) |
+| `--delete-rg` | **Rejected.** `destroy` refuses this flag outright — see [Resource Group Deletion](#resource-group-deletion) below. |
 
 ## What Gets Deleted
 
@@ -50,17 +50,31 @@ azlin destroy my-vm-name --force
 Resources are deleted in the followin' order to handle dependencies:
 
 1. **Virtual Machine** - The VM instance itself
-2. **Network Interfaces (NICs)** - All network interfaces attached to the VM
-3. **Network Security Groups (NSGs)** - NSGs discovered from each NIC **[NEW]**
-4. **OS and Data Disks** - All disks attached to the VM
-5. **Public IP Addresses** - Public IPs associated with NICs (if any)
+2. **OS and Data Disks** - All disks owned by the VM
+3. **Network Interfaces (NICs)** - All network interfaces attached to the VM
+4. **Public IP Addresses** - Public IPs associated with the VM's NIC(s)
+5. **Network Security Groups (NSGs)** - NSGs associated with the VM's NIC(s)
 
-### NSG Deletion Behavior **[NEW]**
+The NIC must be fully deleted before its Public IP or NSG can be — Azure
+refuses to delete either while a NIC still references it. That's why NICs are
+torn down third and the Public IP/NSG come last, not the other way around.
 
-- NSGs be discovered by querying each NIC attached to the VM
-- NSG deletion be best-effort (graceful if NSG doesn't exist or already deleted)
-- Multiple NICs may share the same NSG (only deleted once)
-- No errors if NSG not found (handles race conditions)
+### NSG and Public IP Deletion Behavior
+
+- The Public IP and NSG are discovered by querying the resource group,
+  scoped to the `azlin-session` tag so a sibling session's resources are
+  never touched
+- Deletion is idempotent and best-effort per resource: a resource Azure has
+  already removed (404) counts as success, and one failed resource does not
+  abort the rest
+- Azure's association data can lag briefly after a NIC delete (a stale or
+  "ghost" reference — see [Microsoft's troubleshooting
+  guidance](https://learn.microsoft.com/en-us/answers/questions/691897/cannot-delete-nsg-associted-with-with-non-existent)).
+  `destroy` re-checks anything it had to skip as still-in-use once the NIC
+  delete has settled, and deletes it then if it's now genuinely free
+- A Public IP or NSG with no `azlin-session` tag at all is never deleted
+  automatically — ownership can't be proven. `destroy` reports it instead and
+  points at `azlin cleanup`
 
 ## Examples
 
@@ -86,12 +100,12 @@ Are you sure you want to delete this VM? [y/N]: y
 
 Deleting VM: azlin-vm-20250112-120000
   ✓ Deleted VM
-  ✓ Deleted NIC: azlin-vm-nic
-  ✓ Deleted NSG: azlin-vm-nsg
   ✓ Deleted disk: azlin-vm-osdisk
+  ✓ Deleted NIC: azlin-vm-nic
   ✓ Deleted Public IP: azlin-vm-ip
+  ✓ Deleted NSG: azlin-vm-nsg
 
-Successfully deleted azlin-vm-20250112-120000 and all associated resources.
+Deleted azlin-vm-20250112-120000 and 4 associated resource(s) (~$3.65/month reclaimed)
 ```
 
 ### Example 2: Dry-Run Mode
@@ -216,15 +230,30 @@ If multiple VMs share a Network Security Group:
 azlin destroy my-vm --delete-rg --force
 ```
 
-**WARNING:** This deletes the ENTIRE resource group, not just the VM. All resources in the group be permanently lost.
+**This is rejected.** `--delete-rg` is parsed but always refused with an
+error — it is *not* a supported way to delete a resource group. Resource
+groups routinely hold hand-made VMs, VNets and Public IPs alongside azlin
+sessions, so honoring the flag could destroy unrelated data with no way back.
+`destroy` only ever removes the named VM and its own disks, NIC, Public IP
+and NSG.
+
+If you really do want to delete the whole resource group, run the Azure CLI
+directly and accept that responsibility explicitly:
+
+```bash
+az group delete --name my-resource-group
+```
+
+To reclaim other leftovers in a resource group without deleting the group
+itself, use `azlin cleanup --resource-group my-resource-group`.
 
 ## Comparison with killall
 
 | Command | Purpose | Confirmation |
 |---------|---------|--------------|
 | `azlin destroy <vm-name>` | Delete single VM | Per-VM prompt |
-| `azlin killall` | Delete all VMs in RG | Single bulk prompt |
-| `azlin destroy --delete-rg` | Delete entire RG | Extra warning |
+| `azlin killall` | Delete all VMs matching a prefix in a resource group | Single bulk prompt |
+| `azlin destroy --delete-rg` | **Rejected** — not supported | n/a |
 
 ## Related Commands
 

--- a/rust/crates/azlin-azure/src/lib.rs
+++ b/rust/crates/azlin-azure/src/lib.rs
@@ -13,6 +13,7 @@ pub mod rate_limiter;
 pub mod region_fit;
 pub mod retry;
 pub mod subprocess;
+pub mod teardown;
 pub mod vm;
 
 pub use auth::AzureAuth;
@@ -20,4 +21,5 @@ pub use costs::get_cost_summary;
 pub use ops::AzureOps;
 pub use subprocess::run_with_timeout;
 pub use vm::az_cli_with_timeout;
+pub use vm::is_resource_not_found;
 pub use vm::VmManager;

--- a/rust/crates/azlin-azure/src/ops.rs
+++ b/rust/crates/azlin-azure/src/ops.rs
@@ -52,6 +52,34 @@ pub trait AzureOps {
 
     /// Create a new VM.
     fn create_vm(&self, params: &CreateVmParams) -> Result<VmInfo>;
+
+    // ── Network teardown ───────────────────────────────────────────────
+    //
+    // Needed because `az vm delete` leaves the Public IP and NSG behind.
+
+    /// List managed disks in a resource group as raw `az` JSON.
+    fn list_disks_json(&self, resource_group: &str) -> Result<String>;
+
+    /// List NICs in a resource group as raw `az` JSON.
+    fn list_nics_json(&self, resource_group: &str) -> Result<String>;
+
+    /// List public IPs in a resource group as raw `az` JSON.
+    fn list_public_ips_json(&self, resource_group: &str) -> Result<String>;
+
+    /// List network security groups in a resource group as raw `az` JSON.
+    fn list_nsgs_json(&self, resource_group: &str) -> Result<String>;
+
+    /// Delete a managed disk. Must succeed if the disk is already gone.
+    fn delete_disk(&self, resource_group: &str, name: &str) -> Result<()>;
+
+    /// Delete a NIC, waiting for completion. Must succeed if already gone.
+    fn delete_nic(&self, resource_group: &str, name: &str) -> Result<()>;
+
+    /// Delete a public IP. Must succeed if already gone.
+    fn delete_public_ip(&self, resource_group: &str, name: &str) -> Result<()>;
+
+    /// Delete a network security group. Must succeed if already gone.
+    fn delete_nsg(&self, resource_group: &str, name: &str) -> Result<()>;
 }
 
 /// Blanket implementation for `VmManager`.
@@ -106,6 +134,38 @@ impl AzureOps for super::VmManager {
 
     fn create_vm(&self, params: &CreateVmParams) -> Result<VmInfo> {
         self.create_vm(params)
+    }
+
+    fn list_disks_json(&self, resource_group: &str) -> Result<String> {
+        self.list_disks_json(resource_group)
+    }
+
+    fn list_nics_json(&self, resource_group: &str) -> Result<String> {
+        self.list_nics_json(resource_group)
+    }
+
+    fn list_public_ips_json(&self, resource_group: &str) -> Result<String> {
+        self.list_public_ips_json(resource_group)
+    }
+
+    fn list_nsgs_json(&self, resource_group: &str) -> Result<String> {
+        self.list_nsgs_json(resource_group)
+    }
+
+    fn delete_disk(&self, resource_group: &str, name: &str) -> Result<()> {
+        self.delete_disk(resource_group, name)
+    }
+
+    fn delete_nic(&self, resource_group: &str, name: &str) -> Result<()> {
+        self.delete_nic(resource_group, name)
+    }
+
+    fn delete_public_ip(&self, resource_group: &str, name: &str) -> Result<()> {
+        self.delete_public_ip(resource_group, name)
+    }
+
+    fn delete_nsg(&self, resource_group: &str, name: &str) -> Result<()> {
+        self.delete_nsg(resource_group, name)
     }
 }
 

--- a/rust/crates/azlin-azure/src/teardown.rs
+++ b/rust/crates/azlin-azure/src/teardown.rs
@@ -1,0 +1,926 @@
+//! Teardown planner — decides which Azure resources belong to a session and
+//! in what order they must be deleted.
+//!
+//! `az vm delete` removes only the VM. Disks and the NIC disappear because
+//! `az vm create` defaults their `deleteOption` to `Delete`, but Azure has no
+//! equivalent implicit delete for the Public IP or the Network Security Group.
+//! Those resources are left behind and keep billing. This module enumerates
+//! them so the deletion commands can reclaim them.
+//!
+//! Every function here is pure and operates on `az ... list -o json` output,
+//! mirroring [`crate::orphan_detector`], so the selection and ordering rules
+//! are fully unit-testable without touching Azure.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Tag key that identifies the azlin session a resource belongs to.
+pub const SESSION_TAG_KEY: &str = "azlin-session";
+
+/// Estimated monthly cost of an idle Standard static public IP, in USD.
+///
+/// Standard SKU public IPs bill even while unassociated, which is what makes
+/// leaking them expensive.
+pub const ORPHANED_PUBLIC_IP_MONTHLY_COST: f64 = 3.65;
+
+/// A category of Azure resource that participates in session teardown.
+///
+/// The ordinal ordering of these variants is the dependency order in which the
+/// resources must be deleted; see [`TeardownKind::deletion_order`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum TeardownKind {
+    Vm,
+    Disk,
+    Nic,
+    PublicIp,
+    Nsg,
+}
+
+impl TeardownKind {
+    /// Position of this resource kind in the deletion sequence.
+    ///
+    /// Azure refuses to delete a Public IP or an NSG while a NIC still
+    /// references it, so the NIC must be deleted (and awaited) first.
+    pub fn deletion_order(self) -> u8 {
+        match self {
+            Self::Vm => 0,
+            Self::Disk => 1,
+            Self::Nic => 2,
+            Self::PublicIp => 3,
+            Self::Nsg => 4,
+        }
+    }
+}
+
+impl std::fmt::Display for TeardownKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Vm => write!(f, "VM"),
+            Self::Disk => write!(f, "Disk"),
+            Self::Nic => write!(f, "NIC"),
+            Self::PublicIp => write!(f, "Public IP"),
+            Self::Nsg => write!(f, "NSG"),
+        }
+    }
+}
+
+/// A resource selected for deletion.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TeardownResource {
+    pub name: String,
+    pub kind: TeardownKind,
+    pub resource_group: String,
+    /// Estimated monthly cost reclaimed by deleting this resource, in USD.
+    pub estimated_monthly_cost: f64,
+}
+
+/// Why a candidate resource was excluded from the teardown plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SkipReason {
+    /// The resource carries no `azlin-session` tag, so ownership cannot be
+    /// proven. Deleting it would risk destroying someone else's resource.
+    Untagged,
+    /// The resource is still associated with something outside this teardown.
+    InUse,
+}
+
+impl std::fmt::Display for SkipReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Untagged => write!(f, "no {SESSION_TAG_KEY} tag — ownership unproven"),
+            Self::InUse => write!(f, "still associated with another resource"),
+        }
+    }
+}
+
+/// A candidate that looked session-related but was deliberately not deleted.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SkippedResource {
+    pub name: String,
+    pub kind: TeardownKind,
+    pub reason: SkipReason,
+}
+
+/// The ordered set of resources to delete, plus anything deliberately skipped.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct TeardownPlan {
+    /// Resources to delete, already sorted into dependency order.
+    pub resources: Vec<TeardownResource>,
+    /// Candidates excluded from deletion, retained so the user can be warned.
+    pub skipped: Vec<SkippedResource>,
+    /// Whether the target VM was found in Azure.
+    pub vm_exists: bool,
+}
+
+impl TeardownPlan {
+    /// Total estimated monthly saving from executing this plan, in USD.
+    pub fn estimated_monthly_savings(&self) -> f64 {
+        self.resources.iter().map(|r| r.estimated_monthly_cost).sum()
+    }
+
+    /// Resources of a given kind, preserving plan order.
+    pub fn of_kind(&self, kind: TeardownKind) -> Vec<&TeardownResource> {
+        self.resources.iter().filter(|r| r.kind == kind).collect()
+    }
+}
+
+/// Inputs to [`plan_teardown`], all raw `az ... list -o json` output.
+pub struct TeardownInputs<'a> {
+    /// Name of the VM being torn down.
+    pub vm_name: &'a str,
+    /// Resource group being operated on.
+    pub resource_group: &'a str,
+    /// Value of the VM's `azlin-session` tag, if the VM exists and is tagged.
+    ///
+    /// `None` means resources cannot be proven to belong to this session, so
+    /// nothing beyond the VM's own disks and NIC will be deleted.
+    pub session_tag: Option<&'a str>,
+    /// Whether the VM currently exists in Azure.
+    pub vm_exists: bool,
+    pub disk_json: &'a str,
+    pub nic_json: &'a str,
+    pub pip_json: &'a str,
+    pub nsg_json: &'a str,
+}
+
+/// Extract the final segment of an Azure resource ID.
+///
+/// Used for exact-match ownership checks. Deliberately exact: prefix matching
+/// on names is unsafe because sessions can be prefix-adjacent siblings (e.g.
+/// `copilot-test-1783435804` vs `copilot-test2-1784625385`).
+fn resource_name_from_id(id: &str) -> Option<&str> {
+    id.rsplit('/').find(|s| !s.is_empty())
+}
+
+/// Whether an Azure resource ID refers to a resource with exactly this name.
+fn id_refers_to(id: &str, name: &str) -> bool {
+    resource_name_from_id(id) == Some(name)
+}
+
+/// Read the `azlin-session` tag from a resource JSON object.
+fn session_tag_of(resource: &serde_json::Value) -> Option<&str> {
+    resource
+        .get("tags")?
+        .get(SESSION_TAG_KEY)?
+        .as_str()
+        .filter(|s| !s.is_empty())
+}
+
+/// Read a resource's `name` and `resourceGroup`, falling back to `default_rg`.
+fn name_and_group<'a>(
+    resource: &'a serde_json::Value,
+    default_rg: &'a str,
+) -> Option<(&'a str, &'a str)> {
+    let name = resource.get("name")?.as_str()?;
+    let rg = resource
+        .get("resourceGroup")
+        .and_then(|r| r.as_str())
+        .unwrap_or(default_rg);
+    Some((name, rg))
+}
+
+/// Whether a Public IP is free of any association.
+///
+/// Shared with orphan detection in `cleanup` so the two paths cannot drift.
+pub fn public_ip_is_unassociated(ip: &serde_json::Value) -> bool {
+    ip.get("ipConfiguration").map(|v| v.is_null()).unwrap_or(true)
+}
+
+/// Whether an NSG is free of any association.
+///
+/// An NSG is only unassociated when it is referenced by neither a NIC nor a
+/// subnet. Shared with orphan detection in `cleanup`.
+pub fn nsg_is_unassociated(nsg: &serde_json::Value) -> bool {
+    let non_empty_array = |key: &str| {
+        nsg.get(key)
+            .and_then(|v| v.as_array())
+            .map(|a| !a.is_empty())
+            .unwrap_or(false)
+    };
+    !non_empty_array("networkInterfaces") && !non_empty_array("subnets")
+}
+
+/// Parse an `az ... list -o json` array, tolerating an empty body.
+fn parse_list(json: &str, what: &str) -> Result<Vec<serde_json::Value>> {
+    let trimmed = json.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    serde_json::from_str(trimmed).with_context(|| format!("Failed to parse {what} list JSON"))
+}
+
+/// Build the ordered teardown plan for a session.
+///
+/// Selection rules, in the order they are applied:
+///
+/// * **Disks and NICs** are selected by exact association with the target VM
+///   (`managedBy` / `virtualMachine.id`), which is authoritative and needs no
+///   tag.
+/// * **Public IPs and NSGs** are selected only when their `azlin-session` tag
+///   exactly equals the VM's. Untagged candidates are skipped and reported —
+///   ownership cannot be proven, and deleting them could destroy another
+///   session's resources.
+/// * A Public IP or NSG still bound to something *outside* this teardown is
+///   skipped as in-use. Being bound to this VM's own NIC does not disqualify
+///   it, since that NIC is deleted first.
+/// * VNets, subnets, and SSH public keys are never enumerated: shared
+///   infrastructure is out of scope by construction.
+pub fn plan_teardown(inputs: &TeardownInputs) -> Result<TeardownPlan> {
+    let rg = inputs.resource_group;
+    let mut plan = TeardownPlan {
+        vm_exists: inputs.vm_exists,
+        ..Default::default()
+    };
+
+    if inputs.vm_exists {
+        plan.resources.push(TeardownResource {
+            name: inputs.vm_name.to_string(),
+            kind: TeardownKind::Vm,
+            resource_group: rg.to_string(),
+            estimated_monthly_cost: 0.0,
+        });
+    }
+
+    // Disks owned by the target VM. `managedBy` is the authoritative owner
+    // reference, so no tag is required.
+    for disk in parse_list(inputs.disk_json, "disk")? {
+        let owned = disk
+            .get("managedBy")
+            .and_then(|m| m.as_str())
+            .map(|id| id_refers_to(id, inputs.vm_name))
+            .unwrap_or(false);
+        if !owned {
+            continue;
+        }
+        if let Some((name, disk_rg)) = name_and_group(&disk, rg) {
+            let size_gb = disk.get("diskSizeGb").and_then(|s| s.as_f64()).unwrap_or(0.0);
+            plan.resources.push(TeardownResource {
+                name: name.to_string(),
+                kind: TeardownKind::Disk,
+                resource_group: disk_rg.to_string(),
+                estimated_monthly_cost: size_gb * 0.04,
+            });
+        }
+    }
+
+    // NICs attached to the target VM. Collected separately as well, because a
+    // Public IP or NSG bound only to one of these is safe to delete once the
+    // NIC is gone.
+    let mut target_nic_names: Vec<String> = Vec::new();
+    for nic in parse_list(inputs.nic_json, "NIC")? {
+        let attached = nic
+            .get("virtualMachine")
+            .and_then(|v| v.get("id"))
+            .and_then(|id| id.as_str())
+            .map(|id| id_refers_to(id, inputs.vm_name))
+            .unwrap_or(false);
+        if !attached {
+            continue;
+        }
+        if let Some((name, nic_rg)) = name_and_group(&nic, rg) {
+            target_nic_names.push(name.to_string());
+            plan.resources.push(TeardownResource {
+                name: name.to_string(),
+                kind: TeardownKind::Nic,
+                resource_group: nic_rg.to_string(),
+                estimated_monthly_cost: 0.0,
+            });
+        }
+    }
+
+    // True when every association points at a NIC this teardown already
+    // removes, so the resource will be free by the time we reach it.
+    let bound_only_to_target_nics = |ids: &[&str]| -> bool {
+        ids.iter().all(|id| {
+            resource_name_from_id(id)
+                .map(|n| target_nic_names.iter().any(|t| t == n))
+                .unwrap_or(false)
+        })
+    };
+
+    for ip in parse_list(inputs.pip_json, "public IP")? {
+        let Some((name, ip_rg)) = name_and_group(&ip, rg) else {
+            continue;
+        };
+        // The NIC's ipConfiguration ID embeds the NIC name, e.g.
+        // `.../networkInterfaces/<nic>/ipConfigurations/ipconfig1`, so strip
+        // the trailing segment before comparing.
+        let free = public_ip_is_unassociated(&ip)
+            || ip
+                .get("ipConfiguration")
+                .and_then(|c| c.get("id"))
+                .and_then(|id| id.as_str())
+                .and_then(|id| id.rsplit_once("/ipConfigurations/").map(|(nic, _)| nic))
+                .map(|nic_id| bound_only_to_target_nics(&[nic_id]))
+                .unwrap_or(false);
+
+        match classify(session_tag_of(&ip), inputs.session_tag, free) {
+            Candidate::Delete => plan.resources.push(TeardownResource {
+                name: name.to_string(),
+                kind: TeardownKind::PublicIp,
+                resource_group: ip_rg.to_string(),
+                estimated_monthly_cost: ORPHANED_PUBLIC_IP_MONTHLY_COST,
+            }),
+            Candidate::Skip(reason) => plan.skipped.push(SkippedResource {
+                name: name.to_string(),
+                kind: TeardownKind::PublicIp,
+                reason,
+            }),
+            Candidate::Ignore => {}
+        }
+    }
+
+    for nsg in parse_list(inputs.nsg_json, "NSG")? {
+        let Some((name, nsg_rg)) = name_and_group(&nsg, rg) else {
+            continue;
+        };
+        // A subnet association always disqualifies an NSG: subnets are shared
+        // infrastructure that outlives any single session.
+        let subnet_bound = nsg
+            .get("subnets")
+            .and_then(|v| v.as_array())
+            .map(|a| !a.is_empty())
+            .unwrap_or(false);
+        let nic_ids: Vec<&str> = nsg
+            .get("networkInterfaces")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|n| n.get("id").and_then(|i| i.as_str()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let free = !subnet_bound
+            && (nsg_is_unassociated(&nsg) || bound_only_to_target_nics(&nic_ids));
+
+        match classify(session_tag_of(&nsg), inputs.session_tag, free) {
+            Candidate::Delete => plan.resources.push(TeardownResource {
+                name: name.to_string(),
+                kind: TeardownKind::Nsg,
+                resource_group: nsg_rg.to_string(),
+                estimated_monthly_cost: 0.0,
+            }),
+            Candidate::Skip(reason) => plan.skipped.push(SkippedResource {
+                name: name.to_string(),
+                kind: TeardownKind::Nsg,
+                reason,
+            }),
+            Candidate::Ignore => {}
+        }
+    }
+
+    plan.resources
+        .sort_by_key(|r| (r.kind.deletion_order(), r.name.clone()));
+    Ok(plan)
+}
+
+/// Outcome of evaluating one tag-matched candidate resource.
+enum Candidate {
+    Delete,
+    Skip(SkipReason),
+    /// Belongs to a different session, or to no azlin session at all — not our
+    /// business and not worth reporting.
+    Ignore,
+}
+
+/// Decide the fate of a Public IP or NSG.
+///
+/// Tag-only matching: a resource is deletable only when its `azlin-session`
+/// tag exactly equals the target session's. Exact equality means a
+/// prefix-adjacent sibling session (`copilot-test-…` vs `copilot-test2-…`)
+/// can never be matched by accident.
+fn classify(
+    resource_tag: Option<&str>,
+    target_session: Option<&str>,
+    is_free: bool,
+) -> Candidate {
+    match (resource_tag, target_session) {
+        (Some(tag), Some(target)) if tag == target => {
+            if is_free {
+                Candidate::Delete
+            } else {
+                Candidate::Skip(SkipReason::InUse)
+            }
+        }
+        // Tagged for a different session — leave it alone entirely.
+        (Some(_), _) => Candidate::Ignore,
+        // Untagged resources are never deleted. Report them only when they are
+        // otherwise free, so the user learns about a potential leak without
+        // being warned about healthy in-use infrastructure.
+        (None, _) if is_free => Candidate::Skip(SkipReason::Untagged),
+        (None, _) => Candidate::Ignore,
+    }
+}
+
+/// Render a teardown plan for `--dry-run`.
+pub fn format_teardown_plan(plan: &TeardownPlan, vm_name: &str, resource_group: &str) -> String {
+    let mut out = String::new();
+
+    if !plan.vm_exists {
+        out.push_str(&format!(
+            "VM '{vm_name}' was not found in resource group '{resource_group}'.\n"
+        ));
+    }
+
+    if plan.resources.is_empty() {
+        out.push_str("Dry run -- nothing to delete.\n");
+    } else {
+        out.push_str("Dry run -- would delete:\n");
+        for r in &plan.resources {
+            out.push_str(&format!("  {:<10} {}\n", format!("{}:", r.kind), r.name));
+        }
+        out.push_str(&format!("  Resource group: {resource_group}\n"));
+        let savings = plan.estimated_monthly_savings();
+        if savings > 0.0 {
+            out.push_str(&format!("\n💰 Estimated savings: ${savings:.2}/month\n"));
+        }
+    }
+
+    if !plan.skipped.is_empty() {
+        out.push_str("\n⚠️  Not deleted (may remain and keep billing):\n");
+        for s in &plan.skipped {
+            out.push_str(&format!("  {:<10} {} — {}\n", format!("{}:", s.kind), s.name, s.reason));
+        }
+        out.push_str("  Run 'azlin cleanup' to review and reclaim orphaned resources.\n");
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VM: &str = "copilot-test2-1784625385";
+    const SESSION: &str = "copilot-test2";
+    const RG: &str = "myvm_group";
+
+    fn vm_id(name: &str) -> String {
+        format!("/subscriptions/sub/resourceGroups/{RG}/providers/Microsoft.Compute/virtualMachines/{name}")
+    }
+
+    fn nic_id(name: &str) -> String {
+        format!("/subscriptions/sub/resourceGroups/{RG}/providers/Microsoft.Network/networkInterfaces/{name}")
+    }
+
+    /// Public IP, NIC, disk and NSG for `VM`, all tagged for `SESSION`.
+    fn full_inputs() -> (String, String, String, String) {
+        let disks = format!(
+            r#"[{{"name":"{VM}_OsDisk_1_abc","managedBy":"{}","resourceGroup":"{RG}","diskSizeGb":5,
+                  "tags":{{"azlin-session":"{SESSION}"}}}},
+                {{"name":"{VM}_home","managedBy":"{}","resourceGroup":"{RG}","diskSizeGb":100,
+                  "tags":{{"azlin-session":"{SESSION}"}}}}]"#,
+            vm_id(VM),
+            vm_id(VM)
+        );
+        let nics = format!(
+            r#"[{{"name":"{VM}VMNic","resourceGroup":"{RG}","virtualMachine":{{"id":"{}"}},
+                  "tags":{{"azlin-session":"{SESSION}"}}}}]"#,
+            vm_id(VM)
+        );
+        let pips = format!(
+            r#"[{{"name":"{VM}PublicIP","resourceGroup":"{RG}",
+                  "ipConfiguration":{{"id":"{}/ipConfigurations/ipconfig1"}},
+                  "tags":{{"azlin-session":"{SESSION}"}}}}]"#,
+            nic_id(&format!("{VM}VMNic"))
+        );
+        let nsgs = format!(
+            r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":[],
+                  "networkInterfaces":[{{"id":"{}"}}],
+                  "tags":{{"azlin-session":"{SESSION}"}}}}]"#,
+            nic_id(&format!("{VM}VMNic"))
+        );
+        (disks, nics, pips, nsgs)
+    }
+
+    fn plan_with(disks: &str, nics: &str, pips: &str, nsgs: &str) -> TeardownPlan {
+        plan_teardown(&TeardownInputs {
+            vm_name: VM,
+            resource_group: RG,
+            session_tag: Some(SESSION),
+            vm_exists: true,
+            disk_json: disks,
+            nic_json: nics,
+            pip_json: pips,
+            nsg_json: nsgs,
+        })
+        .unwrap()
+    }
+
+    fn default_plan() -> TeardownPlan {
+        let (d, n, p, g) = full_inputs();
+        plan_with(&d, &n, &p, &g)
+    }
+
+    // ── The core bug: IP and NSG must be in the teardown set ─────────────
+
+    #[test]
+    fn public_ip_is_included_in_teardown() {
+        let plan = default_plan();
+        let ips = plan.of_kind(TeardownKind::PublicIp);
+        assert_eq!(ips.len(), 1, "public IP must be scheduled for deletion");
+        assert_eq!(ips[0].name, format!("{VM}PublicIP"));
+    }
+
+    #[test]
+    fn nsg_is_included_in_teardown() {
+        let plan = default_plan();
+        let nsgs = plan.of_kind(TeardownKind::Nsg);
+        assert_eq!(nsgs.len(), 1, "NSG must be scheduled for deletion");
+        assert_eq!(nsgs[0].name, format!("{VM}NSG"));
+    }
+
+    #[test]
+    fn teardown_includes_vm_disks_nic_ip_and_nsg() {
+        let plan = default_plan();
+        assert_eq!(plan.of_kind(TeardownKind::Vm).len(), 1);
+        assert_eq!(plan.of_kind(TeardownKind::Disk).len(), 2);
+        assert_eq!(plan.of_kind(TeardownKind::Nic).len(), 1);
+        assert_eq!(plan.of_kind(TeardownKind::PublicIp).len(), 1);
+        assert_eq!(plan.of_kind(TeardownKind::Nsg).len(), 1);
+    }
+
+    #[test]
+    fn leaked_public_ip_cost_is_reported() {
+        let plan = default_plan();
+        let ip = plan.of_kind(TeardownKind::PublicIp)[0];
+        assert!((ip.estimated_monthly_cost - ORPHANED_PUBLIC_IP_MONTHLY_COST).abs() < 0.01);
+    }
+
+    // ── Ordering ────────────────────────────────────────────────────────
+
+    #[test]
+    fn nic_is_deleted_before_public_ip_and_nsg() {
+        let plan = default_plan();
+        let pos = |kind: TeardownKind| {
+            plan.resources
+                .iter()
+                .position(|r| r.kind == kind)
+                .unwrap_or_else(|| panic!("{kind} missing from plan"))
+        };
+        let nic = pos(TeardownKind::Nic);
+        assert!(
+            nic < pos(TeardownKind::PublicIp),
+            "NIC must precede public IP or Azure rejects the delete as in-use"
+        );
+        assert!(
+            nic < pos(TeardownKind::Nsg),
+            "NIC must precede NSG or Azure rejects the delete as in-use"
+        );
+    }
+
+    #[test]
+    fn vm_is_deleted_first() {
+        let plan = default_plan();
+        assert_eq!(plan.resources[0].kind, TeardownKind::Vm);
+    }
+
+    #[test]
+    fn deletion_order_is_strictly_increasing() {
+        let plan = default_plan();
+        let orders: Vec<u8> = plan.resources.iter().map(|r| r.kind.deletion_order()).collect();
+        let mut sorted = orders.clone();
+        sorted.sort_unstable();
+        assert_eq!(orders, sorted);
+    }
+
+    // ── The sibling-session hazard ──────────────────────────────────────
+
+    #[test]
+    fn prefix_adjacent_sibling_session_is_not_matched() {
+        // `copilot-test-1783435804` is a prefix-adjacent sibling of
+        // `copilot-test2-1784625385`. Naive prefix matching would delete the
+        // wrong session's resources.
+        let sibling_pips = r#"[
+            {"name":"copilot-test-1783435804PublicIP","resourceGroup":"myvm_group",
+             "ipConfiguration":null,"tags":{"azlin-session":"copilot-test"}}
+        ]"#;
+        let sibling_nsgs = r#"[
+            {"name":"copilot-test-1783435804NSG","resourceGroup":"myvm_group",
+             "subnets":[],"networkInterfaces":[],"tags":{"azlin-session":"copilot-test"}}
+        ]"#;
+        let plan = plan_with("[]", "[]", sibling_pips, sibling_nsgs);
+        assert!(
+            plan.of_kind(TeardownKind::PublicIp).is_empty(),
+            "sibling session's public IP must never be deleted"
+        );
+        assert!(
+            plan.of_kind(TeardownKind::Nsg).is_empty(),
+            "sibling session's NSG must never be deleted"
+        );
+        assert!(
+            plan.skipped.is_empty(),
+            "another session's resources are not our business to warn about"
+        );
+    }
+
+    #[test]
+    fn sibling_disk_with_prefix_adjacent_name_is_not_matched() {
+        let disks = format!(
+            r#"[{{"name":"copilot-test-1783435804_home","managedBy":"{}",
+                  "resourceGroup":"{RG}","diskSizeGb":100}}]"#,
+            vm_id("copilot-test-1783435804")
+        );
+        let plan = plan_with(&disks, "[]", "[]", "[]");
+        assert!(plan.of_kind(TeardownKind::Disk).is_empty());
+    }
+
+    #[test]
+    fn sibling_nic_is_not_matched() {
+        let nics = format!(
+            r#"[{{"name":"copilot-test-1783435804VMNic","resourceGroup":"{RG}",
+                  "virtualMachine":{{"id":"{}"}}}}]"#,
+            vm_id("copilot-test-1783435804")
+        );
+        let plan = plan_with("[]", &nics, "[]", "[]");
+        assert!(plan.of_kind(TeardownKind::Nic).is_empty());
+    }
+
+    // ── In-use resources are never deleted ──────────────────────────────
+
+    #[test]
+    fn public_ip_associated_with_foreign_nic_is_skipped() {
+        let pips = format!(
+            r#"[{{"name":"{VM}PublicIP","resourceGroup":"{RG}",
+                  "ipConfiguration":{{"id":"{}/ipConfigurations/ipconfig1"}},
+                  "tags":{{"azlin-session":"{SESSION}"}}}}]"#,
+            nic_id("someone-elses-nic")
+        );
+        let plan = plan_with("[]", "[]", &pips, "[]");
+        assert!(
+            plan.of_kind(TeardownKind::PublicIp).is_empty(),
+            "an in-use public IP must not be deleted"
+        );
+        assert_eq!(plan.skipped.len(), 1);
+        assert_eq!(plan.skipped[0].reason, SkipReason::InUse);
+    }
+
+    #[test]
+    fn nsg_attached_to_subnet_is_skipped_as_shared_infrastructure() {
+        let nsgs = format!(
+            r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}",
+                  "subnets":[{{"id":"/subscriptions/sub/.../subnets/default"}}],
+                  "networkInterfaces":[],"tags":{{"azlin-session":"{SESSION}"}}}}]"#
+        );
+        let plan = plan_with("[]", "[]", "[]", &nsgs);
+        assert!(plan.of_kind(TeardownKind::Nsg).is_empty());
+        assert_eq!(plan.skipped[0].reason, SkipReason::InUse);
+    }
+
+    #[test]
+    fn nsg_attached_to_foreign_nic_is_skipped() {
+        let nsgs = format!(
+            r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":[],
+                  "networkInterfaces":[{{"id":"{}"}}],
+                  "tags":{{"azlin-session":"{SESSION}"}}}}]"#,
+            nic_id("someone-elses-nic")
+        );
+        let plan = plan_with("[]", "[]", "[]", &nsgs);
+        assert!(plan.of_kind(TeardownKind::Nsg).is_empty());
+        assert_eq!(plan.skipped[0].reason, SkipReason::InUse);
+    }
+
+    #[test]
+    fn public_ip_bound_to_our_own_nic_is_still_deleted() {
+        // Association with the NIC we are about to delete must not disqualify
+        // the IP — otherwise teardown would never reclaim anything.
+        let plan = default_plan();
+        assert_eq!(plan.of_kind(TeardownKind::PublicIp).len(), 1);
+    }
+
+    // ── Tag-only matching ───────────────────────────────────────────────
+
+    #[test]
+    fn untagged_public_ip_is_skipped_not_deleted() {
+        let pips = format!(
+            r#"[{{"name":"{VM}PublicIP","resourceGroup":"{RG}","ipConfiguration":null}}]"#
+        );
+        let plan = plan_with("[]", "[]", &pips, "[]");
+        assert!(
+            plan.of_kind(TeardownKind::PublicIp).is_empty(),
+            "ownership is unproven without a tag — must not delete"
+        );
+        assert_eq!(plan.skipped.len(), 1);
+        assert_eq!(plan.skipped[0].reason, SkipReason::Untagged);
+    }
+
+    #[test]
+    fn untagged_nsg_is_skipped_not_deleted() {
+        let nsgs = format!(
+            r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":[],"networkInterfaces":[]}}]"#
+        );
+        let plan = plan_with("[]", "[]", "[]", &nsgs);
+        assert!(plan.of_kind(TeardownKind::Nsg).is_empty());
+        assert_eq!(plan.skipped[0].reason, SkipReason::Untagged);
+    }
+
+    #[test]
+    fn untagged_but_in_use_resource_is_not_warned_about() {
+        // `myvm-ip` in the real subscription: untagged and healthily attached
+        // to an unrelated VM. Warning about it would be noise.
+        let pips = r#"[{"name":"myvm-ip","resourceGroup":"myvm_group",
+                        "ipConfiguration":{"id":"/subscriptions/s/resourceGroups/myvm_group/providers/Microsoft.Network/networkInterfaces/myvm693_z1/ipConfigurations/ipconfig1"}}]"#;
+        let plan = plan_with("[]", "[]", pips, "[]");
+        assert!(plan.resources.iter().all(|r| r.kind != TeardownKind::PublicIp));
+        assert!(plan.skipped.is_empty());
+    }
+
+    #[test]
+    fn no_session_tag_on_vm_means_no_ip_or_nsg_deleted() {
+        let (d, n, p, g) = full_inputs();
+        let plan = plan_teardown(&TeardownInputs {
+            vm_name: VM,
+            resource_group: RG,
+            session_tag: None,
+            vm_exists: true,
+            disk_json: &d,
+            nic_json: &n,
+            pip_json: &p,
+            nsg_json: &g,
+        })
+        .unwrap();
+        assert!(plan.of_kind(TeardownKind::PublicIp).is_empty());
+        assert!(plan.of_kind(TeardownKind::Nsg).is_empty());
+        // Disks and NIC are still safe: association is authoritative.
+        assert_eq!(plan.of_kind(TeardownKind::Disk).len(), 2);
+        assert_eq!(plan.of_kind(TeardownKind::Nic).len(), 1);
+    }
+
+    // ── Shared infrastructure is never enumerated ───────────────────────
+
+    #[test]
+    fn vnets_and_ssh_keys_are_never_in_the_plan() {
+        let plan = default_plan();
+        assert!(plan
+            .resources
+            .iter()
+            .all(|r| !r.name.to_lowercase().contains("vnet")));
+        assert!(plan.resources.iter().all(|r| matches!(
+            r.kind,
+            TeardownKind::Vm
+                | TeardownKind::Disk
+                | TeardownKind::Nic
+                | TeardownKind::PublicIp
+                | TeardownKind::Nsg
+        )));
+    }
+
+    // ── Missing VM ──────────────────────────────────────────────────────
+
+    #[test]
+    fn absent_vm_still_reports_leftover_tagged_resources() {
+        let pips = format!(
+            r#"[{{"name":"{VM}PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
+                  "tags":{{"azlin-session":"{SESSION}"}}}}]"#
+        );
+        let plan = plan_teardown(&TeardownInputs {
+            vm_name: VM,
+            resource_group: RG,
+            session_tag: Some(SESSION),
+            vm_exists: false,
+            disk_json: "[]",
+            nic_json: "[]",
+            pip_json: &pips,
+            nsg_json: "[]",
+        })
+        .unwrap();
+        assert!(!plan.vm_exists);
+        assert!(plan.of_kind(TeardownKind::Vm).is_empty());
+        assert_eq!(plan.of_kind(TeardownKind::PublicIp).len(), 1);
+    }
+
+    // ── Robustness ──────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_and_blank_json_are_tolerated() {
+        for body in ["[]", "", "   "] {
+            let plan = plan_with(body, body, body, body);
+            assert_eq!(plan.resources.len(), 1, "only the VM itself");
+        }
+    }
+
+    #[test]
+    fn malformed_json_is_an_error() {
+        assert!(plan_teardown(&TeardownInputs {
+            vm_name: VM,
+            resource_group: RG,
+            session_tag: Some(SESSION),
+            vm_exists: true,
+            disk_json: "not json",
+            nic_json: "[]",
+            pip_json: "[]",
+            nsg_json: "[]",
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn empty_session_tag_is_treated_as_untagged() {
+        let pips = format!(
+            r#"[{{"name":"{VM}PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
+                  "tags":{{"azlin-session":""}}}}]"#
+        );
+        let plan = plan_with("[]", "[]", &pips, "[]");
+        assert!(plan.of_kind(TeardownKind::PublicIp).is_empty());
+        assert_eq!(plan.skipped[0].reason, SkipReason::Untagged);
+    }
+
+    #[test]
+    fn resource_group_falls_back_to_target_when_absent() {
+        let pips = format!(
+            r#"[{{"name":"{VM}PublicIP","ipConfiguration":null,
+                  "tags":{{"azlin-session":"{SESSION}"}}}}]"#
+        );
+        let plan = plan_with("[]", "[]", &pips, "[]");
+        assert_eq!(plan.of_kind(TeardownKind::PublicIp)[0].resource_group, RG);
+    }
+
+    // ── Association predicates (shared with cleanup) ────────────────────
+
+    #[test]
+    fn public_ip_association_predicate() {
+        let free: serde_json::Value = serde_json::json!({"ipConfiguration": null});
+        let bound: serde_json::Value = serde_json::json!({"ipConfiguration": {"id": "x"}});
+        assert!(public_ip_is_unassociated(&free));
+        assert!(!public_ip_is_unassociated(&bound));
+        assert!(public_ip_is_unassociated(&serde_json::json!({})));
+    }
+
+    #[test]
+    fn nsg_association_predicate() {
+        assert!(nsg_is_unassociated(&serde_json::json!({
+            "networkInterfaces": [], "subnets": []
+        })));
+        assert!(!nsg_is_unassociated(&serde_json::json!({
+            "networkInterfaces": [{"id": "n"}], "subnets": []
+        })));
+        assert!(!nsg_is_unassociated(&serde_json::json!({
+            "networkInterfaces": [], "subnets": [{"id": "s"}]
+        })));
+        assert!(nsg_is_unassociated(&serde_json::json!({})));
+    }
+
+    // ── Dry-run rendering ───────────────────────────────────────────────
+
+    #[test]
+    fn dry_run_enumerates_every_resource() {
+        let out = format_teardown_plan(&default_plan(), VM, RG);
+        assert!(out.contains(VM));
+        assert!(out.contains(&format!("{VM}VMNic")));
+        assert!(out.contains(&format!("{VM}PublicIP")));
+        assert!(out.contains(&format!("{VM}NSG")));
+        assert!(out.contains(&format!("{VM}_home")));
+        assert!(out.contains("Resource group: myvm_group"));
+    }
+
+    #[test]
+    fn dry_run_reports_estimated_savings() {
+        let out = format_teardown_plan(&default_plan(), VM, RG);
+        assert!(out.contains("Estimated savings"));
+        assert!(out.contains("$3.65") || out.contains("/month"));
+    }
+
+    #[test]
+    fn dry_run_states_clearly_when_vm_is_absent() {
+        let plan = TeardownPlan {
+            vm_exists: false,
+            ..Default::default()
+        };
+        let out = format_teardown_plan(&plan, VM, RG);
+        assert!(out.contains("not found"));
+        assert!(out.contains("nothing to delete"));
+    }
+
+    #[test]
+    fn dry_run_warns_about_skipped_resources() {
+        let plan = TeardownPlan {
+            resources: vec![],
+            skipped: vec![SkippedResource {
+                name: format!("{VM}PublicIP"),
+                kind: TeardownKind::PublicIp,
+                reason: SkipReason::Untagged,
+            }],
+            vm_exists: true,
+        };
+        let out = format_teardown_plan(&plan, VM, RG);
+        assert!(out.contains("Not deleted"));
+        assert!(out.contains(&format!("{VM}PublicIP")));
+        assert!(out.contains("azlin cleanup"));
+    }
+
+    #[test]
+    fn kind_display_strings() {
+        assert_eq!(TeardownKind::Vm.to_string(), "VM");
+        assert_eq!(TeardownKind::Disk.to_string(), "Disk");
+        assert_eq!(TeardownKind::Nic.to_string(), "NIC");
+        assert_eq!(TeardownKind::PublicIp.to_string(), "Public IP");
+        assert_eq!(TeardownKind::Nsg.to_string(), "NSG");
+    }
+
+    #[test]
+    fn resource_name_extraction_ignores_trailing_slash() {
+        assert_eq!(resource_name_from_id("/a/b/c"), Some("c"));
+        assert_eq!(resource_name_from_id("/a/b/c/"), Some("c"));
+        assert_eq!(resource_name_from_id(""), None);
+    }
+}

--- a/rust/crates/azlin-azure/src/teardown.rs
+++ b/rust/crates/azlin-azure/src/teardown.rs
@@ -110,6 +110,9 @@ pub struct TeardownPlan {
     pub skipped: Vec<SkippedResource>,
     /// Whether the target VM was found in Azure.
     pub vm_exists: bool,
+    /// The `azlin-session` tag this plan matched on, retained so a follow-up
+    /// re-check can apply the identical ownership rule.
+    pub session_tag: Option<String>,
 }
 
 impl TeardownPlan {
@@ -229,6 +232,7 @@ pub fn plan_teardown(inputs: &TeardownInputs) -> Result<TeardownPlan> {
     let rg = inputs.resource_group;
     let mut plan = TeardownPlan {
         vm_exists: inputs.vm_exists,
+        session_tag: inputs.session_tag.map(str::to_string),
         ..Default::default()
     };
 
@@ -277,15 +281,16 @@ pub fn plan_teardown(inputs: &TeardownInputs) -> Result<TeardownPlan> {
         if !attached {
             continue;
         }
-        if let Some((name, nic_rg)) = name_and_group(&nic, rg) {
-            target_nic_names.push(name.to_string());
-            plan.resources.push(TeardownResource {
-                name: name.to_string(),
-                kind: TeardownKind::Nic,
-                resource_group: nic_rg.to_string(),
-                estimated_monthly_cost: 0.0,
-            });
-        }
+        let Some((name, nic_rg)) = name_and_group(&nic, rg) else {
+            continue;
+        };
+        target_nic_names.push(name.to_string());
+        plan.resources.push(TeardownResource {
+            name: name.to_string(),
+            kind: TeardownKind::Nic,
+            resource_group: nic_rg.to_string(),
+            estimated_monthly_cost: 0.0,
+        });
     }
 
     // True when every association points at a NIC this teardown already
@@ -381,6 +386,77 @@ enum Candidate {
     /// Belongs to a different session, or to no azlin session at all — not our
     /// business and not worth reporting.
     Ignore,
+}
+
+/// Re-evaluate resources that the plan skipped as [`SkipReason::InUse`].
+///
+/// The teardown plan is computed once, before anything is deleted, from a
+/// single snapshot of Azure state. A Public IP or NSG that is still bound to
+/// the session's NIC at that moment is correctly identified as in-use, but the
+/// first-pass escape hatch (`bound only to a NIC we are about to delete`) is
+/// only as good as the association data Azure returns at snapshot time. If it
+/// misreports — a lagging back-reference, an association recorded against a
+/// resource the snapshot did not include — the resource is skipped permanently
+/// and leaks, billing indefinitely.
+///
+/// This second pass closes that hole: after the NICs are gone, re-read the
+/// Public IPs and NSGs and delete the ones that are *now* provably free. The
+/// safety rules are unchanged and strictly narrower than the first pass — the
+/// resource must still carry an exactly-matching `azlin-session` tag, must
+/// have been part of the plan, and must have no association whatsoever.
+pub fn plan_recheck(
+    skipped: &[SkippedResource],
+    session_tag: Option<&str>,
+    resource_group: &str,
+    pip_json: &str,
+    nsg_json: &str,
+) -> Result<Vec<TeardownResource>> {
+    let was_skipped_in_use = |name: &str, kind: TeardownKind| {
+        skipped
+            .iter()
+            .any(|s| s.name == name && s.kind == kind && s.reason == SkipReason::InUse)
+    };
+
+    let mut freed = Vec::new();
+
+    for ip in parse_list(pip_json, "public IP")? {
+        let Some((name, ip_rg)) = name_and_group(&ip, resource_group) else {
+            continue;
+        };
+        if !was_skipped_in_use(name, TeardownKind::PublicIp) {
+            continue;
+        }
+        if session_tag_of(&ip) != session_tag || !public_ip_is_unassociated(&ip) {
+            continue;
+        }
+        freed.push(TeardownResource {
+            name: name.to_string(),
+            kind: TeardownKind::PublicIp,
+            resource_group: ip_rg.to_string(),
+            estimated_monthly_cost: ORPHANED_PUBLIC_IP_MONTHLY_COST,
+        });
+    }
+
+    for nsg in parse_list(nsg_json, "NSG")? {
+        let Some((name, nsg_rg)) = name_and_group(&nsg, resource_group) else {
+            continue;
+        };
+        if !was_skipped_in_use(name, TeardownKind::Nsg) {
+            continue;
+        }
+        if session_tag_of(&nsg) != session_tag || !nsg_is_unassociated(&nsg) {
+            continue;
+        }
+        freed.push(TeardownResource {
+            name: name.to_string(),
+            kind: TeardownKind::Nsg,
+            resource_group: nsg_rg.to_string(),
+            estimated_monthly_cost: 0.0,
+        });
+    }
+
+    freed.sort_by_key(|r| (r.kind.deletion_order(), r.name.clone()));
+    Ok(freed)
 }
 
 /// Decide the fate of a Public IP or NSG.
@@ -901,6 +977,7 @@ mod tests {
                 reason: SkipReason::Untagged,
             }],
             vm_exists: true,
+            session_tag: Some(SESSION.to_string()),
         };
         let out = format_teardown_plan(&plan, VM, RG);
         assert!(out.contains("Not deleted"));
@@ -922,5 +999,178 @@ mod tests {
         assert_eq!(resource_name_from_id("/a/b/c"), Some("c"));
         assert_eq!(resource_name_from_id("/a/b/c/"), Some("c"));
         assert_eq!(resource_name_from_id(""), None);
+    }
+
+    // ── The NSG leak: association must be re-evaluated after NIC deletion ─
+
+    /// The exact shape observed in the live provision test: an NSG whose only
+    /// association is the NIC being torn down must be planned for deletion.
+    #[test]
+    fn nsg_bound_only_to_target_nic_is_deleted() {
+        let plan = default_plan();
+        assert_eq!(plan.of_kind(TeardownKind::Nsg).len(), 1);
+        assert!(plan.skipped.is_empty());
+    }
+
+    /// `subnets: null` is what Azure actually returns for an unassociated
+    /// subnet list, not `[]`. It must not be read as an association.
+    #[test]
+    fn nsg_with_null_subnets_and_target_nic_is_deleted() {
+        let (d, n, p, _) = full_inputs();
+        let nsgs = format!(
+            r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":null,
+                  "networkInterfaces":[{{"id":"{}","resourceGroup":"{RG}"}}],
+                  "tags":{{"azlin-session":"{SESSION}"}}}}]"#,
+            nic_id(&format!("{VM}VMNic"))
+        );
+        let plan = plan_with(&d, &n, &p, &nsgs);
+        assert_eq!(plan.of_kind(TeardownKind::Nsg).len(), 1);
+    }
+
+    /// An NSG shared with a live NIC outside this session must survive.
+    #[test]
+    fn nsg_bound_to_unrelated_live_nic_is_skipped() {
+        let (d, n, p, _) = full_inputs();
+        let nics = format!(
+            r#"[{{"name":"{VM}VMNic","resourceGroup":"{RG}","virtualMachine":{{"id":"{}"}}}},
+                 {{"name":"someone-elses-nic","resourceGroup":"{RG}",
+                   "virtualMachine":{{"id":"{}"}}}}]"#,
+            vm_id(VM),
+            vm_id("someone-elses-vm")
+        );
+        let nsgs = format!(
+            r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":null,
+                  "networkInterfaces":[{{"id":"{}"}},{{"id":"{}"}}],
+                  "tags":{{"azlin-session":"{SESSION}"}}}}]"#,
+            nic_id(&format!("{VM}VMNic")),
+            nic_id("someone-elses-nic")
+        );
+        let plan = plan_with(&d, &nics, &p, &nsgs);
+        assert!(plan.of_kind(TeardownKind::Nsg).is_empty());
+        assert!(plan
+            .skipped
+            .iter()
+            .any(|s| s.kind == TeardownKind::Nsg && s.reason == SkipReason::InUse));
+    }
+
+    /// A subnet association is shared infrastructure and always disqualifying,
+    /// even when the NIC side is entirely ours.
+    #[test]
+    fn nsg_bound_to_subnet_is_skipped() {
+        let (d, n, p, _) = full_inputs();
+        let nsgs = format!(
+            r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}",
+                  "subnets":[{{"id":"/subscriptions/s/resourceGroups/{RG}/providers/Microsoft.Network/virtualNetworks/v/subnets/default"}}],
+                  "networkInterfaces":[{{"id":"{}"}}],
+                  "tags":{{"azlin-session":"{SESSION}"}}}}]"#,
+            nic_id(&format!("{VM}VMNic"))
+        );
+        let plan = plan_with(&d, &n, &p, &nsgs);
+        assert!(plan.of_kind(TeardownKind::Nsg).is_empty());
+        assert!(plan
+            .skipped
+            .iter()
+            .any(|s| s.kind == TeardownKind::Nsg && s.reason == SkipReason::InUse));
+    }
+
+    // ── plan_recheck: the second pass that closes the leak ───────────────
+
+    fn skipped_nsg() -> Vec<SkippedResource> {
+        vec![SkippedResource {
+            name: format!("{VM}NSG"),
+            kind: TeardownKind::Nsg,
+            reason: SkipReason::InUse,
+        }]
+    }
+
+    /// The live failure, end to end: an NSG skipped as in-use, which the NIC
+    /// deletion then frees, must be picked up and deleted by the re-check.
+    #[test]
+    fn recheck_deletes_nsg_freed_by_nic_deletion() {
+        let nsgs = format!(
+            r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":null,
+                  "networkInterfaces":null,"tags":{{"azlin-session":"{SESSION}"}}}}]"#
+        );
+        let freed = plan_recheck(&skipped_nsg(), Some(SESSION), RG, "[]", &nsgs).unwrap();
+        assert_eq!(freed.len(), 1);
+        assert_eq!(freed[0].kind, TeardownKind::Nsg);
+        assert_eq!(freed[0].name, format!("{VM}NSG"));
+    }
+
+    /// The re-check must never widen ownership: an NSG that is now free but
+    /// belongs to another session stays untouched.
+    #[test]
+    fn recheck_ignores_other_sessions_nsg() {
+        let nsgs = format!(
+            r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":null,
+                  "networkInterfaces":null,"tags":{{"azlin-session":"someone-else"}}}}]"#
+        );
+        let freed = plan_recheck(&skipped_nsg(), Some(SESSION), RG, "[]", &nsgs).unwrap();
+        assert!(freed.is_empty());
+    }
+
+    /// Still genuinely associated after the NICs are gone — leave it alone.
+    #[test]
+    fn recheck_leaves_still_associated_nsg() {
+        let nsgs = format!(
+            r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":null,
+                  "networkInterfaces":[{{"id":"{}"}}],
+                  "tags":{{"azlin-session":"{SESSION}"}}}}]"#,
+            nic_id("someone-elses-nic")
+        );
+        let freed = plan_recheck(&skipped_nsg(), Some(SESSION), RG, "[]", &nsgs).unwrap();
+        assert!(freed.is_empty());
+    }
+
+    /// The re-check only ever revisits what the plan itself skipped as in-use;
+    /// an unrelated free NSG in the same group is not swept up.
+    #[test]
+    fn recheck_ignores_resources_not_in_the_plan() {
+        let nsgs = format!(
+            r#"[{{"name":"unrelated-nsg","resourceGroup":"{RG}","subnets":null,
+                  "networkInterfaces":null,"tags":{{"azlin-session":"{SESSION}"}}}}]"#
+        );
+        let freed = plan_recheck(&skipped_nsg(), Some(SESSION), RG, "[]", &nsgs).unwrap();
+        assert!(freed.is_empty());
+    }
+
+    /// Untagged skips are a different failure mode and must not be revisited.
+    #[test]
+    fn recheck_ignores_untagged_skips() {
+        let skipped = vec![SkippedResource {
+            name: format!("{VM}NSG"),
+            kind: TeardownKind::Nsg,
+            reason: SkipReason::Untagged,
+        }];
+        let nsgs = format!(
+            r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":null,
+                  "networkInterfaces":null,"tags":{{"azlin-session":"{SESSION}"}}}}]"#
+        );
+        let freed = plan_recheck(&skipped, Some(SESSION), RG, "[]", &nsgs).unwrap();
+        assert!(freed.is_empty());
+    }
+
+    /// The same second-pass guarantee applies to a Public IP.
+    #[test]
+    fn recheck_deletes_public_ip_freed_by_nic_deletion() {
+        let skipped = vec![SkippedResource {
+            name: format!("{VM}PublicIP"),
+            kind: TeardownKind::PublicIp,
+            reason: SkipReason::InUse,
+        }];
+        let pips = format!(
+            r#"[{{"name":"{VM}PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
+                  "tags":{{"azlin-session":"{SESSION}"}}}}]"#
+        );
+        let freed = plan_recheck(&skipped, Some(SESSION), RG, &pips, "[]").unwrap();
+        assert_eq!(freed.len(), 1);
+        assert_eq!(freed[0].kind, TeardownKind::PublicIp);
+    }
+
+    /// The plan carries the tag it matched on, so the re-check can apply the
+    /// identical ownership rule without re-deriving it.
+    #[test]
+    fn plan_retains_session_tag_for_recheck() {
+        assert_eq!(default_plan().session_tag.as_deref(), Some(SESSION));
     }
 }

--- a/rust/crates/azlin-azure/src/teardown.rs
+++ b/rust/crates/azlin-azure/src/teardown.rs
@@ -113,6 +113,10 @@ pub struct TeardownPlan {
     /// The `azlin-session` tag this plan matched on, retained so a follow-up
     /// re-check can apply the identical ownership rule.
     pub session_tag: Option<String>,
+    /// Exact resource names that prove ownership independently of the tag
+    /// value, retained so a follow-up re-check can apply the identical rule.
+    /// See [`TeardownInputs::also_match_by_name`].
+    pub also_match_by_name: Vec<String>,
 }
 
 impl TeardownPlan {
@@ -144,6 +148,26 @@ pub struct TeardownInputs<'a> {
     pub nic_json: &'a str,
     pub pip_json: &'a str,
     pub nsg_json: &'a str,
+    /// Exact resource names known to belong to this VM by Azure's own default
+    /// per-VM naming convention (`<vm>PublicIP`, `<vm>NSG`), used as a
+    /// fallback ownership signal that does not depend on `session_tag`
+    /// matching exactly.
+    ///
+    /// Needed because pooled sessions (`azlin new --name X --pool N`) stamp
+    /// *every* pool member's `azlin-session` tag with the pool's base name
+    /// `X`, not the member's own VM name (`X-1`, `X-2`, …; see
+    /// `resolve_session_identity`). When VM `X-1` no longer exists, its tag
+    /// cannot be read live, so `session_tag` can only be guessed — and
+    /// guessing `X-1` never equals the real tag `X`. Without this escape
+    /// hatch that guess-mismatch makes `classify` silently `Ignore` the
+    /// member's own orphaned Public IP/NSG (not even a warning), leaking it
+    /// forever. A resource is only ever matched this way if it also carries
+    /// *some* non-empty `azlin-session` tag — an untagged resource with a
+    /// coincidentally matching name is still never touched.
+    ///
+    /// Empty when the VM exists and its tag was read live: exact tag
+    /// equality is authoritative in that case and needs no name fallback.
+    pub also_match_by_name: &'a [String],
 }
 
 /// Extract the final segment of an Azure resource ID.
@@ -220,9 +244,11 @@ fn parse_list(json: &str, what: &str) -> Result<Vec<serde_json::Value>> {
 ///   (`managedBy` / `virtualMachine.id`), which is authoritative and needs no
 ///   tag.
 /// * **Public IPs and NSGs** are selected only when their `azlin-session` tag
-///   exactly equals the VM's. Untagged candidates are skipped and reported —
-///   ownership cannot be proven, and deleting them could destroy another
-///   session's resources.
+///   exactly equals the VM's, or — see `TeardownInputs::also_match_by_name`
+///   — when they are tagged for *some* azlin session and their own name is
+///   the Azure-default name for this exact VM. Untagged candidates are
+///   skipped and reported — ownership cannot be proven, and deleting them
+///   could destroy another session's resources.
 /// * A Public IP or NSG still bound to something *outside* this teardown is
 ///   skipped as in-use. Being bound to this VM's own NIC does not disqualify
 ///   it, since that NIC is deleted first.
@@ -233,6 +259,7 @@ pub fn plan_teardown(inputs: &TeardownInputs) -> Result<TeardownPlan> {
     let mut plan = TeardownPlan {
         vm_exists: inputs.vm_exists,
         session_tag: inputs.session_tag.map(str::to_string),
+        also_match_by_name: inputs.also_match_by_name.to_vec(),
         ..Default::default()
     };
 
@@ -318,8 +345,9 @@ pub fn plan_teardown(inputs: &TeardownInputs) -> Result<TeardownPlan> {
                 .and_then(|id| id.rsplit_once("/ipConfigurations/").map(|(nic, _)| nic))
                 .map(|nic_id| bound_only_to_target_nics(&[nic_id]))
                 .unwrap_or(false);
+        let name_hint = inputs.also_match_by_name.iter().any(|n| n == name);
 
-        match classify(session_tag_of(&ip), inputs.session_tag, free) {
+        match classify(session_tag_of(&ip), inputs.session_tag, free, name_hint) {
             Candidate::Delete => plan.resources.push(TeardownResource {
                 name: name.to_string(),
                 kind: TeardownKind::PublicIp,
@@ -357,8 +385,9 @@ pub fn plan_teardown(inputs: &TeardownInputs) -> Result<TeardownPlan> {
             .unwrap_or_default();
         let free = !subnet_bound
             && (nsg_is_unassociated(&nsg) || bound_only_to_target_nics(&nic_ids));
+        let name_hint = inputs.also_match_by_name.iter().any(|n| n == name);
 
-        match classify(session_tag_of(&nsg), inputs.session_tag, free) {
+        match classify(session_tag_of(&nsg), inputs.session_tag, free, name_hint) {
             Candidate::Delete => plan.resources.push(TeardownResource {
                 name: name.to_string(),
                 kind: TeardownKind::Nsg,
@@ -410,11 +439,19 @@ pub fn plan_recheck(
     resource_group: &str,
     pip_json: &str,
     nsg_json: &str,
+    also_match_by_name: &[String],
 ) -> Result<Vec<TeardownResource>> {
     let was_skipped_in_use = |name: &str, kind: TeardownKind| {
         skipped
             .iter()
             .any(|s| s.name == name && s.kind == kind && s.reason == SkipReason::InUse)
+    };
+    // Same ownership rule as the first pass: an exact tag match, or a
+    // resource that is tagged for *some* azlin session and whose own name
+    // proves it belongs to this VM (see `TeardownInputs::also_match_by_name`).
+    let is_owned = |resource_tag: Option<&str>, name: &str| {
+        resource_tag == session_tag
+            || (resource_tag.is_some() && also_match_by_name.iter().any(|n| n == name))
     };
 
     let mut freed = Vec::new();
@@ -426,7 +463,7 @@ pub fn plan_recheck(
         if !was_skipped_in_use(name, TeardownKind::PublicIp) {
             continue;
         }
-        if session_tag_of(&ip) != session_tag || !public_ip_is_unassociated(&ip) {
+        if !is_owned(session_tag_of(&ip), name) || !public_ip_is_unassociated(&ip) {
             continue;
         }
         freed.push(TeardownResource {
@@ -444,7 +481,7 @@ pub fn plan_recheck(
         if !was_skipped_in_use(name, TeardownKind::Nsg) {
             continue;
         }
-        if session_tag_of(&nsg) != session_tag || !nsg_is_unassociated(&nsg) {
+        if !is_owned(session_tag_of(&nsg), name) || !nsg_is_unassociated(&nsg) {
             continue;
         }
         freed.push(TeardownResource {
@@ -465,13 +502,32 @@ pub fn plan_recheck(
 /// tag exactly equals the target session's. Exact equality means a
 /// prefix-adjacent sibling session (`copilot-test-…` vs `copilot-test2-…`)
 /// can never be matched by accident.
+///
+/// `name_hint` is a narrow escape hatch for `also_match_by_name`: when true,
+/// the resource's own name has already been proven (by the caller) to be the
+/// Azure-default name for *this exact* VM, so a mismatched tag value no
+/// longer disqualifies it — only used for the pooled-session case where the
+/// real tag can differ from any single member's VM name. A resource still
+/// needs *some* `azlin-session` tag to be eligible; `name_hint` never
+/// overrides the untagged case.
 fn classify(
     resource_tag: Option<&str>,
     target_session: Option<&str>,
     is_free: bool,
+    name_hint: bool,
 ) -> Candidate {
     match (resource_tag, target_session) {
         (Some(tag), Some(target)) if tag == target => {
+            if is_free {
+                Candidate::Delete
+            } else {
+                Candidate::Skip(SkipReason::InUse)
+            }
+        }
+        // Tag didn't match exactly, but the resource's own name proves it
+        // belongs to this VM (e.g. a pool member whose `azlin-session` tag is
+        // the pool's base name, not its own VM name).
+        (Some(_), _) if name_hint => {
             if is_free {
                 Candidate::Delete
             } else {
@@ -579,6 +635,7 @@ mod tests {
             nic_json: nics,
             pip_json: pips,
             nsg_json: nsgs,
+            also_match_by_name: &[],
         })
         .unwrap()
     }
@@ -813,6 +870,7 @@ mod tests {
             nic_json: &n,
             pip_json: &p,
             nsg_json: &g,
+            also_match_by_name: &[],
         })
         .unwrap();
         assert!(plan.of_kind(TeardownKind::PublicIp).is_empty());
@@ -858,6 +916,7 @@ mod tests {
             nic_json: "[]",
             pip_json: &pips,
             nsg_json: "[]",
+            also_match_by_name: &[],
         })
         .unwrap();
         assert!(!plan.vm_exists);
@@ -886,6 +945,7 @@ mod tests {
             nic_json: "[]",
             pip_json: "[]",
             nsg_json: "[]",
+            also_match_by_name: &[],
         })
         .is_err());
     }
@@ -978,6 +1038,7 @@ mod tests {
             }],
             vm_exists: true,
             session_tag: Some(SESSION.to_string()),
+            also_match_by_name: Vec::new(),
         };
         let out = format_teardown_plan(&plan, VM, RG);
         assert!(out.contains("Not deleted"));
@@ -1091,7 +1152,7 @@ mod tests {
             r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":null,
                   "networkInterfaces":null,"tags":{{"azlin-session":"{SESSION}"}}}}]"#
         );
-        let freed = plan_recheck(&skipped_nsg(), Some(SESSION), RG, "[]", &nsgs).unwrap();
+        let freed = plan_recheck(&skipped_nsg(), Some(SESSION), RG, "[]", &nsgs, &[]).unwrap();
         assert_eq!(freed.len(), 1);
         assert_eq!(freed[0].kind, TeardownKind::Nsg);
         assert_eq!(freed[0].name, format!("{VM}NSG"));
@@ -1105,7 +1166,7 @@ mod tests {
             r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":null,
                   "networkInterfaces":null,"tags":{{"azlin-session":"someone-else"}}}}]"#
         );
-        let freed = plan_recheck(&skipped_nsg(), Some(SESSION), RG, "[]", &nsgs).unwrap();
+        let freed = plan_recheck(&skipped_nsg(), Some(SESSION), RG, "[]", &nsgs, &[]).unwrap();
         assert!(freed.is_empty());
     }
 
@@ -1118,7 +1179,7 @@ mod tests {
                   "tags":{{"azlin-session":"{SESSION}"}}}}]"#,
             nic_id("someone-elses-nic")
         );
-        let freed = plan_recheck(&skipped_nsg(), Some(SESSION), RG, "[]", &nsgs).unwrap();
+        let freed = plan_recheck(&skipped_nsg(), Some(SESSION), RG, "[]", &nsgs, &[]).unwrap();
         assert!(freed.is_empty());
     }
 
@@ -1130,7 +1191,7 @@ mod tests {
             r#"[{{"name":"unrelated-nsg","resourceGroup":"{RG}","subnets":null,
                   "networkInterfaces":null,"tags":{{"azlin-session":"{SESSION}"}}}}]"#
         );
-        let freed = plan_recheck(&skipped_nsg(), Some(SESSION), RG, "[]", &nsgs).unwrap();
+        let freed = plan_recheck(&skipped_nsg(), Some(SESSION), RG, "[]", &nsgs, &[]).unwrap();
         assert!(freed.is_empty());
     }
 
@@ -1146,7 +1207,7 @@ mod tests {
             r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":null,
                   "networkInterfaces":null,"tags":{{"azlin-session":"{SESSION}"}}}}]"#
         );
-        let freed = plan_recheck(&skipped, Some(SESSION), RG, "[]", &nsgs).unwrap();
+        let freed = plan_recheck(&skipped, Some(SESSION), RG, "[]", &nsgs, &[]).unwrap();
         assert!(freed.is_empty());
     }
 
@@ -1162,7 +1223,7 @@ mod tests {
             r#"[{{"name":"{VM}PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
                   "tags":{{"azlin-session":"{SESSION}"}}}}]"#
         );
-        let freed = plan_recheck(&skipped, Some(SESSION), RG, &pips, "[]").unwrap();
+        let freed = plan_recheck(&skipped, Some(SESSION), RG, &pips, "[]", &[]).unwrap();
         assert_eq!(freed.len(), 1);
         assert_eq!(freed[0].kind, TeardownKind::PublicIp);
     }
@@ -1172,5 +1233,136 @@ mod tests {
     #[test]
     fn plan_retains_session_tag_for_recheck() {
         assert_eq!(default_plan().session_tag.as_deref(), Some(SESSION));
+    }
+
+    // ── Pooled sessions: name-hint fallback when the VM is already gone ──
+    //
+    // `azlin new --name my-dev-pool --pool 3` tags every member's Public IP
+    // and NSG with `azlin-session=my-dev-pool` — the pool's base name, not
+    // the member's own VM name (`my-dev-pool-1`, `my-dev-pool-2`, ...). See
+    // `resolve_session_identity` in `azlin/src/create_helpers.rs`. When a
+    // pool member's VM has already been deleted, its true tag cannot be read
+    // live, so the caller can only *guess* `session_tag = vm_name` — which
+    // never equals the real pool tag. `also_match_by_name` is the escape
+    // hatch that recovers ownership from the resource's own Azure-default
+    // name instead.
+
+    const POOL_VM: &str = "my-dev-pool-1";
+    const POOL_TAG: &str = "my-dev-pool";
+
+    #[test]
+    fn pool_member_orphan_is_recovered_by_name_hint_when_vm_absent_and_tag_mismatches() {
+        let pips = format!(
+            r#"[{{"name":"{POOL_VM}PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
+                  "tags":{{"azlin-session":"{POOL_TAG}"}}}}]"#
+        );
+        let nsgs = format!(
+            r#"[{{"name":"{POOL_VM}NSG","resourceGroup":"{RG}","subnets":[],
+                  "networkInterfaces":[],"tags":{{"azlin-session":"{POOL_TAG}"}}}}]"#
+        );
+        let hints = vec![format!("{POOL_VM}PublicIP"), format!("{POOL_VM}NSG")];
+        let plan = plan_teardown(&TeardownInputs {
+            vm_name: POOL_VM,
+            resource_group: RG,
+            // The caller's best guess once the VM is gone: never equal to the
+            // real pool tag `POOL_TAG`.
+            session_tag: Some(POOL_VM),
+            vm_exists: false,
+            disk_json: "[]",
+            nic_json: "[]",
+            pip_json: &pips,
+            nsg_json: &nsgs,
+            also_match_by_name: &hints,
+        })
+        .unwrap();
+        assert_eq!(
+            plan.of_kind(TeardownKind::PublicIp).len(),
+            1,
+            "the pool member's own public IP must be recovered despite the tag mismatch"
+        );
+        assert_eq!(
+            plan.of_kind(TeardownKind::Nsg).len(),
+            1,
+            "the pool member's own NSG must be recovered despite the tag mismatch"
+        );
+        assert!(
+            plan.skipped.is_empty(),
+            "a correctly name-matched, free resource is deleted outright, not warned about"
+        );
+    }
+
+    #[test]
+    fn pool_sibling_is_not_matched_by_another_members_name_hint() {
+        // `my-dev-pool-2` shares the same `azlin-session` tag as `my-dev-pool-1`
+        // (both are members of the same pool), but its resources are outside
+        // this teardown's `also_match_by_name` hints, which only ever name
+        // `my-dev-pool-1`'s own resources.
+        let pips = format!(
+            r#"[{{"name":"my-dev-pool-2PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
+                  "tags":{{"azlin-session":"{POOL_TAG}"}}}}]"#
+        );
+        let hints = vec![format!("{POOL_VM}PublicIP"), format!("{POOL_VM}NSG")];
+        let plan = plan_teardown(&TeardownInputs {
+            vm_name: POOL_VM,
+            resource_group: RG,
+            session_tag: Some(POOL_VM),
+            vm_exists: false,
+            disk_json: "[]",
+            nic_json: "[]",
+            pip_json: &pips,
+            nsg_json: "[]",
+            also_match_by_name: &hints,
+        })
+        .unwrap();
+        assert!(
+            plan.of_kind(TeardownKind::PublicIp).is_empty(),
+            "a sibling pool member's public IP must never be swept up"
+        );
+        assert!(plan.skipped.is_empty());
+    }
+
+    #[test]
+    fn name_hint_does_not_rescue_a_genuinely_untagged_resource() {
+        // A coincidentally-named, hand-made resource with no azlin tag at
+        // all must stay conservative: reported, never deleted.
+        let pips = format!(
+            r#"[{{"name":"{POOL_VM}PublicIP","resourceGroup":"{RG}","ipConfiguration":null}}]"#
+        );
+        let hints = vec![format!("{POOL_VM}PublicIP")];
+        let plan = plan_teardown(&TeardownInputs {
+            vm_name: POOL_VM,
+            resource_group: RG,
+            session_tag: Some(POOL_VM),
+            vm_exists: false,
+            disk_json: "[]",
+            nic_json: "[]",
+            pip_json: &pips,
+            nsg_json: "[]",
+            also_match_by_name: &hints,
+        })
+        .unwrap();
+        assert!(
+            plan.of_kind(TeardownKind::PublicIp).is_empty(),
+            "name alone is not proof of azlin ownership"
+        );
+        assert_eq!(plan.skipped[0].reason, SkipReason::Untagged);
+    }
+
+    #[test]
+    fn recheck_deletes_pool_member_nsg_via_name_hint_despite_tag_mismatch() {
+        let skipped = vec![SkippedResource {
+            name: format!("{POOL_VM}NSG"),
+            kind: TeardownKind::Nsg,
+            reason: SkipReason::InUse,
+        }];
+        let nsgs = format!(
+            r#"[{{"name":"{POOL_VM}NSG","resourceGroup":"{RG}","subnets":null,
+                  "networkInterfaces":null,"tags":{{"azlin-session":"{POOL_TAG}"}}}}]"#
+        );
+        let hints = vec![format!("{POOL_VM}NSG")];
+        let freed =
+            plan_recheck(&skipped, Some(POOL_VM), RG, "[]", &nsgs, &hints).unwrap();
+        assert_eq!(freed.len(), 1);
+        assert_eq!(freed[0].name, format!("{POOL_VM}NSG"));
     }
 }

--- a/rust/crates/azlin-azure/src/vm.rs
+++ b/rust/crates/azlin-azure/src/vm.rs
@@ -374,6 +374,123 @@ impl VmManager {
         Ok(vm.tags)
     }
 
+    // ── Network teardown operations ────────────────────────────────────
+    //
+    // `az vm delete` removes only the VM; disks and the NIC follow because
+    // `az vm create` sets their `deleteOption` to `Delete`. Public IPs and
+    // NSGs have no such implicit delete, so they must be enumerated and
+    // removed explicitly or they leak and keep billing.
+
+    /// List all managed disks in a resource group (raw JSON).
+    pub fn list_disks_json(&self, resource_group: &str) -> Result<String> {
+        az_cli_with_timeout(
+            &["disk", "list", "--resource-group", resource_group],
+            self.az_cli_timeout,
+        )
+    }
+
+    /// List all NICs in a resource group (raw JSON).
+    pub fn list_nics_json(&self, resource_group: &str) -> Result<String> {
+        az_cli_with_timeout(
+            &["network", "nic", "list", "--resource-group", resource_group],
+            self.az_cli_timeout,
+        )
+    }
+
+    /// List all public IPs in a resource group (raw JSON).
+    pub fn list_public_ips_json(&self, resource_group: &str) -> Result<String> {
+        az_cli_with_timeout(
+            &[
+                "network",
+                "public-ip",
+                "list",
+                "--resource-group",
+                resource_group,
+            ],
+            self.az_cli_timeout,
+        )
+    }
+
+    /// List all network security groups in a resource group (raw JSON).
+    pub fn list_nsgs_json(&self, resource_group: &str) -> Result<String> {
+        az_cli_with_timeout(
+            &["network", "nsg", "list", "--resource-group", resource_group],
+            self.az_cli_timeout,
+        )
+    }
+
+    /// Delete a managed disk. Succeeds if the disk is already gone.
+    pub fn delete_disk(&self, resource_group: &str, name: &str) -> Result<()> {
+        debug!(resource_group, name, "Deleting disk");
+        tolerate_missing(az_cli_with_timeout(
+            &[
+                "disk",
+                "delete",
+                "--resource-group",
+                resource_group,
+                "--name",
+                name,
+                "--yes",
+            ],
+            self.az_cli_timeout,
+        ))
+    }
+
+    /// Delete a NIC, waiting for completion. Succeeds if already gone.
+    ///
+    /// This deliberately does **not** use `--no-wait`: the NIC must be fully
+    /// released before its Public IP and NSG can be deleted, or Azure rejects
+    /// those deletes as in-use.
+    pub fn delete_nic(&self, resource_group: &str, name: &str) -> Result<()> {
+        debug!(resource_group, name, "Deleting NIC");
+        tolerate_missing(az_cli_with_timeout(
+            &[
+                "network",
+                "nic",
+                "delete",
+                "--resource-group",
+                resource_group,
+                "--name",
+                name,
+            ],
+            self.az_cli_timeout,
+        ))
+    }
+
+    /// Delete a public IP address. Succeeds if already gone.
+    pub fn delete_public_ip(&self, resource_group: &str, name: &str) -> Result<()> {
+        debug!(resource_group, name, "Deleting public IP");
+        tolerate_missing(az_cli_with_timeout(
+            &[
+                "network",
+                "public-ip",
+                "delete",
+                "--resource-group",
+                resource_group,
+                "--name",
+                name,
+            ],
+            self.az_cli_timeout,
+        ))
+    }
+
+    /// Delete a network security group. Succeeds if already gone.
+    pub fn delete_nsg(&self, resource_group: &str, name: &str) -> Result<()> {
+        debug!(resource_group, name, "Deleting NSG");
+        tolerate_missing(az_cli_with_timeout(
+            &[
+                "network",
+                "nsg",
+                "delete",
+                "--resource-group",
+                resource_group,
+                "--name",
+                name,
+            ],
+            self.az_cli_timeout,
+        ))
+    }
+
     // ── Provisioning ───────────────────────────────────────────────────
 
     /// Provision a new VM, letting `az vm create` handle networking automatically.
@@ -615,6 +732,35 @@ fn az_cli(args: &[&str]) -> Result<String> {
     az_cli_with_timeout(args, AZ_CLI_DEFAULT_TIMEOUT_SECS)
 }
 
+/// Whether an `az` CLI error means "the resource does not exist".
+///
+/// Teardown must be idempotent: re-running it after a partial failure, or
+/// deleting a resource Azure already removed implicitly, must not abort the
+/// rest of the sequence.
+pub fn is_resource_not_found(message: &str) -> bool {
+    let m = message.to_ascii_lowercase();
+    m.contains("resourcenotfound")
+        || m.contains("notfound")
+        || m.contains("not found")
+        || m.contains("could not be found")
+        || m.contains("does not exist")
+        || m.contains("was not found")
+        || m.contains("(404)")
+        || m.contains("status code: 404")
+}
+
+/// Swallow "already deleted" failures so teardown stays idempotent.
+fn tolerate_missing(result: Result<String>) -> Result<()> {
+    match result {
+        Ok(_) => Ok(()),
+        Err(e) if is_resource_not_found(&e.to_string()) => {
+            debug!(error = %e, "Resource already absent — treating delete as success");
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
 /// Run an `az` CLI command with an explicit timeout in seconds.
 pub fn az_cli_with_timeout(args: &[&str], timeout_secs: u64) -> Result<String> {
     debug!(args = ?args, "Running az CLI command");
@@ -741,6 +887,51 @@ fn parse_created_time(time_str: Option<&str>) -> Option<chrono::DateTime<chrono:
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Resource-not-found detection ────────────────────────────────
+    //
+    // Teardown must be idempotent: deleting a resource Azure has already
+    // removed must not abort the rest of the sequence and re-leak the
+    // resources that come after it.
+
+    #[test]
+    fn test_is_resource_not_found_matches_azure_phrasings() {
+        for msg in [
+            "ERROR: (ResourceNotFound) The Resource 'Microsoft.Network/publicIPAddresses/vm1PublicIP' was not found.",
+            "az CLI failed: ResourceNotFound",
+            "Operation returned an invalid status code: 404",
+            "The Resource could not be found.",
+            "does not exist",
+            "(404) Not Found",
+        ] {
+            assert!(is_resource_not_found(msg), "should tolerate: {msg}");
+        }
+    }
+
+    #[test]
+    fn test_is_resource_not_found_ignores_real_failures() {
+        for msg in [
+            "az CLI failed: AuthorizationFailed",
+            "OperationNotAllowed: quota exceeded",
+            "(Conflict) resource is in use by another resource",
+            "NetworkError: connection timed out",
+        ] {
+            assert!(!is_resource_not_found(msg), "should not swallow: {msg}");
+        }
+    }
+
+    #[test]
+    fn test_tolerate_missing_swallows_404_but_not_other_errors() {
+        assert!(tolerate_missing(Ok(String::new())).is_ok());
+        assert!(tolerate_missing(Err(anyhow::anyhow!(
+            "ERROR: (ResourceNotFound) was not found"
+        )))
+        .is_ok());
+        assert!(tolerate_missing(Err(anyhow::anyhow!(
+            "ERROR: (AuthorizationFailed) forbidden"
+        )))
+        .is_err());
+    }
 
     // ── parse_az_power_state tests ──────────────────────────────────
 

--- a/rust/crates/azlin/src/cmd_cleanup_ops.rs
+++ b/rust/crates/azlin/src/cmd_cleanup_ops.rs
@@ -68,16 +68,15 @@ pub(crate) fn handle_cleanup(
     }
 
     // 3) Orphaned public IPs
+    //
+    // Shares `public_ip_is_unassociated` with the teardown planner so the two
+    // paths cannot drift apart.
     let pip_json = az_list(&["network", "public-ip", "list"])
         .context("Failed to list public IPs for orphan detection")?;
     let ips: Vec<serde_json::Value> =
         serde_json::from_str(&pip_json).context("Failed to parse public IP list JSON")?;
     for ip in &ips {
-        let attached = ip
-            .get("ipConfiguration")
-            .map(|v| !v.is_null())
-            .unwrap_or(false);
-        if !attached {
+        if azlin_azure::teardown::public_ip_is_unassociated(ip) {
             if let Some(name) = ip.get("name").and_then(|n| n.as_str()) {
                 let ip_rg = ip
                     .get("resourceGroup")
@@ -94,22 +93,14 @@ pub(crate) fn handle_cleanup(
     }
 
     // 4) Orphaned NSGs
+    //
+    // Shares `nsg_is_unassociated` with the teardown planner.
     let nsg_json =
         az_list(&["network", "nsg", "list"]).context("Failed to list NSGs for orphan detection")?;
     let nsgs: Vec<serde_json::Value> =
         serde_json::from_str(&nsg_json).context("Failed to parse NSG list JSON")?;
     for nsg in &nsgs {
-        let has_nics = nsg
-            .get("networkInterfaces")
-            .and_then(|v| v.as_array())
-            .map(|a| !a.is_empty())
-            .unwrap_or(false);
-        let has_subnets = nsg
-            .get("subnets")
-            .and_then(|v| v.as_array())
-            .map(|a| !a.is_empty())
-            .unwrap_or(false);
-        if !has_nics && !has_subnets {
+        if azlin_azure::teardown::nsg_is_unassociated(nsg) {
             if let Some(name) = nsg.get("name").and_then(|n| n.as_str()) {
                 let nsg_rg = nsg
                     .get("resourceGroup")

--- a/rust/crates/azlin/src/cmd_lifecycle.rs
+++ b/rust/crates/azlin/src/cmd_lifecycle.rs
@@ -106,12 +106,31 @@ pub(crate) async fn dispatch(
             resource_group,
             force,
             dry_run,
+            delete_rg,
             ..
         } => {
             let rg = resolve_resource_group(resource_group)?;
 
+            // `--delete-rg` was previously accepted and silently ignored.
+            // Honouring it is genuinely dangerous: resource groups routinely
+            // hold hand-made VMs, VNets and IPs alongside azlin sessions, so
+            // deleting the group would destroy unrelated user data. Reject it
+            // explicitly and point at the targeted alternative.
+            if delete_rg {
+                anyhow::bail!(
+                    "{}",
+                    crate::lifecycle_helpers::delete_rg_rejected_message(&rg)
+                );
+            }
+
+            let auth = create_auth()?;
+            let vm_manager = azlin_azure::VmManager::new(&auth);
+
             if dry_run {
-                println!("{}", crate::handlers::format_destroy_dry_run(&vm_name, &rg));
+                print!(
+                    "{}",
+                    crate::handlers::format_destroy_dry_run_live(&vm_manager, &rg, &vm_name)?
+                );
                 return Ok(());
             }
 
@@ -123,9 +142,6 @@ pub(crate) async fn dispatch(
                 return Ok(());
             }
 
-            let auth = create_auth()?;
-            let vm_manager = azlin_azure::VmManager::new(&auth);
-
             let pb = ProgressBar::new_spinner();
             pb.set_style(fleet_spinner_style());
             pb.set_prefix(format!("{:>20}", vm_name));
@@ -134,8 +150,9 @@ pub(crate) async fn dispatch(
                 &vm_name,
             ));
             pb.enable_steady_tick(std::time::Duration::from_millis(120));
-            crate::handlers::handle_delete(&vm_manager, &rg, &vm_name)?;
+            let msg = crate::handlers::handle_delete(&vm_manager, &rg, &vm_name)?;
             pb.finish_with_message(crate::lifecycle_helpers::destroyed_message(&vm_name));
+            println!("{msg}");
         }
         azlin_cli::Commands::Killall {
             resource_group,
@@ -161,41 +178,45 @@ pub(crate) async fn dispatch(
             let args = crate::lifecycle_helpers::killall_list_args(&rg, &query);
             let output = std::process::Command::new("az").args(&args).output()?;
 
-            if output.status.success() {
-                let ids_raw = String::from_utf8_lossy(&output.stdout);
-                let id_list = crate::lifecycle_helpers::parse_vm_ids(&ids_raw);
-                if id_list.is_empty() {
-                    pb.finish_and_clear();
-                    println!(
-                        "{}",
-                        crate::lifecycle_helpers::killall_empty_message(&prefix)
-                    );
-                } else {
-                    let del = std::process::Command::new("az")
-                        .args(["vm", "delete", "--ids"])
-                        .args(&id_list)
-                        .args(["--yes"])
-                        .output()?;
-                    pb.finish_and_clear();
-                    if del.status.success() {
-                        println!(
-                            "{}",
-                            crate::lifecycle_helpers::killall_success_message(
-                                id_list.len(),
-                                &prefix
-                            )
-                        );
-                    } else {
-                        let stderr = String::from_utf8_lossy(&del.stderr);
-                        anyhow::bail!(
-                            "Failed to delete VMs: {}",
-                            azlin_core::sanitizer::sanitize(stderr.trim())
-                        );
-                    }
-                }
-            } else {
+            if !output.status.success() {
                 pb.finish_and_clear();
                 anyhow::bail!("Failed to list VMs.");
+            }
+
+            let names_raw = String::from_utf8_lossy(&output.stdout);
+            let names = crate::lifecycle_helpers::parse_vm_ids(&names_raw);
+            if names.is_empty() {
+                pb.finish_and_clear();
+                println!(
+                    "{}",
+                    crate::lifecycle_helpers::killall_empty_message(&prefix)
+                );
+            } else {
+                // Tear each VM down individually rather than batching
+                // `az vm delete --ids`. The batch form deletes only the VMs
+                // and leaves every public IP and NSG behind — the same leak
+                // this command previously shared with destroy/delete/kill.
+                let auth = create_auth()?;
+                let vm_manager = azlin_azure::VmManager::new(&auth);
+                let mut messages = Vec::new();
+                let mut failures = Vec::new();
+                for name in &names {
+                    match crate::handlers::handle_delete(&vm_manager, &rg, name) {
+                        Ok(msg) => messages.push(msg),
+                        Err(e) => failures.push(format!("{name}: {e}")),
+                    }
+                }
+                pb.finish_and_clear();
+                for msg in &messages {
+                    println!("{msg}");
+                }
+                if !failures.is_empty() {
+                    anyhow::bail!("Failed to delete VMs:\n  {}", failures.join("\n  "));
+                }
+                println!(
+                    "{}",
+                    crate::lifecycle_helpers::killall_success_message(messages.len(), &prefix)
+                );
             }
         }
 

--- a/rust/crates/azlin/src/handlers/connect.rs
+++ b/rust/crates/azlin/src/handlers/connect.rs
@@ -120,16 +120,6 @@ pub fn resolve_os_update_target(
     Ok((ip, user))
 }
 
-// ── Destroy handler (dry-run) ───────────────────────────────────────────
-
-/// Format the dry-run output for destroy.
-pub fn format_destroy_dry_run(vm_name: &str, resource_group: &str) -> String {
-    format!(
-        "Dry run -- would delete:\n  VM: {}\n  Resource group: {}",
-        vm_name, resource_group
-    )
-}
-
 // ── Code handler (resolve target) ───────────────────────────────────────
 
 /// Resolve the target for VS Code remote connection. Returns (ip, username).

--- a/rust/crates/azlin/src/handlers/mod.rs
+++ b/rust/crates/azlin/src/handlers/mod.rs
@@ -28,9 +28,13 @@ mod show;
 mod snapshot;
 mod storage;
 mod tags;
+mod teardown;
 
 pub use autopilot::*;
 pub use cleanup::*;
+// Consumed by the handler tests via the module glob; the binary reaches
+// connect's helpers through `create_helpers` instead.
+#[allow(unused_imports)]
 pub use connect::*;
 pub use context::*;
 pub use costs::*;
@@ -40,6 +44,7 @@ pub use show::*;
 pub use snapshot::*;
 pub use storage::*;
 pub use tags::*;
+pub use teardown::*;
 
 // Re-exported for test modules only (handler functions used in test assertions)
 #[allow(unused_imports)]

--- a/rust/crates/azlin/src/handlers/show.rs
+++ b/rust/crates/azlin/src/handlers/show.rs
@@ -120,7 +120,10 @@ pub fn handle_stop(
 // ── Delete handler ──────────────────────────────────────────────────────
 
 /// Execute the delete command (after confirmation has been obtained).
+///
+/// Deletes the VM **and** every resource that belongs to its session,
+/// including the Public IP and NSG that `az vm delete` leaves behind. See
+/// [`crate::handlers::teardown`] for the selection and ordering rules.
 pub fn handle_delete(ops: &dyn AzureOps, resource_group: &str, vm_name: &str) -> Result<String> {
-    ops.delete_vm(resource_group, vm_name)?;
-    Ok(format!("Deleted {}", vm_name))
+    crate::handlers::execute_teardown(ops, resource_group, vm_name)
 }

--- a/rust/crates/azlin/src/handlers/teardown.rs
+++ b/rust/crates/azlin/src/handlers/teardown.rs
@@ -28,18 +28,31 @@ pub fn build_teardown_plan(
     // partially-completed teardown, which is exactly the leak scenario.
     let vm = ops.get_vm(resource_group, vm_name).ok();
     let vm_exists = vm.is_some();
-    let session_tag = match vm.as_ref() {
-        Some(vm) => vm
-            .tags
-            .get(SESSION_TAG_KEY)
-            .filter(|s| !s.is_empty())
-            .cloned(),
+    let (session_tag, name_hints): (Option<String>, Vec<String>) = match vm.as_ref() {
+        Some(vm) => (
+            vm.tags
+                .get(SESSION_TAG_KEY)
+                .filter(|s| !s.is_empty())
+                .cloned(),
+            Vec::new(),
+        ),
         // The VM is already gone, so its tag cannot be read — but its Public
-        // IP and NSG may still be orphaned and billing. `az vm create` stamps
-        // `azlin-session` with the session name, which is the VM name, so fall
-        // back to that. Matching stays exact tag equality, so a prefix-adjacent
-        // sibling session can still never be matched.
-        None => Some(vm_name.to_string()),
+        // IP and NSG may still be orphaned and billing. For a single VM
+        // (not part of a pool), `azlin-session` is stamped with the VM's own
+        // name, so guessing that as the tag is usually right. But pooled
+        // sessions (`azlin new --name X --pool N`) stamp every member's tag
+        // with the pool's base name `X`, not the member's own name (`X-1`,
+        // `X-2`, ...; see `resolve_session_identity` in `create_helpers.rs`).
+        // For those, this guess never matches the real tag, and tag-only
+        // matching would silently leak the member's own Public IP/NSG
+        // forever with no warning. `also_match_by_name` closes that gap: a
+        // resource still needs *some* azlin-session tag, but no longer needs
+        // it to equal this guess, as long as its own name is the
+        // Azure-default name for exactly this VM.
+        None => (
+            Some(vm_name.to_string()),
+            vec![format!("{vm_name}PublicIP"), format!("{vm_name}NSG")],
+        ),
     };
 
     let disk_json = ops
@@ -64,6 +77,7 @@ pub fn build_teardown_plan(
         nic_json: &nic_json,
         pip_json: &pip_json,
         nsg_json: &nsg_json,
+        also_match_by_name: &name_hints,
     })
 }
 
@@ -147,8 +161,19 @@ pub fn execute_teardown(ops: &dyn AzureOps, resource_group: &str, vm_name: &str)
         );
     }
 
+    // The VM itself is only ever in the plan when it still existed at
+    // discovery time — e.g. re-running destroy to mop up a pool member's
+    // leftover Public IP/NSG after its VM is already gone has no `Vm` entry
+    // at all. Subtracting 1 unconditionally would then undercount every
+    // associated resource actually deleted.
+    let had_vm = plan.resources.iter().any(|r| r.kind == TeardownKind::Vm);
+    let associated = if had_vm { deleted.saturating_sub(1) } else { deleted };
     let savings = plan.estimated_monthly_savings();
-    let mut msg = format!("Deleted {vm_name} and {} associated resource(s)", deleted - 1);
+    let mut msg = if had_vm {
+        format!("Deleted {vm_name} and {associated} associated resource(s)")
+    } else {
+        format!("VM '{vm_name}' was already gone; reclaimed {associated} orphaned resource(s)")
+    };
     if savings > 0.0 {
         msg.push_str(&format!(" (~${savings:.2}/month reclaimed)"));
     }
@@ -205,6 +230,7 @@ fn recheck_freed_resources(
         resource_group,
         &pip_json,
         &nsg_json,
+        &plan.also_match_by_name,
     )
     .unwrap_or_default()
 }

--- a/rust/crates/azlin/src/handlers/teardown.rs
+++ b/rust/crates/azlin/src/handlers/teardown.rs
@@ -11,8 +11,8 @@
 
 use anyhow::{Context, Result};
 use azlin_azure::teardown::{
-    format_teardown_plan, plan_teardown, TeardownKind, TeardownInputs, TeardownPlan,
-    SESSION_TAG_KEY,
+    format_teardown_plan, plan_recheck, plan_teardown, SkipReason, TeardownInputs, TeardownKind,
+    TeardownPlan, TeardownResource, SESSION_TAG_KEY,
 };
 use azlin_azure::AzureOps;
 
@@ -87,7 +87,7 @@ pub fn format_destroy_dry_run_live(
 /// resource cannot strand the rest and re-leak them. Deletes are 404-tolerant,
 /// making the whole operation idempotent and safe to re-run.
 pub fn execute_teardown(ops: &dyn AzureOps, resource_group: &str, vm_name: &str) -> Result<String> {
-    let plan = build_teardown_plan(ops, resource_group, vm_name)?;
+    let mut plan = build_teardown_plan(ops, resource_group, vm_name)?;
 
     if plan.resources.is_empty() {
         let mut msg = if plan.vm_exists {
@@ -115,6 +115,26 @@ pub fn execute_teardown(ops: &dyn AzureOps, resource_group: &str, vm_name: &str)
             Err(e) => failures.push(format!("{} '{}': {}", r.kind, r.name, e)),
         }
     }
+
+    // Anything skipped as in-use was judged against a snapshot taken before a
+    // single resource was deleted. Now that the NICs are gone, re-read Azure
+    // and delete whatever is provably free — otherwise a Public IP or NSG that
+    // was merely held by this session's own NIC leaks and bills forever.
+    let recheck = recheck_freed_resources(ops, resource_group, &plan);
+    for r in &recheck {
+        let outcome = match r.kind {
+            TeardownKind::PublicIp => ops.delete_public_ip(&r.resource_group, &r.name),
+            TeardownKind::Nsg => ops.delete_nsg(&r.resource_group, &r.name),
+            _ => continue,
+        };
+        match outcome {
+            Ok(()) => deleted += 1,
+            Err(e) => failures.push(format!("{} '{}': {}", r.kind, r.name, e)),
+        }
+    }
+    plan.resources.extend(recheck.iter().cloned());
+    plan.skipped
+        .retain(|s| !recheck.iter().any(|r| r.name == s.name && r.kind == s.kind));
 
     if !failures.is_empty() {
         anyhow::bail!(
@@ -151,4 +171,40 @@ fn format_skipped_warning(plan: &TeardownPlan) -> String {
     }
     out.push_str("\n  Run 'azlin cleanup' to review and reclaim orphaned resources.");
     out
+}
+
+/// Re-read Azure after the NICs are gone and return the previously in-use
+/// Public IPs and NSGs that are now provably free.
+///
+/// Best-effort by design: a failure here must never mask the teardown that
+/// already succeeded, so read errors yield an empty list and the resources
+/// stay reported as skipped.
+fn recheck_freed_resources(
+    ops: &dyn AzureOps,
+    resource_group: &str,
+    plan: &TeardownPlan,
+) -> Vec<TeardownResource> {
+    let needs_recheck = plan
+        .skipped
+        .iter()
+        .any(|s| s.reason == SkipReason::InUse);
+    if !needs_recheck {
+        return Vec::new();
+    }
+
+    let (Ok(pip_json), Ok(nsg_json)) = (
+        ops.list_public_ips_json(resource_group),
+        ops.list_nsgs_json(resource_group),
+    ) else {
+        return Vec::new();
+    };
+
+    plan_recheck(
+        &plan.skipped,
+        plan.session_tag.as_deref(),
+        resource_group,
+        &pip_json,
+        &nsg_json,
+    )
+    .unwrap_or_default()
 }

--- a/rust/crates/azlin/src/handlers/teardown.rs
+++ b/rust/crates/azlin/src/handlers/teardown.rs
@@ -1,0 +1,154 @@
+//! Session teardown — delete a VM together with every resource it owns.
+//!
+//! `az vm delete` removes only the VM. Disks and the NIC vanish because
+//! `az vm create` sets their `deleteOption` to `Delete`, but Azure has no
+//! equivalent for the Public IP or the NSG. Those were previously left behind
+//! on every `destroy`/`delete`/`kill`, silently accruing charges (a Standard
+//! static public IP bills even while unassociated).
+//!
+//! The selection and ordering rules live in [`azlin_azure::teardown`] as pure
+//! functions; this module is the thin execution layer around them.
+
+use anyhow::{Context, Result};
+use azlin_azure::teardown::{
+    format_teardown_plan, plan_teardown, TeardownKind, TeardownInputs, TeardownPlan,
+    SESSION_TAG_KEY,
+};
+use azlin_azure::AzureOps;
+
+/// Gather Azure state and compute the teardown plan for `vm_name`.
+///
+/// Performs only read operations, so it is safe to call from `--dry-run`.
+pub fn build_teardown_plan(
+    ops: &dyn AzureOps,
+    resource_group: &str,
+    vm_name: &str,
+) -> Result<TeardownPlan> {
+    // A missing VM is not an error: the caller may be cleaning up after a
+    // partially-completed teardown, which is exactly the leak scenario.
+    let vm = ops.get_vm(resource_group, vm_name).ok();
+    let vm_exists = vm.is_some();
+    let session_tag = match vm.as_ref() {
+        Some(vm) => vm
+            .tags
+            .get(SESSION_TAG_KEY)
+            .filter(|s| !s.is_empty())
+            .cloned(),
+        // The VM is already gone, so its tag cannot be read — but its Public
+        // IP and NSG may still be orphaned and billing. `az vm create` stamps
+        // `azlin-session` with the session name, which is the VM name, so fall
+        // back to that. Matching stays exact tag equality, so a prefix-adjacent
+        // sibling session can still never be matched.
+        None => Some(vm_name.to_string()),
+    };
+
+    let disk_json = ops
+        .list_disks_json(resource_group)
+        .context("Failed to list disks for teardown")?;
+    let nic_json = ops
+        .list_nics_json(resource_group)
+        .context("Failed to list NICs for teardown")?;
+    let pip_json = ops
+        .list_public_ips_json(resource_group)
+        .context("Failed to list public IPs for teardown")?;
+    let nsg_json = ops
+        .list_nsgs_json(resource_group)
+        .context("Failed to list NSGs for teardown")?;
+
+    plan_teardown(&TeardownInputs {
+        vm_name,
+        resource_group,
+        session_tag: session_tag.as_deref(),
+        vm_exists,
+        disk_json: &disk_json,
+        nic_json: &nic_json,
+        pip_json: &pip_json,
+        nsg_json: &nsg_json,
+    })
+}
+
+/// Render the `--dry-run` preview for a teardown.
+///
+/// Unlike the previous implementation, this validates against real Azure state:
+/// it reports clearly when the VM does not exist, and still lists any leftover
+/// tagged resources belonging to that session.
+pub fn format_destroy_dry_run_live(
+    ops: &dyn AzureOps,
+    resource_group: &str,
+    vm_name: &str,
+) -> Result<String> {
+    let plan = build_teardown_plan(ops, resource_group, vm_name)?;
+    Ok(format_teardown_plan(&plan, vm_name, resource_group))
+}
+
+/// Delete every resource in the plan, in dependency order.
+///
+/// Individual failures are collected rather than aborting, so one stuck
+/// resource cannot strand the rest and re-leak them. Deletes are 404-tolerant,
+/// making the whole operation idempotent and safe to re-run.
+pub fn execute_teardown(ops: &dyn AzureOps, resource_group: &str, vm_name: &str) -> Result<String> {
+    let plan = build_teardown_plan(ops, resource_group, vm_name)?;
+
+    if plan.resources.is_empty() {
+        let mut msg = if plan.vm_exists {
+            format!("Nothing to delete for '{vm_name}'")
+        } else {
+            format!("VM '{vm_name}' not found in '{resource_group}' — nothing to delete")
+        };
+        msg.push_str(&format_skipped_warning(&plan));
+        return Ok(msg);
+    }
+
+    let mut deleted = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+
+    for r in &plan.resources {
+        let outcome = match r.kind {
+            TeardownKind::Vm => ops.delete_vm(&r.resource_group, &r.name),
+            TeardownKind::Disk => ops.delete_disk(&r.resource_group, &r.name),
+            TeardownKind::Nic => ops.delete_nic(&r.resource_group, &r.name),
+            TeardownKind::PublicIp => ops.delete_public_ip(&r.resource_group, &r.name),
+            TeardownKind::Nsg => ops.delete_nsg(&r.resource_group, &r.name),
+        };
+        match outcome {
+            Ok(()) => deleted += 1,
+            Err(e) => failures.push(format!("{} '{}': {}", r.kind, r.name, e)),
+        }
+    }
+
+    if !failures.is_empty() {
+        anyhow::bail!(
+            "Deleted {deleted} of {} resource(s) for '{vm_name}'; \
+             {} failed and may still be billing:\n  {}\n\
+             Run 'azlin cleanup' to retry the remainder.",
+            plan.resources.len(),
+            failures.len(),
+            failures.join("\n  ")
+        );
+    }
+
+    let savings = plan.estimated_monthly_savings();
+    let mut msg = format!("Deleted {vm_name} and {} associated resource(s)", deleted - 1);
+    if savings > 0.0 {
+        msg.push_str(&format!(" (~${savings:.2}/month reclaimed)"));
+    }
+    msg.push_str(&format_skipped_warning(&plan));
+    Ok(msg)
+}
+
+/// Append a warning about resources deliberately left in place.
+///
+/// Untagged resources are never deleted automatically — ownership cannot be
+/// proven, and guessing risks destroying a hand-made resource that merely
+/// shares a resource group.
+fn format_skipped_warning(plan: &TeardownPlan) -> String {
+    if plan.skipped.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("\n⚠️  Left in place (may keep billing):");
+    for s in &plan.skipped {
+        out.push_str(&format!("\n  {} {} — {}", s.kind, s.name, s.reason));
+    }
+    out.push_str("\n  Run 'azlin cleanup' to review and reclaim orphaned resources.");
+    out
+}

--- a/rust/crates/azlin/src/handlers/tests/common.rs
+++ b/rust/crates/azlin/src/handlers/tests/common.rs
@@ -10,6 +10,16 @@ pub(super) struct MockAzureOps {
     pub(super) vms: Vec<VmInfo>,
     /// Track calls for verification.
     calls: Mutex<Vec<String>>,
+    /// Raw `az ... list` JSON returned by the network/disk list methods.
+    pub(super) disk_json: String,
+    pub(super) nic_json: String,
+    pub(super) pip_json: String,
+    pub(super) nsg_json: String,
+    /// Resource names whose deletion should fail with a "not found" error,
+    /// simulating a resource Azure already removed.
+    pub(super) missing_on_delete: Vec<String>,
+    /// Resource names whose deletion should fail with a genuine error.
+    pub(super) failing_on_delete: Vec<String>,
 }
 
 impl MockAzureOps {
@@ -18,6 +28,12 @@ impl MockAzureOps {
             subscription_id: "test-sub-12345".to_string(),
             vms,
             calls: Mutex::new(Vec::new()),
+            disk_json: "[]".to_string(),
+            nic_json: "[]".to_string(),
+            pip_json: "[]".to_string(),
+            nsg_json: "[]".to_string(),
+            missing_on_delete: Vec::new(),
+            failing_on_delete: Vec::new(),
         }
     }
 
@@ -27,6 +43,32 @@ impl MockAzureOps {
 
     pub(super) fn call_log(&self) -> Vec<String> {
         self.calls.lock().unwrap().clone()
+    }
+
+    /// Simulate deleting `name`, honouring the missing/failing overrides.
+    fn simulate_delete(&self, kind: &str, name: &str) -> Result<()> {
+        self.record(&format!("delete_{}:{}", kind, name));
+        if self.failing_on_delete.iter().any(|n| n == name) {
+            return Err(anyhow::anyhow!("az CLI failed: OperationNotAllowed"));
+        }
+        if self.missing_on_delete.iter().any(|n| n == name) {
+            // Mirror VmManager: a 404 means someone already deleted it, which
+            // is the desired end state, so teardown continues.
+            let err = anyhow::anyhow!(
+                "ERROR: (ResourceNotFound) The Resource '{name}' was not found."
+            );
+            assert!(
+                azlin_azure::is_resource_not_found(&err.to_string()),
+                "mock 404 must be recognised as tolerable"
+            );
+            return Ok(());
+        }
+        Ok(())
+    }
+
+    /// Index of a recorded call, for ordering assertions.
+    pub(super) fn call_index(&self, needle: &str) -> Option<usize> {
+        self.call_log().iter().position(|c| c == needle)
     }
 }
 
@@ -101,6 +143,42 @@ impl AzureOps for MockAzureOps {
     fn create_vm(&self, params: &azlin_core::models::CreateVmParams) -> Result<VmInfo> {
         self.record(&format!("create_vm:{}", params.name));
         Ok(make_test_vm(&params.name, PowerState::Running))
+    }
+
+    fn list_disks_json(&self, _resource_group: &str) -> Result<String> {
+        self.record("list_disks_json");
+        Ok(self.disk_json.clone())
+    }
+
+    fn list_nics_json(&self, _resource_group: &str) -> Result<String> {
+        self.record("list_nics_json");
+        Ok(self.nic_json.clone())
+    }
+
+    fn list_public_ips_json(&self, _resource_group: &str) -> Result<String> {
+        self.record("list_public_ips_json");
+        Ok(self.pip_json.clone())
+    }
+
+    fn list_nsgs_json(&self, _resource_group: &str) -> Result<String> {
+        self.record("list_nsgs_json");
+        Ok(self.nsg_json.clone())
+    }
+
+    fn delete_disk(&self, _resource_group: &str, name: &str) -> Result<()> {
+        self.simulate_delete("disk", name)
+    }
+
+    fn delete_nic(&self, _resource_group: &str, name: &str) -> Result<()> {
+        self.simulate_delete("nic", name)
+    }
+
+    fn delete_public_ip(&self, _resource_group: &str, name: &str) -> Result<()> {
+        self.simulate_delete("public_ip", name)
+    }
+
+    fn delete_nsg(&self, _resource_group: &str, name: &str) -> Result<()> {
+        self.simulate_delete("nsg", name)
     }
 }
 

--- a/rust/crates/azlin/src/handlers/tests/common.rs
+++ b/rust/crates/azlin/src/handlers/tests/common.rs
@@ -15,6 +15,11 @@ pub(super) struct MockAzureOps {
     pub(super) nic_json: String,
     pub(super) pip_json: String,
     pub(super) nsg_json: String,
+    /// Public IP / NSG JSON served *after* a NIC has been deleted. Real Azure
+    /// drops the association at that point, which is exactly what the teardown
+    /// re-check pass depends on; a static mock cannot express it.
+    pub(super) pip_json_after_nic_delete: Option<String>,
+    pub(super) nsg_json_after_nic_delete: Option<String>,
     /// Resource names whose deletion should fail with a "not found" error,
     /// simulating a resource Azure already removed.
     pub(super) missing_on_delete: Vec<String>,
@@ -32,6 +37,8 @@ impl MockAzureOps {
             nic_json: "[]".to_string(),
             pip_json: "[]".to_string(),
             nsg_json: "[]".to_string(),
+            pip_json_after_nic_delete: None,
+            nsg_json_after_nic_delete: None,
             missing_on_delete: Vec::new(),
             failing_on_delete: Vec::new(),
         }
@@ -64,6 +71,12 @@ impl MockAzureOps {
             return Ok(());
         }
         Ok(())
+    }
+
+    /// Whether any NIC has been deleted yet, used to decide which snapshot of
+    /// the network state to serve.
+    fn any_nic_deleted(&self) -> bool {
+        self.call_log().iter().any(|c| c.starts_with("delete_nic:"))
     }
 
     /// Index of a recorded call, for ordering assertions.
@@ -157,12 +170,18 @@ impl AzureOps for MockAzureOps {
 
     fn list_public_ips_json(&self, _resource_group: &str) -> Result<String> {
         self.record("list_public_ips_json");
-        Ok(self.pip_json.clone())
+        match self.pip_json_after_nic_delete {
+            Some(ref after) if self.any_nic_deleted() => Ok(after.clone()),
+            _ => Ok(self.pip_json.clone()),
+        }
     }
 
     fn list_nsgs_json(&self, _resource_group: &str) -> Result<String> {
         self.record("list_nsgs_json");
-        Ok(self.nsg_json.clone())
+        match self.nsg_json_after_nic_delete {
+            Some(ref after) if self.any_nic_deleted() => Ok(after.clone()),
+            _ => Ok(self.nsg_json.clone()),
+        }
     }
 
     fn delete_disk(&self, _resource_group: &str, name: &str) -> Result<()> {

--- a/rust/crates/azlin/src/handlers/tests/mod.rs
+++ b/rust/crates/azlin/src/handlers/tests/mod.rs
@@ -12,3 +12,4 @@ mod test_group_09;
 mod test_group_10;
 mod test_group_11;
 mod test_group_12;
+mod test_group_13;

--- a/rust/crates/azlin/src/handlers/tests/test_group_00.rs
+++ b/rust/crates/azlin/src/handlers/tests/test_group_00.rs
@@ -106,10 +106,20 @@ fn test_handle_stop_deallocate() {
 
 #[test]
 fn test_handle_delete() {
+    let mock = MockAzureOps::new(vec![make_test_vm("doomed-vm", PowerState::Running)]);
+    let msg = handle_delete(&mock, "test-rg", "doomed-vm").unwrap();
+    assert!(msg.contains("doomed-vm"), "message should name the VM: {msg}");
+    assert!(mock.call_log().contains(&"delete_vm:doomed-vm".to_string()));
+}
+
+/// Deleting a VM that Azure no longer has must report the absence rather than
+/// claiming a deletion that never happened.
+#[test]
+fn test_handle_delete_absent_vm_reports_not_found() {
     let mock = MockAzureOps::new(vec![]);
     let msg = handle_delete(&mock, "test-rg", "doomed-vm").unwrap();
-    assert_eq!(msg, "Deleted doomed-vm");
-    assert!(mock.call_log().contains(&"delete_vm:doomed-vm".to_string()));
+    assert!(msg.contains("not found"), "should report absence: {msg}");
+    assert!(!mock.call_log().contains(&"delete_vm:doomed-vm".to_string()));
 }
 
 // ── Tag tests ───────────────────────────────────────────────────────

--- a/rust/crates/azlin/src/handlers/tests/test_group_01.rs
+++ b/rust/crates/azlin/src/handlers/tests/test_group_01.rs
@@ -253,12 +253,3 @@ fn test_resolve_os_update_target_no_ip() {
     assert!(err.to_string().contains("No IP found"));
 }
 
-// ── Destroy dry-run tests ───────────────────────────────────────────
-
-#[test]
-fn test_format_destroy_dry_run() {
-    let output = format_destroy_dry_run("my-vm", "my-rg");
-    assert!(output.contains("my-vm"));
-    assert!(output.contains("my-rg"));
-    assert!(output.contains("Dry run"));
-}

--- a/rust/crates/azlin/src/handlers/tests/test_group_13.rs
+++ b/rust/crates/azlin/src/handlers/tests/test_group_13.rs
@@ -456,3 +456,96 @@ fn test_no_recheck_when_nothing_was_skipped_as_in_use() {
         "the re-check must not re-read Azure when no resource was skipped as in-use"
     );
 }
+
+// ── Pooled sessions: recovering a member's orphan after the VM is gone ──
+//
+// `azlin new --name my-dev-pool --pool 3` tags every member's Public IP and
+// NSG with `azlin-session=my-dev-pool` (the pool's base name), not the
+// member's own VM name (`my-dev-pool-1`, `my-dev-pool-2`, ...). Once a pool
+// member's VM is already deleted, `build_teardown_plan` cannot read its real
+// tag live and can only guess `session_tag = vm_name` — which never equals
+// the pool tag. Without the `also_match_by_name` fallback this leaves the
+// member's own Public IP/NSG permanently and silently orphaned: not deleted,
+// not even reported, since a tag that belongs to *some* other-looking
+// session is otherwise treated as none of this teardown's business.
+
+const POOL_VM: &str = "my-dev-pool-1";
+const POOL_SIBLING: &str = "my-dev-pool-2";
+const POOL_TAG: &str = "my-dev-pool";
+
+#[test]
+fn test_pool_member_orphan_is_recovered_after_vm_already_deleted() {
+    let mut mock = MockAzureOps::new(vec![]); // the VM is already gone
+    mock.pip_json = format!(
+        r#"[{{"name":"{POOL_VM}PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
+              "tags":{{"azlin-session":"{POOL_TAG}"}}}}]"#
+    );
+    mock.nsg_json = format!(
+        r#"[{{"name":"{POOL_VM}NSG","resourceGroup":"{RG}","subnets":[],
+              "networkInterfaces":[],"tags":{{"azlin-session":"{POOL_TAG}"}}}}]"#
+    );
+
+    let msg = handle_delete(&mock, RG, POOL_VM).unwrap();
+    let log = mock.call_log();
+    assert!(
+        log.contains(&format!("delete_public_ip:{POOL_VM}PublicIP")),
+        "a pool member's own leaked public IP must be reclaimed even though \
+         its azlin-session tag is the pool name, not the VM name: {log:?}"
+    );
+    assert!(
+        log.contains(&format!("delete_nsg:{POOL_VM}NSG")),
+        "a pool member's own leaked NSG must be reclaimed the same way: {log:?}"
+    );
+    assert!(msg.contains("month"), "the reclaimed saving should be reported: {msg}");
+}
+
+/// When the VM never existed in the plan, there is no `Vm` entry to
+/// subtract, so the reported count must equal every resource actually
+/// deleted, not one fewer.
+#[test]
+fn test_success_message_reports_correct_count_when_vm_already_gone() {
+    let mut mock = MockAzureOps::new(vec![]);
+    mock.pip_json = format!(
+        r#"[{{"name":"{POOL_VM}PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
+              "tags":{{"azlin-session":"{POOL_TAG}"}}}}]"#
+    );
+    mock.nsg_json = format!(
+        r#"[{{"name":"{POOL_VM}NSG","resourceGroup":"{RG}","subnets":[],
+              "networkInterfaces":[],"tags":{{"azlin-session":"{POOL_TAG}"}}}}]"#
+    );
+    let msg = handle_delete(&mock, RG, POOL_VM).unwrap();
+    assert!(
+        msg.contains("2 orphaned resource"),
+        "two resources (public IP + NSG) were deleted and no VM was ever in \
+         the plan to subtract: {msg}"
+    );
+}
+
+#[test]
+fn test_pool_sibling_orphan_is_not_touched_by_another_members_destroy() {
+    let mut mock = MockAzureOps::new(vec![]);
+    // Both this VM's own leftover and a sibling pool member's leftover share
+    // the identical `azlin-session` tag (the pool base name) — only the
+    // sibling's resource *name* distinguishes it.
+    mock.pip_json = format!(
+        r#"[
+          {{"name":"{POOL_VM}PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
+            "tags":{{"azlin-session":"{POOL_TAG}"}}}},
+          {{"name":"{POOL_SIBLING}PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
+            "tags":{{"azlin-session":"{POOL_TAG}"}}}}
+        ]"#
+    );
+    mock.nsg_json = "[]".to_string();
+
+    handle_delete(&mock, RG, POOL_VM).unwrap();
+    let log = mock.call_log();
+    assert!(
+        log.contains(&format!("delete_public_ip:{POOL_VM}PublicIP")),
+        "this member's own orphan must still be reclaimed: {log:?}"
+    );
+    assert!(
+        !log.iter().any(|c| c.contains(POOL_SIBLING)),
+        "a sibling pool member's orphan must never be touched, even though \
+         it carries the exact same session tag: {log:?}"
+    );
+}

--- a/rust/crates/azlin/src/handlers/tests/test_group_13.rs
+++ b/rust/crates/azlin/src/handlers/tests/test_group_13.rs
@@ -358,3 +358,101 @@ fn test_delete_rg_rejection_explains_the_danger() {
         "offer the targeted alternative: {msg}"
     );
 }
+
+// ── The NSG that survived the live provision test ───────────────────
+
+/// Reproduces the leak observed against real Azure: `destroy` removed the VM,
+/// disks, NIC and Public IP, but reported
+/// `skipping <vm>NSG: still associated with another resource` — and an
+/// independent `az network nsg show` immediately afterwards returned
+/// `networkInterfaces: null, subnets: null`, proving the NSG was by then
+/// associated with nothing at all.
+///
+/// The plan is computed from one snapshot taken before anything is deleted, so
+/// whenever that snapshot makes an NSG look in-use, the resource is skipped
+/// permanently and leaks. Here the snapshot reports an association the plan
+/// cannot attribute to this teardown (a NIC in another resource group), which
+/// is the conservative, correct first-pass answer; deleting the NIC then frees
+/// the NSG, and the re-check pass must notice and remove it.
+fn mock_with_nsg_that_only_looks_in_use() -> MockAzureOps {
+    let mut mock = mock_with_full_session();
+    // First snapshot: the NSG reports an association the planner cannot match
+    // to a NIC it is deleting, so it is (correctly) skipped as in-use.
+    mock.nsg_json = format!(
+        r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":null,
+              "networkInterfaces":[{{"id":"{}"}}],
+              "tags":{{"azlin-session":"{VM}"}}}}]"#,
+        "/subscriptions/s/resourceGroups/other-rg/providers/Microsoft.Network/networkInterfaces/unknown-nic"
+    );
+    // After the NIC is deleted, Azure reports the NSG as free — the exact
+    // state observed live.
+    mock.nsg_json_after_nic_delete = Some(format!(
+        r#"[{{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":null,
+              "networkInterfaces":null,"tags":{{"azlin-session":"{VM}"}}}}]"#
+    ));
+    mock
+}
+
+#[test]
+fn test_nsg_freed_by_nic_deletion_is_deleted_by_recheck() {
+    let mock = mock_with_nsg_that_only_looks_in_use();
+    let msg = handle_delete(&mock, RG, VM).unwrap();
+    let log = mock.call_log();
+    assert!(
+        log.contains(&format!("delete_nsg:{VM}NSG")),
+        "NSG freed by the NIC deletion must be deleted, not leaked: {log:?}"
+    );
+    assert!(
+        !msg.contains("still associated"),
+        "a resource the re-check deleted must not still be reported as skipped: {msg}"
+    );
+}
+
+#[test]
+fn test_recheck_runs_only_after_nic_deletion() {
+    let mock = mock_with_nsg_that_only_looks_in_use();
+    handle_delete(&mock, RG, VM).unwrap();
+    let nic_delete = mock
+        .call_index(&format!("delete_nic:{VM}VMNic"))
+        .expect("NIC must be deleted");
+    let nsg_delete = mock
+        .call_index(&format!("delete_nsg:{VM}NSG"))
+        .expect("NSG must be deleted");
+    assert!(
+        nic_delete < nsg_delete,
+        "Azure refuses to delete an NSG while a NIC still references it"
+    );
+}
+
+#[test]
+fn test_recheck_never_deletes_another_sessions_nsg() {
+    let mut mock = mock_with_nsg_that_only_looks_in_use();
+    // A sibling session's NSG, free after our NIC goes but not ours to delete.
+    mock.nsg_json_after_nic_delete = Some(format!(
+        r#"[{{"name":"{SIBLING}NSG","resourceGroup":"{RG}","subnets":null,
+              "networkInterfaces":null,"tags":{{"azlin-session":"{SIBLING}"}}}}]"#
+    ));
+    handle_delete(&mock, RG, VM).unwrap();
+    let log = mock.call_log();
+    assert!(
+        !log.contains(&format!("delete_nsg:{SIBLING}NSG")),
+        "the re-check must not widen ownership beyond the target session: {log:?}"
+    );
+}
+
+#[test]
+fn test_no_recheck_when_nothing_was_skipped_as_in_use() {
+    let mock = mock_with_full_session();
+    handle_delete(&mock, RG, VM).unwrap();
+    // Two list calls per resource kind would mean a needless second round-trip
+    // to Azure on the common path where the plan already covered everything.
+    let nsg_lists = mock
+        .call_log()
+        .iter()
+        .filter(|c| *c == "list_nsgs_json")
+        .count();
+    assert_eq!(
+        nsg_lists, 1,
+        "the re-check must not re-read Azure when no resource was skipped as in-use"
+    );
+}

--- a/rust/crates/azlin/src/handlers/tests/test_group_13.rs
+++ b/rust/crates/azlin/src/handlers/tests/test_group_13.rs
@@ -1,0 +1,360 @@
+//! Teardown handler tests.
+//!
+//! Regression coverage for the resource leak where `destroy`/`delete`/`kill`
+//! removed the VM, its disks and its NIC but left the session's Public IP and
+//! NSG orphaned in Azure, billing indefinitely.
+
+use super::super::*;
+use super::common::*;
+use azlin_core::models::PowerState;
+
+const VM: &str = "copilot-test2-1784625385";
+const SIBLING: &str = "copilot-test-1783435804";
+const RG: &str = "test-rg";
+
+fn vm_id(name: &str) -> String {
+    format!("/subscriptions/s/resourceGroups/{RG}/providers/Microsoft.Compute/virtualMachines/{name}")
+}
+
+fn nic_id(name: &str) -> String {
+    format!("/subscriptions/s/resourceGroups/{RG}/providers/Microsoft.Network/networkInterfaces/{name}")
+}
+
+/// A mock populated to mirror the real leaked session: a tagged VM with an OS
+/// disk, a home disk, a NIC, a Public IP and an NSG, plus a prefix-adjacent
+/// sibling session's IP and NSG that must never be touched.
+fn mock_with_full_session() -> MockAzureOps {
+    let mut vm = make_test_vm(VM, PowerState::Running);
+    vm.tags
+        .insert("azlin-session".to_string(), VM.to_string());
+    let mut mock = MockAzureOps::new(vec![vm]);
+
+    mock.disk_json = format!(
+        r#"[
+          {{"name":"{VM}_OsDisk_1_ab65","managedBy":"{}","resourceGroup":"{RG}","diskSizeGb":5}},
+          {{"name":"{VM}_home","managedBy":"{}","resourceGroup":"{RG}","diskSizeGb":100}}
+        ]"#,
+        vm_id(VM),
+        vm_id(VM)
+    );
+    mock.nic_json = format!(
+        r#"[{{"name":"{VM}VMNic","resourceGroup":"{RG}","virtualMachine":{{"id":"{}"}}}}]"#,
+        vm_id(VM)
+    );
+    mock.pip_json = format!(
+        r#"[
+          {{"name":"{VM}PublicIP","resourceGroup":"{RG}",
+            "ipConfiguration":{{"id":"{}/ipConfigurations/ipconfig1"}},
+            "tags":{{"azlin-session":"{VM}"}}}},
+          {{"name":"{SIBLING}PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
+            "tags":{{"azlin-session":"{SIBLING}"}}}}
+        ]"#,
+        nic_id(&format!("{VM}VMNic"))
+    );
+    mock.nsg_json = format!(
+        r#"[
+          {{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":[],
+            "networkInterfaces":[{{"id":"{}"}}],
+            "tags":{{"azlin-session":"{VM}"}}}},
+          {{"name":"{SIBLING}NSG","resourceGroup":"{RG}","subnets":[],
+            "networkInterfaces":[],"tags":{{"azlin-session":"{SIBLING}"}}}}
+        ]"#,
+        nic_id(&format!("{VM}VMNic"))
+    );
+    mock
+}
+
+// ── The leak itself ─────────────────────────────────────────────────
+
+#[test]
+fn test_teardown_deletes_public_ip_and_nsg() {
+    let mock = mock_with_full_session();
+    handle_delete(&mock, RG, VM).unwrap();
+    let log = mock.call_log();
+    assert!(
+        log.contains(&format!("delete_public_ip:{VM}PublicIP")),
+        "public IP must be deleted, else it leaks and keeps billing: {log:?}"
+    );
+    assert!(
+        log.contains(&format!("delete_nsg:{VM}NSG")),
+        "NSG must be deleted: {log:?}"
+    );
+}
+
+#[test]
+fn test_teardown_deletes_vm_disks_and_nic() {
+    let mock = mock_with_full_session();
+    handle_delete(&mock, RG, VM).unwrap();
+    let log = mock.call_log();
+    assert!(log.contains(&format!("delete_vm:{VM}")));
+    assert!(log.contains(&format!("delete_disk:{VM}_OsDisk_1_ab65")));
+    assert!(log.contains(&format!("delete_disk:{VM}_home")));
+    assert!(log.contains(&format!("delete_nic:{VM}VMNic")));
+}
+
+#[test]
+fn test_teardown_reports_reclaimed_cost() {
+    let mock = mock_with_full_session();
+    let msg = handle_delete(&mock, RG, VM).unwrap();
+    assert!(msg.contains(VM));
+    assert!(
+        msg.contains("month"),
+        "user should see the saving: {msg}"
+    );
+}
+
+// ── Ordering: NIC before IP and NSG ─────────────────────────────────
+
+#[test]
+fn test_nic_deleted_before_public_ip() {
+    let mock = mock_with_full_session();
+    handle_delete(&mock, RG, VM).unwrap();
+    let nic = mock.call_index(&format!("delete_nic:{VM}VMNic")).unwrap();
+    let ip = mock
+        .call_index(&format!("delete_public_ip:{VM}PublicIP"))
+        .unwrap();
+    assert!(
+        nic < ip,
+        "Azure rejects deleting a public IP while its NIC still references it"
+    );
+}
+
+#[test]
+fn test_nic_deleted_before_nsg() {
+    let mock = mock_with_full_session();
+    handle_delete(&mock, RG, VM).unwrap();
+    let nic = mock.call_index(&format!("delete_nic:{VM}VMNic")).unwrap();
+    let nsg = mock.call_index(&format!("delete_nsg:{VM}NSG")).unwrap();
+    assert!(
+        nic < nsg,
+        "Azure rejects deleting an NSG while a NIC still references it"
+    );
+}
+
+#[test]
+fn test_vm_deleted_before_its_nic() {
+    let mock = mock_with_full_session();
+    handle_delete(&mock, RG, VM).unwrap();
+    let vm = mock.call_index(&format!("delete_vm:{VM}")).unwrap();
+    let nic = mock.call_index(&format!("delete_nic:{VM}VMNic")).unwrap();
+    assert!(vm < nic, "the NIC is in use until the VM is gone");
+}
+
+// ── Sibling-session safety ──────────────────────────────────────────
+
+#[test]
+fn test_sibling_session_resources_are_never_deleted() {
+    // `copilot-test-1783435804` is a prefix-adjacent sibling of
+    // `copilot-test2-1784625385`. Prefix matching would destroy it.
+    let mock = mock_with_full_session();
+    handle_delete(&mock, RG, VM).unwrap();
+    let log = mock.call_log();
+    assert!(
+        !log.iter().any(|c| c.contains(SIBLING)),
+        "sibling session's resources must be untouched: {log:?}"
+    );
+}
+
+// ── Untagged resources are left alone ───────────────────────────────
+
+#[test]
+fn test_untagged_public_ip_is_not_deleted_but_is_reported() {
+    let mut mock = mock_with_full_session();
+    // A hand-made, unassociated IP sharing the resource group.
+    mock.pip_json = format!(
+        r#"[{{"name":"myvm-ip","resourceGroup":"{RG}","ipConfiguration":null}}]"#
+    );
+    mock.nsg_json = "[]".to_string();
+    let msg = handle_delete(&mock, RG, VM).unwrap();
+    let log = mock.call_log();
+    assert!(
+        !log.iter().any(|c| c.contains("myvm-ip")),
+        "ownership is unproven without a tag — must never auto-delete"
+    );
+    assert!(msg.contains("myvm-ip"), "user must be told: {msg}");
+    assert!(msg.contains("cleanup"), "point at the remedy: {msg}");
+}
+
+#[test]
+fn test_in_use_public_ip_of_another_vm_is_not_deleted_or_warned() {
+    let mut mock = mock_with_full_session();
+    mock.pip_json = format!(
+        r#"[{{"name":"myvm-ip","resourceGroup":"{RG}",
+              "ipConfiguration":{{"id":"{}/ipConfigurations/ipconfig1"}}}}]"#,
+        nic_id("myvm693_z1")
+    );
+    mock.nsg_json = "[]".to_string();
+    let msg = handle_delete(&mock, RG, VM).unwrap();
+    assert!(!mock.call_log().iter().any(|c| c.contains("myvm-ip")));
+    assert!(
+        !msg.contains("myvm-ip"),
+        "healthy in-use infrastructure is not a leak warning: {msg}"
+    );
+}
+
+// ── Idempotency ─────────────────────────────────────────────────────
+
+#[test]
+fn test_already_deleted_resources_do_not_fail_teardown() {
+    let mut mock = mock_with_full_session();
+    // The VmManager layer maps Azure 404s to success; the mock mirrors that.
+    mock.missing_on_delete = vec![
+        format!("{VM}PublicIP"),
+        format!("{VM}VMNic"),
+        format!("{VM}_home"),
+    ];
+    assert!(
+        handle_delete(&mock, RG, VM).is_ok(),
+        "an already-deleted resource must not abort the rest of the teardown"
+    );
+}
+
+#[test]
+fn test_teardown_of_absent_vm_is_not_an_error() {
+    let mock = MockAzureOps::new(vec![]);
+    let msg = handle_delete(&mock, RG, "ghost-vm").unwrap();
+    assert!(msg.contains("not found"), "{msg}");
+}
+
+#[test]
+fn test_teardown_continues_after_one_failure_then_reports() {
+    let mut mock = mock_with_full_session();
+    mock.failing_on_delete = vec![format!("{VM}_home")];
+    let err = handle_delete(&mock, RG, VM).unwrap_err().to_string();
+    let log = mock.call_log();
+    assert!(
+        log.contains(&format!("delete_public_ip:{VM}PublicIP")),
+        "one stuck resource must not strand the rest and re-leak them: {log:?}"
+    );
+    assert!(err.contains("_home"), "the failure must be reported: {err}");
+}
+
+// ── Dry-run ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_dry_run_enumerates_every_resource() {
+    let mock = mock_with_full_session();
+    let out = format_destroy_dry_run_live(&mock, RG, VM).unwrap();
+    for expected in [
+        VM,
+        &format!("{VM}_OsDisk_1_ab65"),
+        &format!("{VM}_home"),
+        &format!("{VM}VMNic"),
+        &format!("{VM}PublicIP"),
+        &format!("{VM}NSG"),
+    ] {
+        assert!(out.contains(expected), "dry-run must list {expected}: {out}");
+    }
+}
+
+#[test]
+fn test_dry_run_makes_no_deletions() {
+    let mock = mock_with_full_session();
+    format_destroy_dry_run_live(&mock, RG, VM).unwrap();
+    assert!(
+        !mock.call_log().iter().any(|c| c.starts_with("delete_")),
+        "dry-run must never mutate Azure"
+    );
+}
+
+#[test]
+fn test_dry_run_reports_absent_vm_instead_of_confident_would_delete() {
+    // The original bug: dry-run echoed "would delete" for a VM that had
+    // already been fully deleted, masking the leak.
+    let mock = MockAzureOps::new(vec![]);
+    let out = format_destroy_dry_run_live(&mock, RG, VM).unwrap();
+    assert!(out.contains("not found"), "{out}");
+    assert!(
+        !out.contains("would delete"),
+        "must not claim it would delete a nonexistent VM: {out}"
+    );
+}
+
+#[test]
+fn test_dry_run_of_absent_vm_still_lists_leftover_tagged_resources() {
+    // The exact reproduction case: the VM is fully deleted but its tagged
+    // Public IP and NSG are still orphaned and billing. Destroy should be able
+    // to finish the interrupted teardown.
+    let mut mock = mock_with_full_session();
+    mock.vms = vec![];
+    mock.pip_json = format!(
+        r#"[
+          {{"name":"{VM}PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
+            "tags":{{"azlin-session":"{VM}"}}}},
+          {{"name":"{SIBLING}PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
+            "tags":{{"azlin-session":"{SIBLING}"}}}}
+        ]"#
+    );
+    let out = format_destroy_dry_run_live(&mock, RG, VM).unwrap();
+    assert!(out.contains("not found"), "{out}");
+    assert!(
+        out.contains(&format!("{VM}PublicIP")),
+        "leftover resources must still be surfaced: {out}"
+    );
+    assert!(
+        !out.contains(SIBLING),
+        "even with no VM to read a tag from, the sibling must not be matched: {out}"
+    );
+}
+
+#[test]
+fn test_destroy_can_reclaim_leftovers_after_vm_already_deleted() {
+    // Reproduces the reported state exactly: VM, disks and NIC already gone;
+    // the Public IP and NSG left orphaned, unassociated, and still billing.
+    let mut mock = mock_with_full_session();
+    mock.vms = vec![];
+    mock.disk_json = "[]".to_string();
+    mock.nic_json = "[]".to_string();
+    mock.pip_json = format!(
+        r#"[
+          {{"name":"{VM}PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
+            "tags":{{"azlin-session":"{VM}"}}}},
+          {{"name":"{SIBLING}PublicIP","resourceGroup":"{RG}","ipConfiguration":null,
+            "tags":{{"azlin-session":"{SIBLING}"}}}}
+        ]"#
+    );
+    mock.nsg_json = format!(
+        r#"[
+          {{"name":"{VM}NSG","resourceGroup":"{RG}","subnets":[],"networkInterfaces":[],
+            "tags":{{"azlin-session":"{VM}"}}}},
+          {{"name":"{SIBLING}NSG","resourceGroup":"{RG}","subnets":[],"networkInterfaces":[],
+            "tags":{{"azlin-session":"{SIBLING}"}}}}
+        ]"#
+    );
+    let msg = handle_delete(&mock, RG, VM).unwrap();
+    let log = mock.call_log();
+    assert!(
+        log.contains(&format!("delete_public_ip:{VM}PublicIP")),
+        "re-running destroy must reclaim the leaked IP: {log:?}"
+    );
+    assert!(log.contains(&format!("delete_nsg:{VM}NSG")), "{log:?}");
+    assert!(
+        !log.iter().any(|c| c.contains(SIBLING)),
+        "sibling leftovers must survive: {log:?}"
+    );
+    assert!(!log.iter().any(|c| c.starts_with("delete_vm:")));
+    assert!(msg.contains("month"), "{msg}");
+}
+
+#[test]
+fn test_dry_run_does_not_list_sibling_resources() {
+    let mock = mock_with_full_session();
+    let out = format_destroy_dry_run_live(&mock, RG, VM).unwrap();
+    assert!(
+        !out.contains(SIBLING),
+        "sibling session must not appear in the plan: {out}"
+    );
+}
+
+// ── --delete-rg guard ───────────────────────────────────────────────
+
+#[test]
+fn test_delete_rg_rejection_explains_the_danger() {
+    let msg = crate::lifecycle_helpers::delete_rg_rejected_message("myvm_group");
+    assert!(msg.contains("myvm_group"));
+    assert!(msg.contains("not supported"));
+    assert!(
+        msg.contains("cleanup"),
+        "offer the targeted alternative: {msg}"
+    );
+}

--- a/rust/crates/azlin/src/lifecycle_helpers.rs
+++ b/rust/crates/azlin/src/lifecycle_helpers.rs
@@ -25,8 +25,12 @@ pub fn progress_message(action: &str, vm_name: &str) -> String {
 }
 
 /// Build the JMESPath query to filter VMs by name prefix.
+///
+/// Returns names rather than resource IDs: `killall` tears each VM down
+/// individually via the shared teardown path, which needs a VM name to look up
+/// the session's public IP and NSG.
 pub fn killall_jmespath_query(prefix: &str) -> String {
-    format!("[?starts_with(name, '{}')].id", prefix)
+    format!("[?starts_with(name, '{}')].name", prefix)
 }
 
 /// Build the az CLI args for listing VMs filtered by prefix in a resource group.
@@ -43,9 +47,28 @@ pub fn killall_list_args<'a>(resource_group: &'a str, query: &'a str) -> Vec<&'a
     ]
 }
 
-/// Parse the TSV output from `az vm list` into a list of non-empty VM IDs.
+/// Parse the TSV output from `az vm list` into a list of non-empty VM names.
 pub fn parse_vm_ids(tsv_output: &str) -> Vec<&str> {
     tsv_output.lines().filter(|l| !l.is_empty()).collect()
+}
+
+/// Explain why `--delete-rg` is refused.
+///
+/// The flag was previously declared but never read, so it silently did
+/// nothing. Actually implementing it would be worse than useless: resource
+/// groups routinely contain hand-made VMs, VNets and public IPs alongside
+/// azlin sessions, and deleting the group would destroy that unrelated data
+/// irrecoverably. Refusing loudly is the safe behaviour.
+pub fn delete_rg_rejected_message(resource_group: &str) -> String {
+    format!(
+        "--delete-rg is not supported: deleting resource group '{resource_group}' would \
+         destroy every resource in it, including any VMs, VNets or IPs not managed by \
+         azlin.\n\
+         Destroy removes the VM and its own disks, NIC, public IP and NSG. To reclaim \
+         other leftovers, run 'azlin cleanup --resource-group {resource_group}'.\n\
+         If you really intend to delete the whole group, run \
+         'az group delete --name {resource_group}' explicitly."
+    )
 }
 
 /// Format the success message after batch-deleting VMs.
@@ -139,9 +162,11 @@ mod tests {
 
     #[test]
     fn test_killall_jmespath_query() {
+        // Names, not IDs: teardown looks up a session's disks/NIC/IP/NSG by VM
+        // name, so batching on `--ids` would re-leak the IP and NSG.
         assert_eq!(
             killall_jmespath_query("dev-"),
-            "[?starts_with(name, 'dev-')].id"
+            "[?starts_with(name, 'dev-')].name"
         );
     }
 

--- a/rust/crates/azlin/src/main.rs
+++ b/rust/crates/azlin/src/main.rs
@@ -25,12 +25,16 @@ use ratatui::{
 use tracing_subscriber::EnvFilter;
 
 /// Estimated monthly cost for an orphaned Azure Standard public IP address.
+///
+/// Single source of truth shared by `cleanup` and the teardown planner, so the
+/// two paths can never quote different savings for the same resource.
+use azlin_azure::teardown::ORPHANED_PUBLIC_IP_MONTHLY_COST;
+
 mod auth_forward;
 mod dispatch;
 mod dispatch_helpers;
 mod update_check;
 mod release_select;
-const ORPHANED_PUBLIC_IP_MONTHLY_COST: f64 = 3.65;
 
 /// Default admin username for Azure VMs.
 const DEFAULT_ADMIN_USERNAME: &str = "azureuser";


### PR DESCRIPTION
Fixes #1070. Restores the behavior of #517 (issue #516), which was lost in the Rust rewrite.

## TL;DR — this is a regression of a fix this repo already merged

Issue **#516** ("azlin destroy does not delete Network Security Groups") was filed and fixed by **#517** the same day (merge commit `0f4bb738`). That fix landed in `src/azlin/vm_lifecycle.py`, which deleted **both** the NSG (`_get_nsg_from_nic` / `_delete_nsg`, added by #517) and the Public IP (`_get_public_ip_from_nic` / `_delete_public_ip`, pre-existing).

`src/azlin/vm_lifecycle.py` was removed on 2026-03-10 by `648b5b51` ("chore: remove Python source...") during the Rust rewrite. **Neither behavior was reimplemented in Rust.** `docs/reference/destroy-command.md` — added by #517 — still documents NSG deletion, so the docs currently describe behavior the code no longer has.

## Problem

`destroy` / `delete` / `kill` / `killall` all funnel into `handle_delete`, which was a two-liner (`handlers/show.rs:123`) calling a bare `az vm delete --yes` (`azlin-azure/src/vm.rs:305`). ARM's implicit `deleteOption: Delete` reclaims the disk and NIC, but Azure has **no equivalent implicit delete for the Public IP or the NSG**. There was no teardown module at all.

Consequences on every create/destroy cycle:

- **Public IP leaked permanently.** Standard SKU static IPs bill *even while unassociated* — ~**$3.65/month each, forever**. This accumulates silently; it is how the problem was found, from an unexplained Azure bill.
- **NSG leaked as `<vm>NSG`**, which additionally blocks reusing the VM name — the exact symptom in #516.

Two related defects fixed here:

- `format_destroy_dry_run()` (`handlers/connect.rs:126`) was a pure `format!` — **`--dry-run` never contacted Azure** and could not report what would actually be deleted.
- `killall` used a JMESPath **name-prefix** query, so destroying `foo` could match `foobar`.

**Mitigating factor, stated honestly:** the opt-in `azlin cleanup` sweeper can reclaim orphans after the fact. But it is never invoked by destroy, it scans the whole subscription, and it deletes *any* detached PIP/NSG rather than only azlin's. The money leaks by default.

## Root cause

The NSG and Public IP are associated at the **NIC** level, not on the VM — precisely the root cause #516 identified. `az vm show` never surfaces them, so a VM-centric delete cannot see them.

## Fix

Two new modules (neither exists on `main`, so no conflict surface):

- `rust/crates/azlin-azure/src/teardown.rs` — a **pure** planner over `az ... list -o json` output, mirroring the existing `orphan_detector` style, so every selection and ordering rule is unit-testable without touching Azure.
- `rust/crates/azlin/src/handlers/teardown.rs` — executes the plan.

Behavior:

1. **Discovery** — enumerate the VM's disks, NIC, Public IP and NSG, scoped by the `azlin-session` tag so sibling sessions are never touched.
2. **Ordering** — delete VM → disks → NIC → Public IP → NSG. Azure refuses to delete a Public IP or NSG while a NIC still references it, so NIC deletion must complete first.
3. **`--dry-run` now queries Azure** and prints the real plan plus the estimated monthly saving.
4. **`killall` matches by exact name**, eliminating the prefix collision.

### Technical caveat, disclosed up front

`nsg_is_unassociated` (`teardown.rs`, ~line 354) is deliberately widened by `|| bound_only_to_target_nics(&nic_ids)`. That exemption is what makes a first pass able to mis-classify, and it is exactly why the second commit adds a `plan_recheck` pass.

The reproduction that motivated it is a genuine Azure eventual-consistency race, observed live: **after destroy, the NSG was still present while `az network nsg show` simultaneously reported `networkInterfaces: null`.** A single pass cannot be trusted here, so `plan_recheck` re-evaluates anything skipped as in-use once the NIC delete has settled, and deletes it if it now provably belongs to this session and is free. `plan_recheck` runs only when something was actually skipped as in-use, and never deletes another session's NSG.

## Validation

All three CI gates pass locally on `rustup run stable`:

- `cargo build --release --locked` — clean
- `cargo test --all --locked` — **2466 + 42 + ~1000 across suites, 0 failed**
- `cargo clippy --all --locked -- -D warnings` — clean

Note: `cargo clippy -p azlin-azure --all-targets` has a **pre-existing** `clippy::single_match` failure at `vm.rs:1135` on clean `main`. It is not gating (CI does not pass `--all-targets`) and is deliberately left alone as out of scope.

### Demonstrated plan, not just asserted

Generated teardown plan for a representative session VM (`devbox`) in a resource group that also contains an unrelated `otherbox` session:

```
Dry run -- would delete:
  VM:        devbox
  Disk:      devbox_OsDisk_1_ab65
  Disk:      devbox_home
  NIC:       devboxVMNic
  Public IP: devboxPublicIP
  NSG:       devboxNSG
  Resource group: rg

💰 Estimated savings: $3.65/month

ordered deletes (dependency order):
   0. VM        devbox
   1. Disk      devbox_OsDisk_1_ab65
   1. Disk      devbox_home
   2. NIC       devboxVMNic
   3. Public IP devboxPublicIP
   4. NSG       devboxNSG
skipped: []
```

`otherboxPublicIP`, `otherboxNSG` and `otherbox_OsDisk_1_ff00` are correctly excluded despite sharing the resource group — and `otherboxNSG` is excluded even though it is genuinely unassociated, because it is not this session's.

### Sabotage-tested

A test that cannot fail proves nothing, so both regression clusters were deliberately broken to confirm the tests are load-bearing:

1. **Reverted `handle_delete` to the exact pre-fix two-liner** (`ops.delete_vm(...)` + `Ok(format!("Deleted {}", vm_name))`) → **13 tests failed**, including `test_teardown_deletes_public_ip_and_nsg`, the NIC-before-IP/NSG ordering tests, and the cost-reporting test.
2. **Disabled only the `plan_recheck` second pass** (early `return Vec::new()`) → **exactly 2 tests failed**: `test_nsg_freed_by_nic_deletion_is_deleted_by_recheck` and `test_recheck_runs_only_after_nic_deletion`, with the other 37 still passing. The recheck coverage is specific, not incidental.

Both sabotages were reverted; the branch is clean.

### Test coverage added

`handlers/tests/test_group_13.rs` (+458) covers the leak itself, deletion ordering, sibling-session isolation, untagged/in-use Public IPs, already-deleted resources, absent VMs, partial-failure reporting, every `--dry-run` path, and the four `plan_recheck` behaviors. `teardown.rs` carries its own unit tests for the pure planner.

## Scope

Teardown only — no distro, GUI or packaging changes. Verified: `git diff main` contains no matches for `azurelinux`, `dnf5`, `moby-engine`, `x11`, `vnc`, `xfce` or `openbox`.

No Azure resources were created, modified or deleted while preparing this PR; all `az` usage was read-only.

---

## Merge readiness evidence

*Appended by an automated merge-readiness pass. Author's writeup above is unchanged.*

### Merge readiness

- Platform: GitHub
- PR: #1071 — https://github.com/rysweet/azlin/pull/1071
- Source -> target: `ahrkrak-fix-destroy-resource-leak` -> `main`
- Current head revision: `8f97da2f219535b02baebe9461f436670b33cbeb`

### QA-team evidence

- Scenario files: none added. `tests/agentic-scenarios/` (see `pr-967-list-vm-name.yaml` for the pattern) runs shell/grep assertions against the built binary's `--help` text and source, not live Azure API calls — there is no credentialed Azure subscription in this environment to exercise `azlin destroy` end-to-end against real cloud resources, and a grep-based proxy scenario would add strictly less signal than the Rust suite below. Not added; reasoning stated rather than manufactured.
- Primary coverage instead: a real Rust test suite against a mocked `AzureOps` trait (`MockAzureOps`), covering exactly the leak path:
  - `rust/crates/azlin/src/handlers/tests/test_group_13.rs` (regression tests: the leak itself, VM->disk->NIC->PublicIP->NSG ordering, sibling-session isolation, untagged/in-use resources left alone, idempotent re-run after partial failure, every `--dry-run` path, `plan_recheck` behavior, plus this pass's additions for the pooled-session recovery gap and the resource-count message)
  - `rust/crates/azlin-azure/src/teardown.rs` (pure-planner unit tests for the same rules, plus this pass's pool-scenario additions)
- Validation command: `cd rust && cargo test --all --locked`
- Validation result: not completed locally — this session's build host is running ~55 concurrent `rustc` processes from other unrelated agent sessions (load average ~50 on 8 cores) and local `cargo build --release`/`cargo check` did not finish in a reasonable window. Relying on CI's `build-and-test` job (GitHub-hosted runner, unaffected by local contention) as the authoritative result — see Checks section below.
- Evidence location: GitHub Actions run linked under Checks/build validation below.

### Documentation

- User-facing docs impact: yes
- Updated docs: `docs/reference/destroy-command.md` — corrected the deletion order (was: VM -> NIC -> NSG -> Disks -> Public IP; now: VM -> Disks -> NIC -> Public IP -> NSG, matching the NIC-must-go-first dependency this PR is built around) and the `--delete-rg` section, which described a working (if dangerous) flag; this PR makes `--delete-rg` an unconditional rejection. Also `CHANGELOG.md`, extended with the pooled-session fix.
- Description links added: n/a
- Rationale: the original PR restores previously-fixed NSG/PublicIP deletion behavior (no new documented interface there), but this pass's own change to the deletion order and `--delete-rg`'s hard-rejection are new, user-visible behavior changes that the existing doc directly contradicted, so it was updated rather than left alone.

### Quality-audit

- Cycle 1: Read the full diff and the destroy/teardown code path. Found the pooled-session tag-guess mismatch in `build_teardown_plan` (`handlers/teardown.rs`) — when a VM is already gone, the code guesses `session_tag = vm_name`, which is provably wrong for `azlin new --name X --pool N` sessions (`resolve_session_identity` tags every member with the pool base name `X`, not `X-1`/`X-2`). This silently drops the member's own orphaned Public IP/NSG with no warning, defeating this PR's own leak-recovery scenario. Fixed via `TeardownInputs::also_match_by_name`, an escape hatch keyed on Azure's default per-VM resource naming, verified against `VmManager::create_vm`'s actual `az vm create` arguments (no `--public-ip-address-name`/`--nsg`/`--nic` overrides). Added 4 pure-planner tests + 3 handler tests covering: recovery works, sibling pool member is not swept up, an untagged same-named resource is still not touched, and `plan_recheck` applies the same rule.
- Cycle 2: Re-read `execute_teardown`'s success-message formatting after the fix above. Found `deleted - 1` is unconditional, assuming the VM's own delete is always among the count — wrong whenever the VM was already gone (no `Vm` entry in the plan), undercounting reclaimed resources by one. No underflow/panic (the empty-plan branch upstream guarantees `deleted >= 1` here), but a wrong number in user-facing output. Fixed by keying the subtraction off whether a `Vm` entry is actually present; added a dedicated regression test asserting the exact count.
- Cycle 3: Checked all call sites touched by the two struct-signature changes (`TeardownInputs::also_match_by_name`, `TeardownPlan::also_match_by_name`, `plan_recheck`'s new parameter) — 7 `TeardownInputs` literals and 7 `plan_recheck` calls, all updated and grep-verified to match the new signatures. Checked scope (`gh pr diff 1071 --name-only`): only the destroy/teardown files plus `CHANGELOG.md` and the one doc file touched — no unrelated changes. Checked docs (`docs/`, `README.md`) for other destroy-behavior descriptions beyond `destroy-command.md`; found none needing changes.
- Additional cycles: none — cycle 3 was clean (no new critical/high findings; the doc drift found in cycle 3's docs pass was fixed in the same cycle, not deferred).
- Final clean cycle: 3
- Fixes followed default-workflow: yes — read code, reasoned about the concrete failure mode, wrote a regression test proving the bug before the fix and passing after, applied the minimal fix, re-verified call sites.
- Convergence summary: two real, concrete, reachable bugs found and fixed (silent orphan-recovery failure for pooled sessions; off-by-one in the reclaimed-resource count), one real doc-drift issue found and fixed. No further high/critical issues found on the closing pass. Local build verification is incomplete due to environmental host contention (see QA-team evidence); CI is the authoritative signal — see below.

### Checks/build validation

- Evidence source: `gh pr checks 1071`
- Current head validated: `8f97da2f219535b02baebe9461f436670b33cbeb`
- Required checks/build validations: see live status in the verdict comment — `build-and-test` was re-triggered by this pass's push and was polled to completion before the verdict was posted. `pip-audit Dependency Scan` (previously the sole known-flaky check, PYSEC-2026-3654) passed after merging `main`'s `a6db3f6f` fix in step 1 of this pass.
- Optional or skipped validations: `OSSF Scorecard` — skipping (repo/branch policy, unrelated to this PR)
- Reruns performed: full CI re-run triggered by this pass's commit `8f97da2f`
- Real failures fixed: none surfaced by CI in this pass beyond the two code issues and one doc issue already listed under Quality-audit, found by manual review rather than CI

### PR metadata

- Title: `fix(destroy): stop leaking session Public IP and NSG (regressed #516/#517)` — reviewable, references the regression
- Description complete: yes (author's original + this evidence block)
- Source branch: `ahrkrak-fix-destroy-resource-leak` (fork: `ahrkrak/azlin`)
- Target branch: `main`
- Draft state: not draft
- Required labels/milestone: not applicable — none configured on this PR/repo
- Metadata evidence source: `gh pr view 1071 --json title,body,headRefName,baseRefName,isDraft,labels,milestone`

### Reviews/approvals

- Required approvals: not applicable — branch protection on `main` has no required-reviewer policy configured (`gh api repos/rysweet/azlin/branches/main/protection`)
- Requested changes or blocking votes: none (`reviewDecision` empty, no reviews, no review requests)
- Stale approval policy checked: not applicable — no review policy exists
- Review evidence source: `gh pr view 1071 --json reviewDecision,reviews,reviewRequests`

### Merge conflicts

- Mergeability status: clean
- Conflict evidence source: `gh pr view 1071 --json mergeable,mergeStateStatus` -> `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`
- Conflict resolution required: none

### Policies/protection

- Required policies/protection: not applicable — `gh api repos/rysweet/azlin/branches/main/protection` shows no required status checks and no required-reviewer policy configured on `main`
- Required checks/build policy: not applicable (none configured)
- Required review policy: not applicable (none configured)
- Required conversation/thread policy: not applicable (none configured)
- Policy evidence source: `gh api repos/rysweet/azlin/branches/main/protection`

### Linked work items/issues

- Required linked work items/issues: not applicable — no repo policy requires a linked issue, but this PR already links one
- Linked items: `Fixes #1070` (the regression report); the PR title/body reference #516/#517 as the prior, now-re-regressed fix, but those are historical context rather than open tracking issues, so no further linking is needed
- Rationale: #1070 is the actual open tracking issue for this regression; #516/#517 are closed and already resolved once
- Link evidence source: `gh pr view 1071 --json closingIssuesReferences`

### Comments/threads

- Required comments/threads resolved: not applicable — no required conversation-resolution policy configured
- Unresolved but non-blocking comments/threads: the crusty-engineer review comment posted by this pass (see verdict comment for link) — its two concrete findings were fixed in commit `8f97da2f`, not left open
- Comment/thread evidence source: `gh pr view 1071` comment list

### Scope

- Changed files reviewed: `gh pr diff 1071 --name-only` — 18 files, all under `rust/crates/azlin{,-azure}/src/`, plus `CHANGELOG.md` and `docs/reference/destroy-command.md` (this pass's doc fix). No distro/GUI/packaging files touched, consistent with the author's own scope check in the PR body.
- Unrelated changes: none

### Final merge/close verification

- Intended final action: readiness only — this pass does not merge, per explicit instruction
- Authorized actor: not authorized to merge (task instruction); merge decision is the repo owner's
