### PR TITLE
fix(killall): report prefix mismatch instead of silently deleting nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,23 +724,30 @@ azlin destroy my-vm --delete-rg --force
 - `destroy` - Advanced with dry-run and RG deletion
 - `killall` - Bulk cleanup of multiple VMs
 
-#### `azlin killall` - Delete all VMs in resource group
+#### `azlin killall` - Delete prefix-matched VMs in resource group
 
 ```bash
-# Delete all VMs (with confirmation)
+# Delete VMs matching the default "azlin" prefix (with confirmation)
 azlin killall
 
-# Delete all in specific resource group
+# Same, in a specific resource group
 azlin killall --resource-group my-rg
 
-# Force delete all
+# Skip the confirmation prompt
 azlin killall --force
+
+# Target VMs created with an explicit --name
+azlin killall --prefix smoke-test
+
+# Delete every VM in the resource group
+azlin killall --prefix ''
 ```
 
-**Warning**: This deletes ALL VMs in the resource group!
+**Warning**: This deletes every VM matching `--prefix` and cannot be undone.
 
 **Defaults:**
-- `--prefix`: "azlin" (only deletes azlin-created VMs)
+- `--prefix`: "azlin" (VMs whose name does not start with the prefix — e.g. one
+  created with `azlin new --name smoke-test` — are NOT deleted)
 
 ### `azlin prune` - Automated VM cleanup
 

--- a/docs-site/commands/index.md
+++ b/docs-site/commands/index.md
@@ -50,7 +50,7 @@ Complete reference for all azlin commands organized by category.
 - `azlin vm update-tools` - Update development tools
 - `azlin destroy` - Delete a VM
 - `azlin kill` - Delete VM and resources
-- `azlin killall` - Delete all VMs
+- `azlin killall` - Delete VMs matching a name prefix
 - `azlin prune` - Delete idle VMs
 
 ### AI-Powered Features

--- a/docs-site/commands/util/prune.md
+++ b/docs-site/commands/util/prune.md
@@ -183,5 +183,5 @@ azlin tag vm-prod-1 --add critical=true
 
 - [azlin autopilot](../autopilot/index.md) - Automated optimization
 - [azlin kill](../vm/kill.md) - Delete specific VM
-- [azlin killall](../vm/killall.md) - Delete all VMs
+- [azlin killall](../vm/killall.md) - Delete VMs matching a name prefix
 - [azlin status](../vm/status.md) - View VM activity

--- a/docs-site/commands/vm/destroy.md
+++ b/docs-site/commands/vm/destroy.md
@@ -220,7 +220,7 @@ azlin destroy my-vm --force
 ## Related Commands
 
 - [`azlin kill`](kill.md) - Simple VM deletion
-- [`azlin killall`](killall.md) - Delete all VMs in resource group
+- [`azlin killall`](killall.md) - Delete VMs matching a name prefix
 - [`azlin prune`](../util/prune.md) - Delete inactive VMs
 - [`azlin snapshot create`](../snapshot/create.md) - Create snapshot before destroying
 

--- a/docs-site/commands/vm/kill.md
+++ b/docs-site/commands/vm/kill.md
@@ -223,7 +223,7 @@ azlin kill my-vm --force
 |---------|---------|---------|
 | `azlin kill` | Quick VM deletion | Basic, fast |
 | `azlin destroy` | VM deletion with options | Dry-run, delete-rg |
-| `azlin killall` | Delete all VMs in RG | Mass deletion |
+| `azlin killall` | Delete prefix-matched VMs in RG | Mass deletion |
 | `azlin prune` | Delete inactive VMs | Age/idle filters |
 
 ## Common Workflows
@@ -288,7 +288,7 @@ done
 ## Related Commands
 
 - [`azlin destroy`](destroy.md) - Delete with dry-run and RG options
-- [`azlin killall`](killall.md) - Delete all VMs in resource group
+- [`azlin killall`](killall.md) - Delete VMs matching a name prefix
 - [`azlin prune`](../util/prune.md) - Delete inactive VMs automatically
 - [`azlin snapshot create`](../snapshot/create.md) - Backup before deletion
 

--- a/docs-site/commands/vm/killall.md
+++ b/docs-site/commands/vm/killall.md
@@ -1,6 +1,6 @@
 # azlin killall
 
-Delete all VMs in resource group.
+Delete every VM in a resource group whose name starts with `--prefix`.
 
 ## Synopsis
 
@@ -10,21 +10,39 @@ azlin killall [OPTIONS]
 
 ## Description
 
-Deletes ALL VMs in the resource group and their associated resources. Use with caution!
+Deletes the VMs in the resource group whose names start with `--prefix`
+(default: `azlin`) along with their associated resources. Use with caution!
+
+VMs created with an explicit `--name` that does not start with the prefix are
+**not** deleted. For example `azlin new --name smoke-test` creates a VM that
+`azlin killall` skips by default; delete it with
+`azlin killall --prefix smoke-test`, or pass `--prefix ''` to match every VM in
+the resource group.
 
 ## Options
 
 | Option | Description |
 |--------|-------------|
 | `--force` | Skip confirmation |
+| `--prefix TEXT` | Only delete VMs whose name starts with this prefix (default: `azlin`). Use `''` to match every VM |
 | `--rg TEXT` | Resource group |
 | `-h, --help` | Show help |
 
 ## Examples
 
-### Delete all VMs (with confirmation)
+### Delete the default `azlin`-prefixed VMs (with confirmation)
 ```bash
 azlin killall
+```
+
+### Delete VMs with a custom name prefix
+```bash
+azlin killall --prefix smoke-test
+```
+
+### Delete every VM in the resource group
+```bash
+azlin killall --prefix ''
 ```
 
 ### Force delete without confirmation
@@ -40,34 +58,39 @@ azlin killall --rg test-rg --force
 ## Output Example
 
 ```
-Delete ALL VMs in resource group: my-rg
+Delete these 2 VM(s) with prefix 'azlin' in 'my-rg'? This cannot be undone.
+  azlin-vm-1760000000
+  azlin-vm-1760000001
+ [y/N]: y
 
-VMs to delete:
-  - vm-test-1
-  - vm-test-2
-  - vm-prod-1
-  - vm-staging
+Deleted azlin-vm-1760000000 and 4 associated resource(s)
+Deleted azlin-vm-1760000001 and 4 associated resource(s)
+Deleted 2 VMs with prefix 'azlin'
+```
 
-Total: 4 VMs
+Each VM is torn down individually, so its disks, NIC, Public IP and NSG go
+with it rather than being orphaned.
 
-THIS WILL DELETE ALL VMs AND CANNOT BE UNDONE!
+When nothing matches the prefix but the resource group is not empty, `killall`
+says so instead of silently doing nothing:
 
-Type 'yes' to confirm: yes
-
-Deleting VMs...
-✓ Deleted vm-test-1
-✓ Deleted vm-test-2
-✓ Deleted vm-prod-1
-✓ Deleted vm-staging
-
-All VMs deleted successfully.
+```
+No VMs matched prefix 'azlin' in 'my-rg'. Nothing was deleted.
+2 VM(s) exist in this resource group but do not start with 'azlin':
+  smoke-test
+  other-vm
+Target them with --prefix, for example:
+  azlin killall --prefix 'smoke-test'
+  azlin killall --prefix ''   # every VM in the resource group
 ```
 
 ## Safety Features
 
 - Requires explicit confirmation
-- Lists all VMs before deletion
-- Shows resource count
+- Names the exact VMs that will be deleted before confirming
+- Only deletes VMs matching `--prefix` (default `azlin`)
+- Reports non-matching VMs instead of silently deleting nothing
+- Deletes only the VMs it named, even if a new one appears while you decide
 - Warns about irreversibility
 
 ## Use Cases

--- a/docs-site/development/testing.md
+++ b/docs-site/development/testing.md
@@ -96,7 +96,7 @@ tests/
 - `azlin stop` - Stop running VM
 - `azlin kill` - Delete single VM
 - `azlin destroy` - Delete single VM (alias)
-- `azlin killall` - Delete all VMs in resource group
+- `azlin killall` - Delete VMs matching a name prefix
 - `azlin prune` - Clean up unused resources
 
 **Information/Status (5)**:

--- a/docs-site/vm-lifecycle/deleting.md
+++ b/docs-site/vm-lifecycle/deleting.md
@@ -8,7 +8,7 @@ azlin provides multiple commands for VM deletion with different safety levels an
 
 - **`azlin kill`** - Delete single VM and resources
 - **`azlin destroy`** - Delete VM with dry-run and RG deletion options
-- **`azlin killall`** - Delete all VMs in resource group
+- **`azlin killall`** - Delete VMs matching a name prefix (default: `azlin`)
 - **`azlin prune`** - Intelligently delete inactive/idle VMs
 
 All commands clean up associated resources (NICs, disks, public IPs) to avoid orphaned resources and unnecessary costs.
@@ -64,24 +64,29 @@ azlin destroy my-vm --force
 
 ### azlin killall
 
-Delete all VMs in a resource group, optionally filtered by prefix.
+Delete the VMs in a resource group whose names start with `--prefix`
+(default: `azlin`).
 
 ```bash
-# Delete all VMs (with confirmation)
+# Delete VMs matching the default "azlin" prefix (with confirmation)
 azlin killall
 
-# Delete all VMs without confirmation
+# Same, without confirmation
 azlin killall --force
 
-# Delete only VMs with specific prefix
+# Target VMs created with an explicit --name
 azlin killall --prefix test-vm
+
+# Delete every VM in the resource group
+azlin killall --prefix ''
 
 # Delete in specific resource group
 azlin killall --rg dev-team --force
 ```
 
 **Options:**
-- `--prefix` - Only delete VMs starting with this prefix
+- `--prefix` - Only delete VMs starting with this prefix (default: `azlin`).
+  VMs named outside the prefix are skipped; use `''` to match every VM
 - `--force` - Skip confirmation
 - `--resource-group`, `--rg` - Specify resource group
 

--- a/rust/crates/azlin-cli/src/lib.rs
+++ b/rust/crates/azlin-cli/src/lib.rs
@@ -821,7 +821,7 @@ pub enum Commands {
         delete_rg: bool,
     },
 
-    /// Delete all VMs in resource group
+    /// Delete all VMs whose name starts with --prefix (default: "azlin")
     Killall {
         /// Resource group
         #[arg(long, alias = "rg")]
@@ -835,7 +835,9 @@ pub enum Commands {
         #[arg(long)]
         force: bool,
 
-        /// Only delete VMs with this prefix
+        /// Only delete VMs whose name starts with this prefix. VMs created
+        /// with an explicit --name that does not start with the prefix are
+        /// NOT deleted. Use --prefix '' to match every VM in the group.
         #[arg(long, default_value = "azlin")]
         prefix: String,
     },

--- a/rust/crates/azlin/src/cmd_lifecycle.rs
+++ b/rust/crates/azlin/src/cmd_lifecycle.rs
@@ -161,8 +161,37 @@ pub(crate) async fn dispatch(
             ..
         } => {
             let rg = resolve_resource_group(resource_group)?;
+
+            // List every VM in the resource group first (read-only) so we can
+            // tell "resource group is empty" apart from "prefix matched
+            // nothing", and so the confirmation names the actual VMs.
+            let all_query = crate::lifecycle_helpers::killall_all_names_query();
+            let list_pb = penguin_spinner("Listing VMs...");
+            let list_out = std::process::Command::new("az")
+                .args(crate::lifecycle_helpers::killall_list_args(&rg, all_query))
+                .output()?;
+            list_pb.finish_and_clear();
+            if !list_out.status.success() {
+                anyhow::bail!("Failed to list VMs.");
+            }
+            let names_raw = String::from_utf8_lossy(&list_out.stdout);
+            let all_names: Vec<String> = crate::lifecycle_helpers::parse_vm_ids(&names_raw)
+                .into_iter()
+                .map(str::to_string)
+                .collect();
+            let (matching, unmatched) =
+                crate::lifecycle_helpers::partition_by_prefix(&all_names, &prefix);
+
+            if matching.is_empty() {
+                println!(
+                    "{}",
+                    crate::lifecycle_helpers::killall_no_match_message(&prefix, &rg, &unmatched)
+                );
+                return Ok(());
+            }
+
             if !safe_confirm(
-                &crate::lifecycle_helpers::killall_confirm_prompt(&prefix, &rg),
+                &crate::lifecycle_helpers::killall_confirm_prompt(&prefix, &rg, &matching),
                 force,
             )? {
                 println!("Cancelled.");
@@ -184,12 +213,18 @@ pub(crate) async fn dispatch(
             }
 
             let names_raw = String::from_utf8_lossy(&output.stdout);
-            let names = crate::lifecycle_helpers::parse_vm_ids(&names_raw);
+            // Re-listing picks up VMs deleted elsewhere since the enumeration,
+            // but must never widen the set: the confirmation named specific
+            // VMs, so anything not in that list is not ours to delete.
+            let listed = crate::lifecycle_helpers::parse_vm_ids(&names_raw);
+            let names = crate::lifecycle_helpers::narrow_to_confirmed(&listed, &matching);
             if names.is_empty() {
+                // Only reachable if the matched VMs disappeared between the
+                // enumeration above and this query; report it the same way.
                 pb.finish_and_clear();
                 println!(
                     "{}",
-                    crate::lifecycle_helpers::killall_empty_message(&prefix)
+                    crate::lifecycle_helpers::killall_no_match_message(&prefix, &rg, &unmatched)
                 );
             } else {
                 // Tear each VM down individually rather than batching

--- a/rust/crates/azlin/src/lifecycle_helpers.rs
+++ b/rust/crates/azlin/src/lifecycle_helpers.rs
@@ -11,12 +11,58 @@ pub fn destroy_confirm_prompt(vm_name: &str) -> String {
     format!("Destroy VM '{}'? This cannot be undone.", vm_name)
 }
 
-/// Build the confirmation prompt for killall (batch delete).
-pub fn killall_confirm_prompt(prefix: &str, resource_group: &str) -> String {
+/// Maximum number of VM names listed inline before the list is truncated.
+const NAME_LIST_LIMIT: usize = 10;
+
+/// Format a list of VM names as indented lines, truncated to `NAME_LIST_LIMIT`.
+fn format_name_list(names: &[String]) -> String {
+    let mut out = String::new();
+    for name in names.iter().take(NAME_LIST_LIMIT) {
+        out.push_str(&format!("  {}\n", name));
+    }
+    if names.len() > NAME_LIST_LIMIT {
+        out.push_str(&format!(
+            "  ... and {} more\n",
+            names.len() - NAME_LIST_LIMIT
+        ));
+    }
+    out
+}
+
+/// Build the confirmation prompt for killall.
+///
+/// Lists the VM names that are actually about to be deleted so the user can
+/// see the real blast radius before confirming an irreversible action.
+pub fn killall_confirm_prompt(prefix: &str, resource_group: &str, names: &[String]) -> String {
     format!(
-        "Delete ALL VMs with prefix '{}' in '{}'? This cannot be undone.",
-        prefix, resource_group
+        "Delete these {} VM(s) with prefix '{}' in '{}'? This cannot be undone.\n{}",
+        names.len(),
+        prefix,
+        resource_group,
+        format_name_list(names)
     )
+}
+
+/// Split VM names into (matching prefix, not matching prefix).
+pub fn partition_by_prefix(names: &[String], prefix: &str) -> (Vec<String>, Vec<String>) {
+    names
+        .iter()
+        .cloned()
+        .partition(|name| name.starts_with(prefix))
+}
+
+/// Narrow a freshly listed set of VM names to those the user actually
+/// confirmed.
+///
+/// The confirmation prompt names specific VMs, so the delete set may only
+/// shrink (VMs removed elsewhere in the meantime) and never grow (VMs created
+/// during the prompt must not be deleted unannounced).
+pub fn narrow_to_confirmed<'a>(listed: &[&'a str], confirmed: &[String]) -> Vec<&'a str> {
+    listed
+        .iter()
+        .copied()
+        .filter(|n| confirmed.iter().any(|c| c == n))
+        .collect()
 }
 
 /// Build a spinner progress message for a lifecycle action on a VM.
@@ -31,6 +77,11 @@ pub fn progress_message(action: &str, vm_name: &str) -> String {
 /// the session's public IP and NSG.
 pub fn killall_jmespath_query(prefix: &str) -> String {
     format!("[?starts_with(name, '{}')].name", prefix)
+}
+
+/// JMESPath query listing every VM name in the resource group (read-only).
+pub fn killall_all_names_query() -> &'static str {
+    "[].name"
 }
 
 /// Build the az CLI args for listing VMs filtered by prefix in a resource group.
@@ -48,6 +99,10 @@ pub fn killall_list_args<'a>(resource_group: &'a str, query: &'a str) -> Vec<&'a
 }
 
 /// Parse the TSV output from `az vm list` into a list of non-empty VM names.
+///
+/// Used for both the full-resource-group enumeration (`[].name`) and the
+/// prefix-filtered query; both select names, because per-VM teardown looks a
+/// session's disks/NIC/IP/NSG up by VM name.
 pub fn parse_vm_ids(tsv_output: &str) -> Vec<&str> {
     tsv_output.lines().filter(|l| !l.is_empty()).collect()
 }
@@ -76,9 +131,32 @@ pub fn killall_success_message(count: usize, prefix: &str) -> String {
     format!("Deleted {} VMs with prefix '{}'", count, prefix)
 }
 
-/// Format the "no VMs found" message for killall.
-pub fn killall_empty_message(prefix: &str) -> String {
-    format!("No VMs found with prefix '{}'", prefix)
+/// Format the message shown when no VM matched the killall prefix.
+///
+/// `unmatched` are the VMs that exist in the resource group but do not start
+/// with `prefix`. Reporting them prevents the silent no-op that makes an empty
+/// resource group indistinguishable from a prefix mismatch.
+pub fn killall_no_match_message(prefix: &str, resource_group: &str, unmatched: &[String]) -> String {
+    if unmatched.is_empty() {
+        return format!(
+            "No VMs found in resource group '{}'. Nothing was deleted.",
+            resource_group
+        );
+    }
+    format!(
+        "No VMs matched prefix '{}' in '{}'. Nothing was deleted.\n\
+         {} VM(s) exist in this resource group but do not start with '{}':\n\
+         {}\
+         Target them with --prefix, for example:\n  \
+         azlin killall --prefix '{}'\n  \
+         azlin killall --prefix ''   # every VM in the resource group",
+        prefix,
+        resource_group,
+        unmatched.len(),
+        prefix,
+        format_name_list(unmatched),
+        unmatched[0]
+    )
 }
 
 /// Format the OS update error detail from stderr.
@@ -144,10 +222,23 @@ mod tests {
 
     #[test]
     fn test_killall_confirm_prompt() {
-        assert_eq!(
-            killall_confirm_prompt("test-", "my-rg"),
-            "Delete ALL VMs with prefix 'test-' in 'my-rg'? This cannot be undone."
-        );
+        let names = vec!["test-a".to_string(), "test-b".to_string()];
+        let prompt = killall_confirm_prompt("test-", "my-rg", &names);
+        assert!(prompt.starts_with(
+            "Delete these 2 VM(s) with prefix 'test-' in 'my-rg'? This cannot be undone."
+        ));
+        assert!(prompt.contains("\n  test-a\n"));
+        assert!(prompt.contains("\n  test-b\n"));
+    }
+
+    #[test]
+    fn test_killall_confirm_prompt_truncates_long_lists() {
+        let names: Vec<String> = (0..13).map(|i| format!("vm-{i}")).collect();
+        let prompt = killall_confirm_prompt("vm-", "rg", &names);
+        assert!(prompt.contains("Delete these 13 VM(s)"));
+        assert!(prompt.contains("  vm-9\n"));
+        assert!(!prompt.contains("  vm-10\n"));
+        assert!(prompt.contains("... and 3 more"));
     }
 
     // ── Progress / spinner messages ────────────────────────────────────
@@ -203,11 +294,68 @@ mod tests {
     }
 
     #[test]
-    fn test_killall_empty_message() {
+    fn test_killall_no_match_message_empty_rg() {
         assert_eq!(
-            killall_empty_message("nope-"),
-            "No VMs found with prefix 'nope-'"
+            killall_no_match_message("azlin", "my-rg", &[]),
+            "No VMs found in resource group 'my-rg'. Nothing was deleted."
         );
+    }
+
+    #[test]
+    fn test_killall_no_match_message_reports_unmatched_vms() {
+        let unmatched = vec!["smoke-test".to_string(), "other-vm".to_string()];
+        let msg = killall_no_match_message("azlin", "my-rg", &unmatched);
+        assert!(msg.contains("No VMs matched prefix 'azlin' in 'my-rg'. Nothing was deleted."));
+        assert!(msg.contains("2 VM(s) exist in this resource group"));
+        assert!(msg.contains("  smoke-test\n"));
+        assert!(msg.contains("  other-vm\n"));
+        assert!(msg.contains("azlin killall --prefix 'smoke-test'"));
+        assert!(msg.contains("--prefix ''"));
+    }
+
+    #[test]
+    fn test_killall_all_names_query() {
+        assert_eq!(killall_all_names_query(), "[].name");
+    }
+
+    #[test]
+    fn test_partition_by_prefix() {
+        let names = vec![
+            "azlin-vm-1".to_string(),
+            "smoke-test".to_string(),
+            "azlin-vm-2".to_string(),
+        ];
+        let (matched, unmatched) = partition_by_prefix(&names, "azlin");
+        assert_eq!(matched, vec!["azlin-vm-1", "azlin-vm-2"]);
+        assert_eq!(unmatched, vec!["smoke-test"]);
+    }
+
+    #[test]
+    fn test_narrow_to_confirmed_drops_unannounced_vms() {
+        // A VM created between the confirmation and the delete query must not
+        // be torn down: the user never saw it in the prompt.
+        let listed = vec!["azlin-a", "azlin-new", "azlin-b"];
+        let confirmed = vec!["azlin-a".to_string(), "azlin-b".to_string()];
+        assert_eq!(
+            narrow_to_confirmed(&listed, &confirmed),
+            vec!["azlin-a", "azlin-b"]
+        );
+    }
+
+    #[test]
+    fn test_narrow_to_confirmed_allows_shrinking() {
+        // A VM deleted elsewhere in the meantime simply drops out.
+        let listed = vec!["azlin-a"];
+        let confirmed = vec!["azlin-a".to_string(), "azlin-gone".to_string()];
+        assert_eq!(narrow_to_confirmed(&listed, &confirmed), vec!["azlin-a"]);
+    }
+
+    #[test]
+    fn test_partition_by_prefix_empty_prefix_matches_all() {
+        let names = vec!["a".to_string(), "b".to_string()];
+        let (matched, unmatched) = partition_by_prefix(&names, "");
+        assert_eq!(matched.len(), 2);
+        assert!(unmatched.is_empty());
     }
 
     // ── OS update helpers ──────────────────────────────────────────────

--- a/tests/agentic-scenarios/pr-1073-killall-prefix-mismatch.yaml
+++ b/tests/agentic-scenarios/pr-1073-killall-prefix-mismatch.yaml
@@ -1,0 +1,122 @@
+name: "azlin killall reports prefix mismatch instead of silently deleting nothing"
+description: |
+  Verifies PR #1073: `killall` no longer confirms a destructive "delete ALL"
+  action and then silently no-ops when no VM matches --prefix. The help text
+  must describe the prefix filter accurately, and the source must implement
+  the enumerate-then-partition-then-narrow safety logic (report unmatched
+  VMs, name the VMs actually about to be deleted, and never widen the delete
+  set past what was confirmed). This does not exercise a live Azure call
+  (no credentials in this environment); it checks the CLI surface and the
+  presence of the safety-critical functions in source.
+
+version: "1.0.0"
+
+config:
+  timeout: 30000
+
+agents:
+  - name: "cli-agent"
+    type: "system"
+    config:
+      workingDirectory: "."
+      shell: "bash"
+      timeout: 10000
+
+steps:
+  - name: "Verify killall --help documents prefix filtering, not 'delete all'"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: |
+        HELP=$(rust/target/debug/azlin killall --help)
+        echo "$HELP" | grep -q -- "--prefix" || { echo "FAIL: --prefix not documented"; exit 1; }
+        echo "$HELP" | grep -qi "starts with this prefix" || { echo "FAIL: prefix semantics not documented"; exit 1; }
+        echo "$HELP" | grep -qi "Delete all VMs in resource group" && { echo "FAIL: stale 'delete all' wording still present"; exit 1; }
+        echo "PASS: killall --help documents prefix filtering"
+    expect:
+      exit_code: 0
+      stdout_contains: "PASS"
+    timeout: 5000
+
+  - name: "Verify killall command help summary reflects prefix scoping"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: |
+        rust/target/debug/azlin --help | grep -i killall | grep -qi "prefix" \
+          && echo "PASS: top-level help mentions prefix scoping" \
+          || { echo "FAIL: top-level killall summary does not mention prefix"; exit 1; }
+    expect:
+      exit_code: 0
+      stdout_contains: "PASS"
+    timeout: 5000
+
+  - name: "Verify no-match reporting distinguishes prefix-mismatch from empty resource group"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: |
+        grep -q "fn killall_no_match_message" rust/crates/azlin/src/lifecycle_helpers.rs \
+          && grep -q "No VMs matched prefix" rust/crates/azlin/src/lifecycle_helpers.rs \
+          && grep -q "No VMs found in resource group" rust/crates/azlin/src/lifecycle_helpers.rs \
+          && echo "PASS: distinct empty-RG vs prefix-mismatch messages present" \
+          || { echo "FAIL: killall_no_match_message missing or does not distinguish cases"; exit 1; }
+    expect:
+      exit_code: 0
+      stdout_contains: "PASS"
+    timeout: 5000
+
+  - name: "Verify confirmation prompt names the VMs actually targeted"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: |
+        grep -q "fn killall_confirm_prompt" rust/crates/azlin/src/lifecycle_helpers.rs \
+          && grep -q "names: &\[String\]" rust/crates/azlin/src/lifecycle_helpers.rs \
+          && echo "PASS: confirm prompt takes the concrete VM name list" \
+          || { echo "FAIL: confirm prompt no longer names specific VMs"; exit 1; }
+    expect:
+      exit_code: 0
+      stdout_contains: "PASS"
+    timeout: 5000
+
+  - name: "Verify the delete set can only shrink after confirmation, never grow"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: |
+        grep -q "fn narrow_to_confirmed" rust/crates/azlin/src/lifecycle_helpers.rs \
+          && grep -q "narrow_to_confirmed(&listed, &matching)" rust/crates/azlin/src/cmd_lifecycle.rs \
+          && echo "PASS: post-confirmation query is narrowed to the confirmed set" \
+          || { echo "FAIL: narrow_to_confirmed not wired into the killall dispatch path"; exit 1; }
+    expect:
+      exit_code: 0
+      stdout_contains: "PASS"
+    timeout: 5000
+
+  - name: "Run lifecycle_helpers unit tests covering the killall safety logic"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: |
+        cd rust && cargo test --locked -p azlin --lib lifecycle_helpers::tests 2>&1 | tail -20
+    expect:
+      exit_code: 0
+      stdout_contains: "test result: ok"
+    timeout: 25000
+
+assertions:
+  - name: "killall prefix-mismatch safety logic is present and passing"
+    type: "command_success"
+    agent: "cli-agent"
+    params:
+      step: "Run lifecycle_helpers unit tests covering the killall safety logic"
+
+metadata:
+  tags:
+    - "killall"
+    - "safety"
+    - "cli"
+    - "regression"
+  priority: "high"
+  pr: 1073


### PR DESCRIPTION
> **Depends on #1071 — merge that first.**
> This branch is rebased onto #1071 (`ahrkrak-fix-destroy-resource-leak`), which is itself based on `main` @ a70f1a9d. #1071 replaces killall's batch `az vm delete --ids` with a per-VM teardown loop so Public IPs and NSGs are not orphaned; **that behaviour is preserved verbatim here** and the batch form is never reintroduced. The diff below is only what this PR adds on top. Reviewing #1073's own changes: compare against the #1071 branch.

Two pre-existing bugs found while smoke-testing on macOS. Both are small and independent; grouped here because they were hit in the same session.

## 1. `killall` silently deletes nothing when the prefix does not match

`Killall` filters VMs by `--prefix` (default `azlin`), but its help said *"Delete all VMs in resource group"* and the prompt said *"Delete **ALL** VMs with prefix 'azlin' in '<rg>'? This cannot be undone."*

Auto-generated names are `azlin-vm-<timestamp>` so they match — but a VM created with an explicit name (`azlin new --name smoke-test`) does not. `killall` then printed only:

```
No VMs found with prefix 'azlin'
```

which is practically indistinguishable from *"the resource group is empty"*. I confirmed a scary irreversible prompt, nothing happened, and I concluded the group was empty while a VM could still have been billing. Silently no-opping after a destructive confirmation is the wrong failure direction for a cost-sensitive command.

**This does not widen the blast radius.** The default prefix stays `azlin`; changing it to match everything would make an already-destructive command far more dangerous. Instead the command is made honest and discoverable:

- Help text now states the prefix filtering accurately.
- One extra **read-only** `az vm list --query "[].name"` enumerates every VM in the group, so a zero-match run can tell the two cases apart:

  ```
  No VMs matched prefix 'azlin' in 'my-rg'. Nothing was deleted.
  3 VM(s) exist in this resource group but do not start with 'azlin':
    smoke-test
    other-vm
    third-box
  Target them with --prefix, for example:
    azlin killall --prefix 'smoke-test'
    azlin killall --prefix ''   # every VM in the resource group
  ```

  vs. a genuinely empty group:

  ```
  No VMs found in resource group 'my-rg'. Nothing was deleted.
  ```

- The confirmation now names the VMs actually about to be deleted rather than an abstract "ALL" (list truncated after 10):

  ```
  Delete these 2 VM(s) with prefix 'azlin' in 'my-rg'? This cannot be undone.
    azlin-vm-1760000000
    azlin-vm-1760000001
  ```

- Because the prompt now *promises* a specific list, the delete set is narrowed to the confirmed names (`narrow_to_confirmed`). It may shrink — a VM removed elsewhere while you decide simply drops out — but a VM created during the prompt is never torn down unannounced.

The teardown itself is #1071's per-VM `handle_delete` loop, untouched.

## 2. macOS: `vncviewer` app bundle never found

`azlin gui` probed only `which vncviewer`. On macOS `brew install --cask tigervnc` installs an **app bundle** at `/Applications/TigerVNC.app/Contents/MacOS/vncviewer` and creates no symlink on PATH, so the check failed — and told the user to run `brew install --cask tigervnc-viewer`, which they had already done. Following the advice could never fix it. (Verified locally: TigerVNC 1.16.2, `brew list` shows `tigervnc`, bundle binary present.)

- On macOS, when the PATH lookup misses, fall back to known app-bundle locations (`/Applications` and `~/Applications`), and launch the **resolved absolute path** rather than the bare name.
- PATH still wins when it hits. **Non-macOS behaviour is unchanged** (PATH lookup only).
- Only `TigerVNC.app` is probed — the one bundle path I could actually verify rather than guess.
- The "not found" error now lists every location probed:

  ```
  vncviewer not found on PATH or in any known app bundle:
    /Applications/TigerVNC.app/Contents/MacOS/vncviewer
    /Users/<you>/Applications/TigerVNC.app/Contents/MacOS/vncviewer
  Install it with:
    macOS:         brew install --cask tigervnc
    Debian/Ubuntu: sudo apt-get install -y tigervnc-viewer tigervnc-common
  ```

## Verification

Real output from the discovery function on a Mac with TigerVNC installed:

```
vncviewer_on_path()        : true
find_vncviewer_with(true)  : Some("vncviewer")                                          # PATH wins
find_vncviewer_with(false) : Some("/Applications/TigerVNC.app/Contents/MacOS/vncviewer") # bundle fallback
```

Queries after the rebase — both select names, as #1071 requires for per-VM teardown:

```
matched VMs   : [?starts_with(name, 'azlin')].name
enumerate all : [].name
```

Narrowing, exercised directly:

```
listed by delete query : ["azlin-vm-1760000000", "azlin-vm-CREATED-DURING-PROMPT"]
confirmed in prompt    : ["azlin-vm-1760000000", "azlin-vm-1760000001"]
actually deleted       : ["azlin-vm-1760000000"]
```

Gates (`rustup run stable`):
- `cargo build --release --locked` — clean
- `cargo test --all --locked` — 3564 passed, 0 failed
- `cargo clippy --all --locked -- -D warnings` — clean

Unit tests added for both fixes; docs (`README.md`, `docs-site/commands/vm/killall.md`, `docs-site/vm-lifecycle/deleting.md`, `docs-site/commands/index.md`) updated to describe actual behaviour.

Opened as a draft for review.

---

## Merge readiness (added by merge-ready pass)

- Platform: GitHub
- PR: #1073 — https://github.com/rysweet/azlin/pull/1073
- Source -> target: `ahrkrak-fix-killall-and-viewer-discovery` -> `main`
- Current head revision: `6d917964ac45052343c9289268ed0f7a2a4f44fc`

### QA-team evidence

- Scenario file: `tests/agentic-scenarios/pr-1073-killall-prefix-mismatch.yaml`
- Validation command: `gadugi-test validate -f tests/agentic-scenarios/pr-1073-killall-prefix-mismatch.yaml --strict`
- Validation result: passed (`✓ All 1 file(s) are valid`)
- Run command: `gadugi-test run -f tests/agentic-scenarios/pr-1073-killall-prefix-mismatch.yaml`
- Run target: local sandbox (no Azure credentials available)
- Run result: not executed end-to-end against a live resource group — `killall` requires real `az` CLI auth to enumerate VMs, which this sandbox does not have. The scenario instead validates the CLI surface (`--help` text no longer says "delete all", documents `--prefix`), confirms the safety-critical functions (`killall_no_match_message`, `killall_confirm_prompt`, `narrow_to_confirmed`) are present and wired into the dispatch path, and runs the existing `lifecycle_helpers` unit test suite that exercises the same logic without a live VM.
- Evidence location: `tests/agentic-scenarios/pr-1073-killall-prefix-mismatch.yaml`

### Documentation

- User-facing docs impact: yes
- Updated docs: `README.md`, `docs-site/commands/vm/killall.md`, `docs-site/commands/index.md`, `docs-site/vm-lifecycle/deleting.md` (author's own commit); `docs-site/commands/vm/kill.md`, `docs-site/commands/vm/destroy.md`, `docs-site/commands/util/prune.md`, `docs-site/development/testing.md` (merge-ready pass — these four pages still said "Delete all VMs in resource group" in cross-references to `killall`, which is exactly the stale wording this PR's fix corrects; brought them in line with the corrected description)
- Description links added: n/a
- Rationale: `killall`'s prompt/help/error-message text is a documented, user-facing interface, not an internal-only message, so the doc updates are required and were largely already done by the author; the merge-ready pass closed the remaining cross-reference gaps.

### Quality-audit

- Cycle 1: Read the full diff of the PR's own commit (`c6d5b56a`) plus `cmd_lifecycle.rs`/`lifecycle_helpers.rs` in full; confirmed single production call site for all touched helpers, confirmed the pre-existing `autopilot_helpers::build_prefix_filter_query` is dead code (not a second live killall path); verified prefix-matching semantics agree between Rust `str::starts_with` (client partition) and Azure CLI JMESPath `starts_with()` (server-side query used to build the delete list), per the JMESPath spec (no normalization, no case-folding on either side). No blocking findings; posted as a PR review comment.
- Cycle 2: Grepped `docs-site/` and `README.md` for every remaining "killall" reference to check for stale "delete all" wording outside the files the author already touched. Found four: `kill.md`, `destroy.md`, `prune.md`, `development/testing.md`. Fixed all four to match the corrected description; verified `docs-site/` is not in `doc-validation.yml`'s path filters (so this doesn't gate CI) but is covered by the `build-preview` mkdocs job, which passed after the push.
- Cycle 3: Re-read the full diff after the two fix commits, re-ran `gh pr checks 1073` (all green) and the `gadugi-test validate --strict` check on the new scenario file (passed). Checked branch protection (`gh api repos/rysweet/azlin/branches/main/protection`) — no required status checks, no required review policy configured. Checked PR metadata (`reviews`, `latestReviews`, `reviewRequests`, `closingIssuesReferences`) — all empty; not applicable. No further findings; final cycle clean.
- Additional cycles: none required — cycle 3 was clean (no new critical/high findings).
- Final clean cycle: 3
- Fixes followed default-workflow: yes
- Convergence summary: The only concrete, fixable finding from the technical review (crusty-engineer comment) was a documentation gap (stale cross-references), which is fixed above; the other two review observations (dead `build_prefix_filter_query` helper, PR description mentioning a bug that lives entirely in sibling PR #1074) are explicitly flagged as non-blocking follow-ups, not defects in this PR's own diff.

### Checks/build validation

- Evidence source: `gh pr checks 1073`
- Current head validated: `6d917964ac45052343c9289268ed0f7a2a4f44fc`
- Required checks/build validations: all passed (no required checks are configured on `main`, but every check GitHub reports for this PR is green, including `pip-audit Dependency Scan`, `Validate Documentation Consistency`, `build-preview`, and `build-and-test`, which runs `cargo build --release --locked`, `cargo test --all --locked`, and `cargo clippy --all --locked -- -D warnings`)
- Optional or skipped validations: `OSSF Scorecard` — skipping (repo/branch policy, not related to this PR)
- Reruns performed: full CI reran automatically after each of the two merge-ready-pass pushes; both runs are green
- Real failures fixed: none — CI was green from the first push (the `pip-audit` failure referenced in the merge-ready brief was already resolved on `main` by a6db3f6f before this branch synced with it)

### PR metadata

- Title: `fix(killall): report prefix mismatch instead of silently deleting nothing`
- Description complete: yes (author's original write-up plus this evidence block)
- Source branch: `ahrkrak-fix-killall-and-viewer-discovery` (fork: `ahrkrak/azlin`)
- Target branch: `main`
- Draft state: **draft** — this blocks GitHub's merge button; not changed by this pass per instructions
- Required labels/tags/milestone: not applicable (none configured on this repo/PR)
- Metadata evidence source: `gh pr view 1073 --json title,body,headRefName,baseRefName,isDraft,labels,milestone`

### Reviews/approvals

- Required approvals: not applicable — no required review policy configured on `main`
- Requested changes or blocking votes: none
- Stale approval policy checked: not applicable
- Review evidence source: `gh pr view 1073 --json reviewDecision,reviews,reviewRequests` (all empty)

### Merge conflicts

- Mergeability status: clean (`MERGEABLE` / `mergeStateStatus: CLEAN`)
- Conflict evidence source: `gh pr view 1073 --json mergeable,mergeStateStatus`
- Conflict resolution required: none

### Policies/protection

- Required policies/protection: not applicable — no branch protection rules configured on `main` (verified via `gh api repos/rysweet/azlin/branches/main/protection`: no required status checks, `enforce_admins: false`, no required PR review block present)
- Required checks/build policy: not applicable
- Required review policy: not applicable
- Required conversation/thread policy: not applicable
- Policy evidence source: `gh api repos/rysweet/azlin/branches/main/protection`

### Linked work items/issues

- Required linked work items/issues: not applicable — repo does not require issue linkage
- Linked items: none
- Rationale: `gh pr view 1073 --json closingIssuesReferences` returns an empty list; this PR documents its own repro rather than referencing a filed issue
- Link evidence source: `gh pr view 1073 --json closingIssuesReferences`

### Comments/threads

- Required comments/threads resolved: not applicable — no review threads exist yet
- Unresolved but non-blocking comments/threads: none at push time (the crusty-engineer review and this evidence update are the only PR-level comments so far; both are informational, not blocking review comments)
- Comment/thread evidence source: `gh pr view 1073 --json comments`

### Scope

- Changed files reviewed: `gh pr diff 1073 --name-only`
- Unrelated changes: **none in code** — the PR's own commit (`c6d5b56a`) touches only killall's help text, prompt, and matching/reporting logic (`lifecycle_helpers.rs`, `cmd_lifecycle.rs`, `azlin-cli/src/lib.rs`) plus its own docs. The large additional diff visible in `gh pr diff`/file list (`teardown.rs`, `vm.rs`, `ops.rs`, `handlers/*`, etc.) comes entirely from the still-open, not-yet-merged dependency PR #1071 (`ahrkrak-fix-destroy-resource-leak`), which this branch is intentionally stacked on, as stated at the top of the PR description ("Depends on #1071 — merge that first"). **The PR title/body's second topic — macOS `vncviewer` app-bundle discovery — is not in this PR's diff at all**; that work lives entirely in the independent sibling PR #1074 (`ahrkrak-fix-macos-vncviewer-discovery`, based directly on `main`, no shared files with #1073). This is a description/title mismatch, not a code scope problem: recommend trimming PR #1073's description to the killall fix only before merge, since as written it describes work that isn't here.

### Final merge/close verification

- Intended final action: readiness only — this pass does not merge or un-draft
- Authorized actor: not authorized (explicitly out of scope for this pass)
- Final action performed: no
- Final platform state: open (draft)
- Verification evidence source: `gh pr view 1073 --json state,isDraft,mergedAt`
- Remaining external blockers: PR is a draft; GitHub will not offer a merge button until it is marked ready for review. #1071 (the dependency this branch is stacked on) is also still open/unmerged, per the PR's own stated dependency — merging #1073 before #1071 would put unmerged #1071 commits on `main` via #1073's squash merge, so #1071 should land first regardless of #1073's own readiness.

### Verdict

- Verdict: **MERGE_READY** (code and CI), blocked only by process/state items outside this pass's authority
- Remaining blockers:
  1. PR is a **draft** — must be marked "ready for review" by the author or a maintainer before GitHub allows merging (not done here, per instructions).
  2. This branch is stacked on **#1071**, which is not yet merged — merging #1073 first would carry #1071's unmerged commits into `main` through #1073's squash merge. #1071 should merge first.
  3. PR description currently describes a second bug (macOS `vncviewer`) that is not in this PR's diff — recommend trimming before merge so the merged history matches the merged diff (cosmetic, not a code blocker).
