### PR TITLE
fix(gui): find vncviewer in macOS app bundles when it is not on PATH

### DIFF
--- a/rust/crates/azlin/src/cmd_gui.rs
+++ b/rust/crates/azlin/src/cmd_gui.rs
@@ -182,24 +182,89 @@ fn check_local_deps() -> Result<()> {
         // Not fatal — vncviewer may still work if DISPLAY gets set before launch
     }
 
-    // Check for vncviewer
-    let has_vncviewer = std::process::Command::new("which")
+    // Check for vncviewer (PATH first, then macOS app bundles)
+    if find_vncviewer().is_none() {
+        anyhow::bail!("{}", vncviewer_missing_message());
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// vncviewer discovery
+// ---------------------------------------------------------------------------
+
+/// Relative paths (inside an applications directory) of known macOS VNC viewer
+/// app bundles. `brew install --cask tigervnc` installs an app bundle and does
+/// not put `vncviewer` on PATH, so a PATH-only probe misses it.
+#[cfg(target_os = "macos")]
+const MACOS_VIEWER_BUNDLE_PATHS: &[&str] = &["TigerVNC.app/Contents/MacOS/vncviewer"];
+
+/// Absolute macOS app-bundle locations to probe, in priority order.
+#[cfg(target_os = "macos")]
+fn macos_viewer_candidates() -> Vec<std::path::PathBuf> {
+    let mut roots = vec![std::path::PathBuf::from("/Applications")];
+    if let Some(home) = std::env::var_os("HOME") {
+        roots.push(std::path::Path::new(&home).join("Applications"));
+    }
+    roots
+        .iter()
+        .flat_map(|root| MACOS_VIEWER_BUNDLE_PATHS.iter().map(move |p| root.join(p)))
+        .collect()
+}
+
+/// True when `vncviewer` is resolvable on PATH.
+fn vncviewer_on_path() -> bool {
+    std::process::Command::new("which")
         .arg("vncviewer")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()
         .map(|s| s.success())
-        .unwrap_or(false);
+        .unwrap_or(false)
+}
 
-    if !has_vncviewer {
-        anyhow::bail!(
-            "vncviewer not found. Install it with:\n  \
-             sudo apt-get install -y tigervnc-viewer tigervnc-common\n  \
-             Or on macOS: brew install --cask tigervnc-viewer"
-        );
+/// Resolve the vncviewer command, given whether it is already on PATH.
+///
+/// PATH always wins (unchanged behaviour on every platform). Only when PATH
+/// lookup fails does macOS fall back to well-known app-bundle locations.
+fn find_vncviewer_with(on_path: bool) -> Option<std::path::PathBuf> {
+    if on_path {
+        return Some(std::path::PathBuf::from("vncviewer"));
     }
+    #[cfg(target_os = "macos")]
+    {
+        macos_viewer_candidates()
+            .into_iter()
+            .find(|candidate| candidate.is_file())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
+}
 
-    Ok(())
+/// Locate the vncviewer binary to launch, or `None` if it is not installed.
+fn find_vncviewer() -> Option<std::path::PathBuf> {
+    find_vncviewer_with(vncviewer_on_path())
+}
+
+/// Error text for a genuinely missing viewer, naming every location probed.
+fn vncviewer_missing_message() -> String {
+    let mut msg = String::from("vncviewer not found on PATH");
+    #[cfg(target_os = "macos")]
+    {
+        msg.push_str(" or in any known app bundle:");
+        for candidate in macos_viewer_candidates() {
+            msg.push_str(&format!("\n  {}", candidate.display()));
+        }
+    }
+    msg.push_str(
+        "\nInstall it with:\n  \
+         macOS:         brew install --cask tigervnc\n  \
+         Debian/Ubuntu: sudo apt-get install -y tigervnc-viewer tigervnc-common",
+    );
+    msg
 }
 
 // ---------------------------------------------------------------------------
@@ -544,7 +609,14 @@ fn launch_viewer(ssh_cmd_prefix: &[String], password: &str, local_port: u16) -> 
         display
     };
 
-    let mut cmd = std::process::Command::new("vncviewer");
+    let viewer = match find_vncviewer() {
+        Some(v) => v,
+        None => {
+            let _ = std::fs::remove_file(&passwd_file);
+            anyhow::bail!("{}", vncviewer_missing_message());
+        }
+    };
+    let mut cmd = std::process::Command::new(&viewer);
     cmd.args(build_vnc_viewer_args(&passwd_file, local_port));
 
     if !effective_display.is_empty() {
@@ -916,5 +988,59 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("dependency/setup phase"));
         assert!(msg.contains("apt failed"));
+    }
+
+    // ── vncviewer discovery ────────────────────────────────────────────
+
+    #[test]
+    fn test_find_vncviewer_prefers_path() {
+        assert_eq!(
+            find_vncviewer_with(true),
+            Some(std::path::PathBuf::from("vncviewer"))
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_macos_viewer_candidates_include_system_and_user_bundles() {
+        let candidates = macos_viewer_candidates();
+        assert!(candidates.contains(&std::path::PathBuf::from(
+            "/Applications/TigerVNC.app/Contents/MacOS/vncviewer"
+        )));
+        if let Some(home) = std::env::var_os("HOME") {
+            let user_bundle = std::path::Path::new(&home)
+                .join("Applications/TigerVNC.app/Contents/MacOS/vncviewer");
+            assert!(candidates.contains(&user_bundle));
+        }
+        // /Applications is probed before ~/Applications.
+        assert!(candidates[0].starts_with("/Applications"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_find_vncviewer_falls_back_to_app_bundle_when_present() {
+        // When TigerVNC.app is installed, a PATH miss must still resolve to
+        // the bundle binary rather than reporting "not found".
+        let installed = macos_viewer_candidates().into_iter().find(|c| c.is_file());
+        match installed {
+            Some(expected) => assert_eq!(find_vncviewer_with(false), Some(expected)),
+            None => assert_eq!(find_vncviewer_with(false), None),
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn test_find_vncviewer_no_fallback_off_macos() {
+        assert_eq!(find_vncviewer_with(false), None);
+    }
+
+    #[test]
+    fn test_vncviewer_missing_message_mentions_install_commands() {
+        let msg = vncviewer_missing_message();
+        assert!(msg.contains("vncviewer not found on PATH"));
+        assert!(msg.contains("brew install --cask tigervnc"));
+        assert!(msg.contains("tigervnc-viewer"));
+        #[cfg(target_os = "macos")]
+        assert!(msg.contains("/Applications/TigerVNC.app/Contents/MacOS/vncviewer"));
     }
 }

--- a/tests/agentic-scenarios/pr-1074-macos-vncviewer-discovery.yaml
+++ b/tests/agentic-scenarios/pr-1074-macos-vncviewer-discovery.yaml
@@ -1,0 +1,87 @@
+name: "PR 1074 macOS vncviewer app-bundle discovery"
+description: |
+  Verifies that `azlin gui`'s vncviewer discovery is no longer PATH-only.
+  On macOS, `brew install --cask tigervnc` installs an app bundle with no
+  PATH symlink; a PATH-only `which vncviewer` probe reports the viewer as
+  missing even when it is correctly installed. This PR adds a macOS
+  app-bundle fallback (`find_vncviewer_with`) that both the pre-flight
+  check and the actual launch site now share, and rewrites the "not found"
+  message to list every location actually probed.
+
+  Live end-to-end coverage of the macOS-only fallback path is not possible
+  in this sandbox: it requires real macOS hardware with TigerVNC.app
+  installed via the cask, and this repo's CI matrix is Linux-only (the
+  `#[cfg(target_os = "macos")]` branch is never compiled, let alone run,
+  on Linux). The author validated the macOS-specific behavior by hand on
+  real hardware (see the PR body). This scenario instead asserts the
+  cross-platform contract that IS exercisable here: PATH still wins when a
+  PATH binary exists, the source correctly separates the macOS-only
+  fallback behind a cfg gate, and the "not found" message documents both
+  the macOS cask and the Debian/Ubuntu apt install path.
+version: "1.0.0"
+
+config:
+  timeout: 60000
+
+agents:
+  - name: "cli-agent"
+    type: "system"
+    config:
+      workingDirectory: "."
+      shell: "bash"
+      timeout: 60000
+
+steps:
+  - name: "vncviewer discovery helpers exist and PATH still wins"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: |
+        set -euo pipefail
+        FILE=rust/crates/azlin/src/cmd_gui.rs
+
+        grep -q "fn find_vncviewer_with(on_path: bool)" "$FILE"
+        grep -q "fn vncviewer_on_path()" "$FILE"
+        grep -q 'cfg(target_os = "macos")' "$FILE"
+        grep -q "fn vncviewer_missing_message()" "$FILE"
+
+        # launch_viewer must resolve through find_vncviewer(), not a bare
+        # "vncviewer" Command::new — otherwise discovery and launch could
+        # disagree about what "found" means.
+        grep -q 'let viewer = match find_vncviewer()' "$FILE"
+
+        # the "not found" message must name both real install paths so the
+        # self-defeating "install what you already installed" bug this PR
+        # fixes cannot recur.
+        grep -q "brew install --cask tigervnc" "$FILE"
+        grep -q "apt-get install -y tigervnc-viewer" "$FILE"
+
+        echo PR1074_SOURCE_CONTRACT_OK
+    expect:
+      exit_code: 0
+      stdout_contains: "PR1074_SOURCE_CONTRACT_OK"
+    timeout: 5000
+
+  - name: "cmd_gui unit tests pass (PATH-priority + non-macOS contract; macOS-only branch is author-verified on real hardware, not runnable here)"
+    agent: "cli-agent"
+    action: "execute_command"
+    params:
+      command: |
+        cd rust && cargo test --release -p azlin cmd_gui:: -- --test-threads=1
+    expect:
+      exit_code: 0
+      stdout_contains: "test result: ok"
+    timeout: 55000
+
+metadata:
+  tags:
+    - "gui"
+    - "vnc"
+    - "macos"
+    - "discovery"
+    - "regression"
+  priority: "medium"
+  notes: >-
+    Cross-platform contract only. The macOS app-bundle fallback itself
+    requires real macOS hardware with TigerVNC.app installed; not runnable
+    in this sandbox or in this repo's Linux-only CI.


### PR DESCRIPTION
## Problem

On macOS, `brew install --cask tigervnc` installs an **application bundle** and creates **no symlink on PATH**. `azlin gui` probes for the viewer with a bare `which vncviewer`, so a correctly installed TigerVNC is reported as missing.

The failure is self-defeating: the error message tells the user to run

```
brew install --cask tigervnc-viewer
```

which is what they already did. Following the advice can never fix it.

## Reproduction

Real macOS machine, TigerVNC 1.16.2 installed via the cask:

```
$ brew list | grep -i vnc
tigervnc
$ which vncviewer          # -> nothing
$ ls /Applications/TigerVNC.app/Contents/MacOS/vncviewer
/Applications/TigerVNC.app/Contents/MacOS/vncviewer
```

Found while smoke-testing `azlin gui` against a live VM — `gui` refused to launch a viewer that was installed and working.

Note the existing message already suggests the macOS cask, so cask installs were anticipated; only the probe was not updated.

## Fix

- When the PATH lookup misses on macOS, fall back to known app-bundle locations under `/Applications` and `~/Applications`.
- **Launch the resolved absolute path**, not the bare name — fixing discovery alone would still fail at the launch site.
- PATH still wins when a PATH binary exists.
- Non-macOS behaviour is unchanged (PATH lookup only).
- The error now lists every location probed, and only asks the user to install when the viewer is genuinely absent everywhere.

Only TigerVNC bundle paths are probed — the only bundle layout I could verify first-hand rather than guess at.

## Validation

Discovery exercised on a real machine where TigerVNC.app genuinely exists:

```
vncviewer_on_path()        : true
find_vncviewer_with(true)  : Some("vncviewer")                  # PATH wins
find_vncviewer_with(false) : Some("/Applications/TigerVNC.app/Contents/MacOS/vncviewer")
candidates                 : ["/Applications/TigerVNC.app/...", "~/Applications/TigerVNC.app/..."]
```

CI gates on `rustup run stable`, based on `upstream/main` (a70f1a9d):

- `cargo build --release --locked` — clean
- `cargo test --all --locked` — **3488 passed / 0 failed**
- `cargo clippy --all --locked -- -D warnings` — clean

## Scope

One file, `rust/crates/azlin/src/cmd_gui.rs` (+137/-11). Independent of my other open PRs — based directly on `main`, no dependencies.

## Not verified

The end-to-end viewer launch against a live VNC session was not re-run after the change; discovery and launch-path construction are verified, the RFB session itself is unchanged machinery.

---

## Merge readiness

- Platform: GitHub
- PR: #1074 — https://github.com/rysweet/azlin/pull/1074
- Source -> target: `ahrkrak-fix-macos-vncviewer-discovery` -> `main`
- Current head revision: `69fc41601d70482f3b4a9a9832dc20732a47be2e`

### Crusty-old-engineer review

Posted: https://github.com/rysweet/azlin/pull/1074#issuecomment-5303407636

Findings: only one macOS bundle layout probed (disclosed, acceptable — the only cask this repo's own docs/error text recommend); the macOS-only code path is never compiled by this repo's Linux-only CI (structural, not a defect in this diff); `is_file()` doesn't check executability (minor, non-blocking). None required a code change — all disclosed/structural/non-blocking, explicitly not held against merge.

### QA-team evidence

- Scenario file: `tests/agentic-scenarios/pr-1074-macos-vncviewer-discovery.yaml`
- Validation command: `gadugi-test validate -f tests/agentic-scenarios/pr-1074-macos-vncviewer-discovery.yaml --strict`
- Validation result: passed
- Run command: `gadugi-test run -d <isolated dir containing only this scenario>`
- Run target: local sandbox (Linux)
- Run result: passed — 1/1
- Evidence location: run output included in PR review discussion; asserts the cross-platform contract (PATH-priority resolution, cfg-gate structure, both install paths named in the error message) and runs `cargo test --release -p azlin cmd_gui::` (27 passed / 0 failed). The macOS-only app-bundle fallback itself is **not** exercised — no macOS hardware in this sandbox — consistent with the author's own real-hardware validation already in this PR body.

### Documentation

- User-facing docs impact: no
- Updated docs: none
- Rationale: internal viewer-resolution logic change; the user-visible error message already documented both install paths pre-PR (`docs/GUI_FORWARDING.md`/`docs-site/advanced/gui-forwarding.md` reference TigerVNC as the tested viewer without prescribing PATH-only discovery) — no interface/doc contract changed, only how the binary is located.

### Quality-audit

- Cycle 1: read diff + surrounding code; confirmed `check_local_deps` and `launch_viewer` both route through the same `find_vncviewer()` resolver (no discovery/launch drift); confirmed non-macOS branch always returns `None` (no accidental macOS-only behavior leaking cross-platform). No fixes needed.
- Cycle 2: verified build (`cargo build --release --locked`, clean) and full `cmd_gui` test module (27/27 pass) on the branch after syncing with current `main` (post #1069/#1071/#1072/#1073 merges) plus the new scenario commit. No fixes needed.
- Cycle 3: re-read `vncviewer_missing_message()` and `macos_viewer_candidates()` for injection/path-traversal risk (none — `Command::new` takes the resolved `PathBuf` directly, no shell involved; `HOME` env var use is standard) and for the crusty findings' severity (all non-blocking, confirmed above). Clean.
- Final clean cycle: 3
- Fixes followed default-workflow: not applicable — no code fixes were required
- Convergence summary: three cycles found no correctness or security defect requiring a change; all crusty findings are disclosed scope limits or structural CI-matrix constraints, not bugs in this diff

### Checks/build validation

- Evidence source: `gh pr checks 1074`
- Current head validated: `69fc41601d70482f3b4a9a9832dc20732a47be2e`
- Required checks/build validations: all passed (no required-checks policy configured on this repo; reporting actual CI state as evidence regardless)
- Optional or skipped validations: OSSF Scorecard skips per repo policy (unrelated)
- Reruns performed: none — synced branch with `main` once (clean auto-merge, including `cmd_gui.rs` alongside PR #1072's now-merged GUI-install changes) and pushed once (added the QA scenario)
- Real failures fixed: none

### PR metadata

- Title: `fix(gui): find vncviewer in macOS app bundles when it is not on PATH`
- Description complete: yes (this evidence block)
- Source branch: `ahrkrak-fix-macos-vncviewer-discovery`
- Target branch: `main`
- Draft state: not draft
- Required labels/tags/milestone: not applicable — none configured
- Metadata evidence source: `gh pr view 1074 --json title,body,headRefName,baseRefName,isDraft`

### Reviews/approvals

- Required approvals: not applicable — no required-review branch protection configured (`gh api repos/rysweet/azlin/branches/main/protection`)
- Requested changes or blocking votes: none
- Review evidence source: `gh pr view 1074 --json reviewDecision,reviews,reviewRequests`

### Merge conflicts

- Mergeability status: clean
- Conflict evidence source: `gh pr view 1074 --json mergeable,mergeStateStatus`
- Conflict resolution required: none — `cmd_gui.rs` auto-merged cleanly against main's current state (including PR #1072's unrelated `azlin gui install` additions to the same file)

### Policies/protection

- Required policies/protection: not applicable — none configured on `main`
- Policy evidence source: `gh api repos/rysweet/azlin/branches/main/protection`

### Linked work items/issues

- Required linked work items/issues: not applicable — no policy requiring this in the repo; no tracking issue exists or is needed (self-contained bug report + fix)

### Comments/threads

- Required comments/threads resolved: not applicable — no unresolved review threads
- Comment/thread evidence source: `gh pr view 1074 --json comments,reviews`

### Scope

- Changed files reviewed: `gh pr diff 1074 --name-only` — `rust/crates/azlin/src/cmd_gui.rs` plus this session's added `tests/agentic-scenarios/pr-1074-macos-vncviewer-discovery.yaml`
- Unrelated changes: none

### Verdict

- Verdict: MERGE_READY
- Remaining blockers: none
