### PR TITLE
fix(ci): bump pymdown-extensions to 11.0.1 to fix failing pip-audit scan

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -5,5 +5,5 @@
 mkdocs-material==9.7.6
 mkdocs-git-revision-date-localized-plugin==1.5.3
 mkdocs-minify-plugin==0.8.0
-pymdown-extensions==11.0
+pymdown-extensions==11.0.1
 pyyaml==6.0.3


### PR DESCRIPTION
## Why this is failing today

The `pip-audit Dependency Scan` job in the Security Scanning workflow is **red on `main`** and on **every open pull request**. It has been failing on daily `main` runs (observed 12, 13 and 14 Aug) on commits that predate any current in-flight work, so it is pre-existing and repo-wide — not attributable to any contributor's change.

The step runs `pip-audit --strict -r docs-requirements.txt`:

```
Found 1 known vulnerability in 1 package
Name               Version ID              Fix Versions
pymdown-extensions 11.0    PYSEC-2026-3654 11.0.1
```

## The advisory

**PYSEC-2026-3654** — aliases **CVE-2026-67422**, **GHSA-gm37-52c6-37mw**.

Exponential-backtracking ReDoS in the `caret`, `tilde`, `betterem` and `magiclink` inline processors. A single untrusted Markdown line under 50 bytes drives `markdown.markdown()` into unbounded CPU on the rendering thread — seconds at ~45 bytes, growing exponentially with each added character. All four processors fire in the extension's **default configuration**. Fixed in **11.0.1**.

## Realistic impact for this repo

Modest, and worth stating plainly rather than overselling. This is the **docs toolchain only** — it is not in the shipped Rust binary. MkDocs renders repo-authored Markdown, so the untrusted-input surface is essentially content arriving via pull requests, which could stall a docs build job. Real, but not a critical remote vulnerability here. The primary value of this PR is **unblocking the security gate for the entire repository**.

## The change

One line:

```diff
-pymdown-extensions==11.0
+pymdown-extensions==11.0.1
```

`11.0.1` is a **patch** bump (it is the only other 11.x release, and is the current latest on PyPI). I left the file header comment alone — it is a standing policy statement that still reads correctly after the bump, and a minimal diff reviews faster.

## Verification

All run independently against a clean virtualenv with `pip-audit 2.10.1`.

**Before** (`docs-requirements.txt` at `upstream/main`):

```
$ pip-audit --strict -r docs-requirements.txt
Found 1 known vulnerability in 1 package
Name               Version ID              Fix Versions
------------------ ------- --------------- ------------
pymdown-extensions 11.0    PYSEC-2026-3654 11.0.1
EXIT=1
```

**After** (this branch):

```
$ pip-audit --strict -r docs-requirements.txt
No known vulnerabilities found
EXIT=0
```

**Compatibility**, checked against live PyPI metadata for each pinned package:

| Pinned package | Constraint on `pymdown-extensions` |
| --- | --- |
| `mkdocs-material==9.7.6` | `>=10.2` — satisfied by 11.0.1 |
| `mkdocs-git-revision-date-localized-plugin==1.5.3` | none |
| `mkdocs-minify-plugin==0.8.0` | none |
| `pyyaml==6.0.3` | none |

Nothing caps `pymdown-extensions` below 11.0.1.

**Docs build**, in a second clean virtualenv installed from the amended file:

```
$ mkdocs build
INFO - Documentation built in 29.85 seconds
```

158 HTML pages generated successfully with 11.0.1 installed.

One caveat, stated honestly: `mkdocs build --strict` still aborts, but on **126 pre-existing broken-link warnings** (e.g. `docs/monitoring/logs.md` links to `status.md`, `w.md`, `ps.md` which do not exist). Those are unrelated to this bump — they are missing-file link warnings, entirely independent of the pymdown version — and I have deliberately left them out of scope.
